### PR TITLE
Bump version to 0.1.7

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1784,7 +1784,7 @@ dependencies = [
 
 [[package]]
 name = "wasm-wnfs"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1918,7 +1918,7 @@ checksum = "c811ca4a8c853ef420abd8592ba53ddbbac90410fab6903b3e79972a631f7680"
 
 [[package]]
 name = "wnfs"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "anyhow",
  "async-once-cell",

--- a/crates/fs/Cargo.toml
+++ b/crates/fs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wnfs"
-version = "0.1.6"
+version = "0.1.7"
 description = "WebNative filesystem core implementation"
 keywords = ["wnfs", "webnative", "ipfs", "decentralisation"]
 categories = [

--- a/crates/wasm/Cargo.toml
+++ b/crates/wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasm-wnfs"
-version = "0.1.6"
+version = "0.1.7"
 description = "WebNative Filesystem API (WebAssembly)"
 keywords = ["wnfs", "webnative", "ipfs", "decentralisation"]
 categories = [


### PR DESCRIPTION
Bumping the version to 0.1.7 so we can release a new npm package.
(Not a blocker for me though, I've already released 0.1.7-alpha as an alpha package)