### PR TITLE
Use published skip-ratchet crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1493,7 +1493,8 @@ dependencies = [
 [[package]]
 name = "skip_ratchet"
 version = "0.1.0"
-source = "git+https://github.com/appcypher/rs-skip-ratchet?branch=appcypher/doc-and-structure#57d1acd0e09b852b1056a32cbdb2e2f5fee02ad1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d92b3722e0b051481c7f7ea42504415adad19f7426d9729834b3ad2b1252a59"
 dependencies = [
  "base64",
  "hex",

--- a/crates/fs/Cargo.toml
+++ b/crates/fs/Cargo.toml
@@ -31,7 +31,7 @@ async-recursion = "1.0.0"
 futures = "0.3.21"
 async-stream = "0.3.3"
 futures-util = "0.3.21"
-skip_ratchet = { git = "https://github.com/appcypher/rs-skip-ratchet", branch = "appcypher/doc-and-structure" }
+skip_ratchet = "0.1.0"
 bitvec = "1.0.0"
 async-once-cell = "0.4.0"
 sha3 = "0.10.0"


### PR DESCRIPTION
I just went ahead and [published the `skip_ratchet` crate](https://crates.io/crates/skip_ratchet) and updated that as a dependency instead of depending on the github repo URL.

Otherwise I couldn't `cargo publish`:
```sh
$ cargo publish -p wnfs
    Updating crates.io index
error: all dependencies must have a version specified when publishing.
dependency `skip_ratchet` does not specify a version
Note: The published dependency will use the version from crates.io,
the `git` specification will be removed from the dependency declaration.
```