### PR TITLE
Leverage `rand_core::RngCore` implementations in `Rng`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2149,7 +2149,7 @@ dependencies = [
  "log",
  "multihash",
  "proptest",
- "rand 0.8.5",
+ "rand_core 0.6.3",
  "semver",
  "serde",
  "sha3",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2003,6 +2003,7 @@ dependencies = [
  "console_error_panic_hook",
  "js-sys",
  "libipld",
+ "rand_core 0.6.3",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "wasm-bindgen-test",

--- a/crates/fs/Cargo.toml
+++ b/crates/fs/Cargo.toml
@@ -39,11 +39,11 @@ xxhash-rust = { version = "0.8.5", features = ["xxh3"] }
 lazy_static = "1.4.0"
 thiserror = "1.0.31"
 aes-gcm = "0.9.4"
+rand_core = "0.6.3"
 
 [dev-dependencies]
 env_logger = "0.9.0"
 test-log = "0.2.10"
-rand = "0.8.5"
 proptest = "1.0.0"
 test-strategy = "0.2.0"
 

--- a/crates/fs/common/utils.rs
+++ b/crates/fs/common/utils.rs
@@ -10,12 +10,6 @@ use crate::{error, FsError};
 
 pub(crate) struct ByteArrayVisitor<const N: usize>;
 
-#[cfg(test)]
-pub(crate) struct TestRng();
-
-#[cfg(test)]
-pub(crate) struct ProptestRng(proptest::test_runner::TestRng);
-
 //--------------------------------------------------------------------------------------------------
 // Implementations
 //--------------------------------------------------------------------------------------------------
@@ -33,33 +27,6 @@ impl<'de, const N: usize> Visitor<'de> for ByteArrayVisitor<N> {
     {
         let bytes: [u8; N] = v.try_into().map_err(E::custom)?;
         Ok(bytes)
-    }
-}
-
-#[cfg(test)]
-impl crate::private::Rng for TestRng {
-    fn random_bytes<const N: usize>(&mut self) -> [u8; N] {
-        use rand::RngCore;
-        let mut bytes = [0u8; N];
-        rand::thread_rng().fill_bytes(&mut bytes);
-        bytes
-    }
-}
-
-#[cfg(test)]
-impl ProptestRng {
-    pub(crate) fn from_seed(algorithm: proptest::test_runner::RngAlgorithm, seed: &[u8]) -> Self {
-        Self(proptest::test_runner::TestRng::from_seed(algorithm, seed))
-    }
-}
-
-#[cfg(test)]
-impl crate::private::Rng for ProptestRng {
-    fn random_bytes<const N: usize>(&mut self) -> [u8; N] {
-        use rand::RngCore;
-        let mut bytes = [0u8; N];
-        self.0.fill_bytes(&mut bytes);
-        bytes
     }
 }
 

--- a/crates/fs/private/directory.rs
+++ b/crates/fs/private/directory.rs
@@ -598,12 +598,13 @@ impl Id for PrivateDirectory {
 #[cfg(test)]
 mod private_directory_tests {
     use super::*;
-    use crate::{utils::TestRng, MemoryBlockStore, HASH_BYTE_SIZE};
+    use crate::{MemoryBlockStore, HASH_BYTE_SIZE};
+    use proptest::test_runner::{RngAlgorithm, TestRng};
     use test_log::test;
 
     #[test(async_std::test)]
     async fn look_up_can_fetch_file_added_to_directory() {
-        let rng = &mut TestRng();
+        let rng = &mut TestRng::deterministic_rng(RngAlgorithm::ChaCha);
         let root_dir = Rc::new(PrivateDirectory::new(
             Namefilter::default(),
             rng.random_bytes::<HASH_BYTE_SIZE>(),
@@ -638,7 +639,7 @@ mod private_directory_tests {
 
     #[test(async_std::test)]
     async fn look_up_cannot_fetch_file_not_added_to_directory() {
-        let rng = &mut TestRng();
+        let rng = &mut TestRng::deterministic_rng(RngAlgorithm::ChaCha);
         let root_dir = Rc::new(PrivateDirectory::new(
             Namefilter::default(),
             rng.random_bytes::<HASH_BYTE_SIZE>(),
@@ -658,7 +659,7 @@ mod private_directory_tests {
 
     #[test(async_std::test)]
     async fn mkdir_can_create_new_directory() {
-        let rng = &mut TestRng();
+        let rng = &mut TestRng::deterministic_rng(RngAlgorithm::ChaCha);
         let root_dir = Rc::new(PrivateDirectory::new(
             Namefilter::default(),
             rng.random_bytes::<HASH_BYTE_SIZE>(),
@@ -690,7 +691,7 @@ mod private_directory_tests {
 
     #[test(async_std::test)]
     async fn ls_can_list_children_under_directory() {
-        let rng = &mut TestRng();
+        let rng = &mut TestRng::deterministic_rng(RngAlgorithm::ChaCha);
         let root_dir = Rc::new(PrivateDirectory::new(
             Namefilter::default(),
             rng.random_bytes::<HASH_BYTE_SIZE>(),
@@ -749,7 +750,7 @@ mod private_directory_tests {
 
     #[test(async_std::test)]
     async fn rm_can_remove_children_from_directory() {
-        let rng = &mut TestRng();
+        let rng = &mut TestRng::deterministic_rng(RngAlgorithm::ChaCha);
         let root_dir = Rc::new(PrivateDirectory::new(
             Namefilter::default(),
             rng.random_bytes::<HASH_BYTE_SIZE>(),
@@ -822,7 +823,7 @@ mod private_directory_tests {
 
     #[async_std::test]
     async fn read_can_fetch_userland_of_file_added_to_directory() {
-        let rng = &mut TestRng();
+        let rng = &mut TestRng::deterministic_rng(RngAlgorithm::ChaCha);
         let root_dir = Rc::new(PrivateDirectory::new(
             Namefilter::default(),
             rng.random_bytes::<HASH_BYTE_SIZE>(),
@@ -857,7 +858,7 @@ mod private_directory_tests {
     async fn path_nodes_can_generates_new_path_nodes() {
         let store = &mut MemoryBlockStore::default();
         let hamt = Rc::new(PrivateForest::new());
-        let rng = &mut TestRng();
+        let rng = &mut TestRng::deterministic_rng(RngAlgorithm::ChaCha);
 
         let path_nodes = PrivateDirectory::create_path_nodes(
             &["Documents".into(), "Apps".into()],
@@ -891,7 +892,7 @@ mod private_directory_tests {
     async fn search_latest_finds_the_most_recent() {
         let store = &mut MemoryBlockStore::default();
         let hamt = Rc::new(PrivateForest::new());
-        let rng = &mut TestRng();
+        let rng = &mut TestRng::deterministic_rng(RngAlgorithm::ChaCha);
 
         let root_dir = Rc::new(PrivateDirectory::new(
             Namefilter::default(),

--- a/crates/fs/private/forest.rs
+++ b/crates/fs/private/forest.rs
@@ -132,8 +132,8 @@ impl PrivateForest {
 
 #[cfg(test)]
 mod hamt_store_tests {
+    use proptest::test_runner::{RngAlgorithm, TestRng};
     use std::rc::Rc;
-    use proptest::test_runner::{TestRng, RngAlgorithm};
     use test_log::test;
 
     use chrono::Utc;

--- a/crates/fs/private/forest.rs
+++ b/crates/fs/private/forest.rs
@@ -6,7 +6,7 @@ use log::debug;
 
 use crate::{BlockStore, HashOutput};
 
-use super::{hamt::Hamt, namefilter::Namefilter, Key, PrivateNode, PrivateRef};
+use super::{hamt::Hamt, namefilter::Namefilter, Key, PrivateNode, PrivateRef, Rng};
 
 //--------------------------------------------------------------------------------------------------
 // Type Definitions
@@ -15,10 +15,6 @@ use super::{hamt::Hamt, namefilter::Namefilter, Key, PrivateNode, PrivateRef};
 // TODO(appcypher): Change Cid to PrivateLink<PrivateNode>.
 // TODO(appcypher): And eventually to BTreeSet<PrivateLink<PrivateNode>>.
 pub type PrivateForest = Hamt<Namefilter, Cid>;
-
-pub trait Rng {
-    fn random_bytes<const N: usize>(&mut self) -> [u8; N];
-}
 
 //--------------------------------------------------------------------------------------------------
 // Implementations
@@ -137,18 +133,19 @@ impl PrivateForest {
 #[cfg(test)]
 mod hamt_store_tests {
     use std::rc::Rc;
+    use proptest::test_runner::{TestRng, RngAlgorithm};
     use test_log::test;
 
     use chrono::Utc;
 
     use super::*;
-    use crate::{private::PrivateDirectory, utils::TestRng, MemoryBlockStore};
+    use crate::{private::PrivateDirectory, MemoryBlockStore};
 
     #[test(async_std::test)]
     async fn inserted_items_can_be_fetched() {
         let store = &mut MemoryBlockStore::new();
         let hamt = Rc::new(PrivateForest::new());
-        let rng = &mut TestRng();
+        let rng = &mut TestRng::deterministic_rng(RngAlgorithm::ChaCha);
 
         let dir = Rc::new(PrivateDirectory::new(
             Namefilter::default(),

--- a/crates/fs/private/key.rs
+++ b/crates/fs/private/key.rs
@@ -84,21 +84,19 @@ impl Debug for Key {
 
 #[cfg(test)]
 mod key_prop_tests {
-    use crate::utils::ProptestRng;
-
     use super::*;
     use proptest::prelude::any;
-    use proptest::test_runner::RngAlgorithm;
+    use proptest::test_runner::{RngAlgorithm, TestRng};
     use test_strategy::proptest;
 
-    #[proptest(cases = 50)]
+    #[proptest(cases = 100)]
     fn key_can_encrypt_and_decrypt_data(
         #[strategy(any::<Vec<u8>>())] data: Vec<u8>,
         #[strategy(any::<[u8; 32]>())] rng_seed: [u8; 32],
         key_bytes: [u8; 32],
     ) {
         let key = Key::new(key_bytes);
-        let rng = &mut ProptestRng::from_seed(RngAlgorithm::ChaCha, &rng_seed);
+        let rng = &mut TestRng::from_seed(RngAlgorithm::ChaCha, &rng_seed);
 
         let encrypted = key.encrypt(&Key::generate_nonce(rng), &data).unwrap();
         let decrypted = key.decrypt(&encrypted).unwrap();

--- a/crates/fs/private/mod.rs
+++ b/crates/fs/private/mod.rs
@@ -6,6 +6,7 @@ mod key;
 mod link;
 pub mod namefilter;
 mod node;
+mod rng;
 
 pub use directory::*;
 pub use file::*;
@@ -13,3 +14,4 @@ pub use forest::*;
 pub use key::*;
 pub use link::*;
 pub use node::*;
+pub use rng::*;

--- a/crates/fs/private/node.rs
+++ b/crates/fs/private/node.rs
@@ -282,13 +282,13 @@ impl PrivateNodeHeader {
 
 #[cfg(test)]
 mod private_node_tests {
-    use crate::{private::Rng, utils::TestRng};
+    use proptest::test_runner::{RngAlgorithm, TestRng};
 
     use super::*;
 
     #[test]
     fn serialized_private_node_can_be_deserialized() {
-        let rng = &mut TestRng();
+        let rng = &mut TestRng::deterministic_rng(RngAlgorithm::ChaCha);
         let original_file = PrivateNode::File(Rc::new(PrivateFile::new(
             Namefilter::default(),
             rng.random_bytes::<32>(),

--- a/crates/fs/private/rng.rs
+++ b/crates/fs/private/rng.rs
@@ -1,0 +1,12 @@
+use rand_core::RngCore;
+
+pub trait Rng: RngCore {
+    fn random_bytes<const N: usize>(&mut self) -> [u8; N] {
+        let mut bytes = [0u8; N];
+        self.fill_bytes(&mut bytes);
+        bytes
+    }
+}
+
+#[cfg(test)]
+impl crate::private::Rng for proptest::test_runner::TestRng {}

--- a/crates/wasm/Cargo.toml
+++ b/crates/wasm/Cargo.toml
@@ -29,6 +29,7 @@ async-trait = "0.1"
 console_error_panic_hook = { version = "0.1", optional = true }
 wee_alloc = { version = "0.4", optional = true }
 cfg-if = "1.0.0"
+rand_core = "0.6.3"
 
 [dev-dependencies]
 wasm-bindgen-test = "0.3"

--- a/crates/wasm/fs/private/rng.rs
+++ b/crates/wasm/fs/private/rng.rs
@@ -1,3 +1,4 @@
+use rand_core::RngCore;
 use wasm_bindgen::prelude::wasm_bindgen;
 use wnfs::private::Rng as WnfsRng;
 
@@ -18,8 +19,24 @@ extern "C" {
 // Implementations
 //--------------------------------------------------------------------------------------------------
 
-impl WnfsRng for Rng {
-    fn random_bytes<const N: usize>(&mut self) -> [u8; N] {
-        self.get_random_bytes(N).try_into().unwrap()
+impl RngCore for Rng {
+    fn next_u32(&mut self) -> u32 {
+        let bytes = self.get_random_bytes(4);
+        u32::from_le_bytes(bytes.try_into().unwrap())
+    }
+
+    fn next_u64(&mut self) -> u64 {
+        let bytes = self.get_random_bytes(8);
+        u64::from_le_bytes(bytes.try_into().unwrap())
+    }
+
+    fn fill_bytes(&mut self, dest: &mut [u8]) {
+        dest.copy_from_slice(&self.get_random_bytes(dest.len()));
+    }
+
+    fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), rand_core::Error> {
+        Ok(self.fill_bytes(dest))
     }
 }
+
+impl WnfsRng for Rng {}


### PR DESCRIPTION
## Summary

Leverage `RngCore` in `Rng` implementation

<!-- Summary of the PR -->

This PR turns `Rng` `random_bytes` method into a default method that depends on `RngCore` implementation. It allows us directly use existing `RngCore` implementations out there without wrapping them, like proptest `TestRng`.

<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

## Test plan (required)
-  Testing the Rust core.
    
    ```bash
    cargo test -p wnfs --release
    ```

- Testing the wasm bindings.
  
  ```bash
  cd crates/wasm
  ```
  
  ```bash
  yarn playwright test
  ```

<!-- Make sure tests pass on Circle CI. -->

## Closing issues

<!-- Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such). -->

Fixes https://github.com/wnfs-wg/rs-wnfs/issues/55