### PR TITLE
Make private forest multivalue

### DIFF
--- a/wnfs-wasm/fs/private/forest.rs
+++ b/wnfs-wasm/fs/private/forest.rs
@@ -56,7 +56,7 @@ impl PrivateForest {
 
         Ok(future_to_promise(async move {
             let node_option = forest
-                .get(&private_ref, &store)
+                .get(&private_ref, WnfsPrivateForest::resolve_lowest, &store)
                 .await
                 .map_err(error("Cannot 'get' in forest"))?;
 

--- a/wnfs/common/utils.rs
+++ b/wnfs/common/utils.rs
@@ -19,7 +19,7 @@ impl<'de, const N: usize> Visitor<'de> for ByteArrayVisitor<N> {
     type Value = [u8; N];
 
     fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
-        write!(formatter, "a byte array of length {}", N)
+        write!(formatter, "a byte array of length {N}")
     }
 
     fn visit_bytes<E>(self, v: &[u8]) -> Result<Self::Value, E>

--- a/wnfs/examples/private.rs
+++ b/wnfs/examples/private.rs
@@ -33,7 +33,7 @@ async fn main() {
 
     // Fetch and decrypt a directory from the private forest using provided private ref.
     let dir = forest
-        .get(&private_ref, BTreeSet::first, store)
+        .get(&private_ref, PrivateForest::resolve_lowest, store)
         .await
         .unwrap();
 

--- a/wnfs/examples/private.rs
+++ b/wnfs/examples/private.rs
@@ -4,7 +4,7 @@
 use chrono::Utc;
 use libipld::Cid;
 use rand::{thread_rng, RngCore};
-use std::rc::Rc;
+use std::{collections::BTreeSet, rc::Rc};
 use wnfs::{
     dagcbor,
     private::{PrivateForest, PrivateRef},
@@ -32,7 +32,10 @@ async fn main() {
     let forest = dagcbor::decode::<PrivateForest>(cbor_bytes.as_ref()).unwrap();
 
     // Fetch and decrypt a directory from the private forest using provided private ref.
-    let dir = forest.get(&private_ref, store).await.unwrap();
+    let dir = forest
+        .get(&private_ref, BTreeSet::first, store)
+        .await
+        .unwrap();
 
     // Print the directory.
     println!("{:#?}", dir);

--- a/wnfs/examples/private.rs
+++ b/wnfs/examples/private.rs
@@ -4,7 +4,7 @@
 use chrono::Utc;
 use libipld::Cid;
 use rand::{thread_rng, RngCore};
-use std::{collections::BTreeSet, rc::Rc};
+use std::rc::Rc;
 use wnfs::{
     dagcbor,
     private::{PrivateForest, PrivateRef},

--- a/wnfs/private/directory.rs
+++ b/wnfs/private/directory.rs
@@ -1,4 +1,7 @@
-use std::{collections::BTreeMap, rc::Rc};
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    rc::Rc,
+};
 
 use anyhow::{bail, ensure, Result};
 use chrono::{DateTime, Utc};
@@ -279,7 +282,7 @@ impl PrivateDirectory {
             let parent_dir = Rc::new(parent_dir);
 
             working_hamt = working_hamt
-                .set(
+                .put(
                     working_child_dir.header.get_saturated_name(),
                     &child_private_ref,
                     &PrivateNode::Dir(Rc::clone(&working_child_dir)),
@@ -292,7 +295,7 @@ impl PrivateDirectory {
         }
 
         working_hamt = working_hamt
-            .set(
+            .put(
                 working_child_dir.header.get_saturated_name(),
                 &working_child_dir.header.get_private_ref()?,
                 &PrivateNode::Dir(Rc::clone(&working_child_dir)),
@@ -555,7 +558,7 @@ impl PrivateDirectory {
 
         let child_private_ref = file.header.get_private_ref()?;
         let hamt = hamt
-            .set(
+            .put(
                 file.header.get_saturated_name(),
                 &child_private_ref,
                 &PrivateNode::File(Rc::new(file)),
@@ -630,7 +633,7 @@ impl PrivateDirectory {
     ) -> Result<Option<PrivateNode>> {
         Ok(match self.entries.get(path_segment) {
             Some(private_ref) => {
-                let private_node = hamt.get(private_ref, store).await?;
+                let private_node = hamt.get(private_ref, BTreeSet::first, store).await?;
                 match (search_latest, private_node) {
                     (true, Some(node)) => Some(node.search_latest(hamt, store).await?),
                     (_, node) => node,
@@ -773,7 +776,7 @@ impl PrivateDirectory {
             PathNodesResult::Complete(path_nodes) => {
                 let mut result = vec![];
                 for (name, private_ref) in path_nodes.tail.entries.iter() {
-                    match hamt.get(private_ref, store).await? {
+                    match hamt.get(private_ref, BTreeSet::first, store).await? {
                         Some(PrivateNode::File(file)) => {
                             result.push((name.clone(), file.metadata.clone()));
                         }
@@ -875,7 +878,10 @@ impl PrivateDirectory {
 
         // Remove the entry from its parent directory
         let removed_node = match directory.entries.remove(node_name) {
-            Some(ref private_ref) => hamt.get(private_ref, store).await?.unwrap(),
+            Some(ref private_ref) => hamt
+                .get(private_ref, BTreeSet::first, store)
+                .await?
+                .unwrap(),
             None => bail!(FsError::NotFound),
         };
 

--- a/wnfs/private/forest.rs
+++ b/wnfs/private/forest.rs
@@ -48,7 +48,7 @@ impl PrivateForest {
     /// # Examples
     ///
     /// ```
-    /// use std::{collections::BTreeSet, rc::Rc};
+    /// use std::rc::Rc;
     ///
     /// use chrono::Utc;
     /// use rand::thread_rng;
@@ -116,7 +116,7 @@ impl PrivateForest {
     /// # Examples
     ///
     /// ```
-    /// use std::{collections::BTreeSet, rc::Rc};
+    /// use std::rc::Rc;
     ///
     /// use chrono::Utc;
     /// use rand::thread_rng;

--- a/wnfs/private/hamt/hamt.rs
+++ b/wnfs/private/hamt/hamt.rs
@@ -143,7 +143,7 @@ where
 
                 Ok(Self { root, version })
             }
-            other => Err(format!("Expected `Ipld::Map`, got {:#?}", other)),
+            other => Err(format!("Expected `Ipld::Map`, got {other:#?}")),
         }
     }
 }

--- a/wnfs/private/key.rs
+++ b/wnfs/private/key.rs
@@ -82,7 +82,7 @@ impl Key {
 
         let cipher_text = Aes256Gcm::new(AesKey::from_slice(&self.0))
             .encrypt(nonce, data)
-            .map_err(|e| FsError::UnableToEncrypt(format!("{}", e)))?;
+            .map_err(|e| FsError::UnableToEncrypt(format!("{e}")))?;
 
         Ok([nonce_bytes.to_vec(), cipher_text].concat())
     }
@@ -110,7 +110,7 @@ impl Key {
 
         Ok(Aes256Gcm::new(AesKey::from_slice(&self.0))
             .decrypt(Nonce::from_slice(nonce_bytes), data)
-            .map_err(|e| FsError::UnableToDecrypt(format!("{}", e)))?)
+            .map_err(|e| FsError::UnableToDecrypt(format!("{e}")))?)
     }
 
     /// Generates a nonce that can be used to encrypt data.
@@ -153,7 +153,7 @@ impl Debug for Key {
                 write!(f, "..")?;
                 break;
             } else {
-                write!(f, "{:02X}", byte)?;
+                write!(f, "{byte:02X}")?;
             }
         }
 

--- a/wnfs/private/namefilter/bloomfilter.rs
+++ b/wnfs/private/namefilter/bloomfilter.rs
@@ -264,7 +264,7 @@ impl<const N: usize, const K: usize> Debug for BloomFilter<N, K> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "0x")?;
         for byte in self.as_bytes().iter() {
-            write!(f, "{:02X}", byte)?;
+            write!(f, "{byte:02X}")?;
         }
 
         Ok(())

--- a/wnfs/private/node.rs
+++ b/wnfs/private/node.rs
@@ -1,4 +1,4 @@
-use std::{cmp::Ordering, collections::BTreeSet, fmt::Debug, io::Cursor, rc::Rc};
+use std::{cmp::Ordering, fmt::Debug, io::Cursor, rc::Rc};
 
 use anyhow::{bail, Result};
 use async_recursion::async_recursion;
@@ -189,7 +189,7 @@ impl PrivateNode {
                 let mut working_hamt = Rc::clone(&hamt);
                 for (name, private_ref) in &old_dir.entries {
                     let mut node = hamt
-                        .get(private_ref, BTreeSet::first, store)
+                        .get(private_ref, PrivateForest::resolve_lowest, store)
                         .await?
                         .ok_or(FsError::NotFound)?;
 
@@ -400,7 +400,7 @@ impl PrivateNode {
         let latest_private_ref = current_header.get_private_ref()?;
 
         match forest
-            .get(&latest_private_ref, BTreeSet::first, store)
+            .get(&latest_private_ref, PrivateForest::resolve_lowest, store)
             .await?
         {
             Some(node) => Ok(node),

--- a/wnfs/private/previous.rs
+++ b/wnfs/private/previous.rs
@@ -1,4 +1,4 @@
-use std::{collections::BTreeSet, rc::Rc};
+use std::rc::Rc;
 
 use anyhow::{bail, Result};
 use skip_ratchet::{ratchet::PreviousIterator, Ratchet};
@@ -105,7 +105,11 @@ impl PrivateNodeHistory {
                 // TODO(matheus23) Make the `resolve_bias` be biased towards eventual `previous` backpointers.
                 self.header.ratchet = previous_ratchet;
                 self.forest
-                    .get(&self.header.get_private_ref()?, BTreeSet::first, store)
+                    .get(
+                        &self.header.get_private_ref()?,
+                        PrivateForest::resolve_lowest,
+                        store,
+                    )
                     .await
             }
         }

--- a/wnfs/private/previous.rs
+++ b/wnfs/private/previous.rs
@@ -1,4 +1,4 @@
-use std::rc::Rc;
+use std::{collections::BTreeSet, rc::Rc};
 
 use anyhow::{bail, Result};
 use skip_ratchet::{ratchet::PreviousIterator, Ratchet};
@@ -102,9 +102,10 @@ impl PrivateNodeHistory {
         match self.ratchets.next() {
             None => Ok(None),
             Some(previous_ratchet) => {
+                // TODO(matheus23) Make the `resolve_bias` be biased towards eventual `previous` backpointers.
                 self.header.ratchet = previous_ratchet;
                 self.forest
-                    .get(&self.header.get_private_ref()?, store)
+                    .get(&self.header.get_private_ref()?, BTreeSet::first, store)
                     .await
             }
         }
@@ -521,7 +522,7 @@ mod private_history_tests {
         let store = &mut store;
 
         let hamt = hamt
-            .set(
+            .put(
                 root_dir.header.get_saturated_name(),
                 &root_dir.header.get_private_ref().unwrap(),
                 &PrivateNode::Dir(Rc::clone(&root_dir)),
@@ -611,7 +612,7 @@ mod private_history_tests {
         let store = &mut store;
 
         let hamt = hamt
-            .set(
+            .put(
                 root_dir.header.get_saturated_name(),
                 &root_dir.header.get_private_ref().unwrap(),
                 &PrivateNode::Dir(Rc::clone(&root_dir)),
@@ -706,7 +707,7 @@ mod private_history_tests {
         let store = &mut store;
 
         let hamt = hamt
-            .set(
+            .put(
                 root_dir.header.get_saturated_name(),
                 &root_dir.header.get_private_ref().unwrap(),
                 &PrivateNode::Dir(Rc::clone(&root_dir)),
@@ -957,7 +958,7 @@ mod private_history_tests {
         };
 
         let hamt = hamt
-            .set(
+            .put(
                 root_dir.header.get_saturated_name(),
                 &root_dir.header.get_private_ref().unwrap(),
                 &PrivateNode::Dir(Rc::clone(&root_dir)),

--- a/wnfs/public/directory.rs
+++ b/wnfs/public/directory.rs
@@ -880,7 +880,7 @@ impl AsyncSerialize for PublicDirectory {
                     *link
                         .resolve_cid(store)
                         .await
-                        .map_err(|e| SerError::custom(format!("{}", e)))?,
+                        .map_err(|e| SerError::custom(format!("{e}")))?,
                 );
             }
             map


### PR DESCRIPTION
This PR only changes the data format, but minimally changes the actual data stored. Specifically: We never actually generate multivalues in rs-wnfs. So why add support for them?
The reason is being future-proof: We *know* we'll make use of multivalues in the future, so we add support for them *today*, so that *today*'s version of rs-wnfs will have *some* support for them even when future versions of rs-wnfs actually write multivalues.

In this PR:
- the `PrivateForest` type alias changed to use `BTreeSet<Cid>` as value, instead of just `Cid`
- `PrivateForest.set` was renamed to `put`, and it adds to the multivalues at a given key, instead of replacing. There's a performance optimization opportunity here to avoid walking the HAMT twice by creating a `modify`/`upsert` implementation in `hamt/node.rs`. But that turned out to be quite some effort, so I'm postponing that for now.
- `PrivateForest.get` now expects a `resolve_bias` function parameter. Today that mostly ends up being `BTreeSet::first`, in order to fetch the smallest CID. That's the tie-breaking that's specified for WNFS by default, but that will be something different e.g. when we have previous pointers, then we'll bias towards those pointers.
- `PrivateForest.get_encrypted` returns the whole `BTreeSet` now.
- There's some helper functions in `PrivateForest` like `resolve_lowest`, `resolve_single` and `resolve_one_of` that are supposed to be helpers for use with `PrivateForest.get`.

Closes issue: #74 