### PR TITLE
Use `Rc::try_unwrap` for (possibly?) better performance

### DIFF
--- a/wnfs/src/common/metadata.rs
+++ b/wnfs/src/common/metadata.rs
@@ -94,9 +94,12 @@ impl Metadata {
     /// let imprecise_time = Utc.timestamp(time.timestamp(), 0);
     /// assert_eq!(metadata.get_created(), Some(imprecise_time));
     /// ```
+    ///
+    /// Will return `None` if there's no created metadata on the
+    /// node or if it's not a second-based POSIX timestamp integer.
     pub fn get_created(&self) -> Option<DateTime<Utc>> {
         self.0.get("created").and_then(|ipld| match ipld {
-            Ipld::Integer(i) => Some(Utc.timestamp(i64::try_from(*i).ok()?, 0)),
+            Ipld::Integer(i) => Utc.timestamp_opt(i64::try_from(*i).ok()?, 0).single(),
             _ => None,
         })
     }
@@ -115,9 +118,12 @@ impl Metadata {
     /// let imprecise_time = Utc.timestamp(time.timestamp(), 0);
     /// assert_eq!(metadata.get_modified(), Some(imprecise_time));
     /// ```
+    ///
+    /// Will return `None` if there's no created metadata on the
+    /// node or if it's not a second-based POSIX timestamp integer.
     pub fn get_modified(&self) -> Option<DateTime<Utc>> {
         self.0.get("modified").and_then(|ipld| match ipld {
-            Ipld::Integer(i) => Some(Utc.timestamp(i64::try_from(*i).ok()?, 0)),
+            Ipld::Integer(i) => Utc.timestamp_opt(i64::try_from(*i).ok()?, 0).single(),
             _ => None,
         })
     }


### PR DESCRIPTION
Putting this up here for discussion.

We can make use of mutability in `Node::set_value` and `Node::remove_value`, by turning values of type `Rc<Node<...>>` into `mut Node<...>` using `Rc::try_unwrap(...).unwrap_or_else(|rc| (*rc).clone())`.
Essentially that'll just give us an owned `Node` if we hold the only reference to it, or it'll clone the inner `Rc`.
Theory is that if the calling code is basically doing lots of changes on the HAMT in a tight loop, that's going to get sped up, since that'll end up being lots of in-place mutation.

The benchmarks don't look *too* promising though. I got ~10% improvements.
To test this, just compare the two commits in the PR against each other. Specifically their `cargo bench -p wnfs-bench node`.

Also, I had to hand-expand the `async_recursion` macro for `set_value` and `remove_value`, because otherwise there would've been lifetime issues with the original versions. We should probably figure out another way, but only if we really want to keep this PR.