### PR TITLE
Allow user-provided ratchet seed and inumber

### DIFF
--- a/wnfs-wasm/Cargo.toml
+++ b/wnfs-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasm-wnfs"
-version = "0.1.9"
+version = "0.1.10"
 description = "WebNative Filesystem API (WebAssembly)"
 keywords = ["wnfs", "wasm", "webnative", "ipfs", "decentralisation"]
 categories = [

--- a/wnfs-wasm/src/fs/private/directory.rs
+++ b/wnfs-wasm/src/fs/private/directory.rs
@@ -6,7 +6,10 @@ use chrono::{DateTime, Utc};
 use js_sys::{Array, Date, Promise, Uint8Array};
 use wasm_bindgen::{prelude::wasm_bindgen, JsValue};
 use wasm_bindgen_futures::future_to_promise;
-use wnfs::{Id, PrivateDirectory as WnfsPrivateDirectory, PrivateOpResult as WnfsPrivateOpResult};
+use wnfs::{
+    Id, PrivateDirectory as WnfsPrivateDirectory, PrivateOpResult as WnfsPrivateOpResult,
+    HASH_BYTE_SIZE,
+};
 
 use crate::{
     fs::{
@@ -43,6 +46,26 @@ impl PrivateDirectory {
             parent_bare_name.0,
             time,
             &mut rng,
+        ))))
+    }
+
+    /// Creates a new directory with the ratchet seed and inumber provided.
+    #[wasm_bindgen(js_name = "withSeed")]
+    pub fn with_seed(
+        parent_bare_name: Namefilter,
+        time: &Date,
+        ratchet_seed: Vec<u8>,
+        inumber: Vec<u8>,
+    ) -> JsResult<PrivateDirectory> {
+        let time = DateTime::<Utc>::from(time);
+        let ratchet_seed = utils::expect_bytes::<HASH_BYTE_SIZE>(ratchet_seed)?;
+        let inumber = utils::expect_bytes::<HASH_BYTE_SIZE>(inumber)?;
+
+        Ok(Self(Rc::new(WnfsPrivateDirectory::with_seed(
+            parent_bare_name.0,
+            time,
+            ratchet_seed,
+            inumber,
         ))))
     }
 

--- a/wnfs-wasm/src/fs/private/forest.rs
+++ b/wnfs-wasm/src/fs/private/forest.rs
@@ -55,7 +55,7 @@ impl PrivateForest {
         let key = Key::new(key_bytes);
         let revision_key = RevisionKey(key);
 
-        let private_ref = PrivateRef::from_revision_key(saturated_name_hash, revision_key);
+        let private_ref = PrivateRef::with_revision_key(saturated_name_hash, revision_key);
 
         Ok(future_to_promise(async move {
             let node_option = forest

--- a/wnfs-wasm/src/fs/private/forest.rs
+++ b/wnfs-wasm/src/fs/private/forest.rs
@@ -1,6 +1,6 @@
 use std::rc::Rc;
 
-use js_sys::{Error, Promise};
+use js_sys::Promise;
 use wasm_bindgen::{prelude::wasm_bindgen, JsValue};
 use wasm_bindgen_futures::future_to_promise;
 use wnfs::{
@@ -9,7 +9,10 @@ use wnfs::{
 };
 
 use crate::{
-    fs::{utils::error, BlockStore, ForeignBlockStore, JsResult},
+    fs::{
+        utils::{self, error},
+        BlockStore, ForeignBlockStore, JsResult,
+    },
     value,
 };
 
@@ -46,9 +49,9 @@ impl PrivateForest {
         let store = ForeignBlockStore(store);
         let forest = self.0.clone();
 
-        let saturated_name_hash = expect_bytes::<HASH_BYTE_SIZE>(saturated_namefilter_hash)?;
+        let saturated_name_hash = utils::expect_bytes::<HASH_BYTE_SIZE>(saturated_namefilter_hash)?;
 
-        let key_bytes = expect_bytes::<KEY_BYTE_SIZE>(revision_key)?;
+        let key_bytes = utils::expect_bytes::<KEY_BYTE_SIZE>(revision_key)?;
         let key = Key::new(key_bytes);
         let revision_key = RevisionKey(key);
 
@@ -66,14 +69,4 @@ impl PrivateForest {
             })
         }))
     }
-}
-
-#[inline]
-fn expect_bytes<const N: usize>(bytes: Vec<u8>) -> JsResult<[u8; N]> {
-    bytes.try_into().map_err(|v: Vec<u8>| {
-        Error::new(&format!(
-            "Unexpected number of bytes received. Expected {N}, but got {}",
-            v.len()
-        ))
-    })
 }

--- a/wnfs-wasm/src/fs/private/node.rs
+++ b/wnfs-wasm/src/fs/private/node.rs
@@ -8,7 +8,7 @@ use crate::fs::{JsResult, PrivateDirectory};
 // Type Definitions
 //--------------------------------------------------------------------------------------------------
 
-/// Wraps a wnfs PublicNode.
+/// Wraps `wnfs::PrivateNode`.
 #[wasm_bindgen]
 pub struct PrivateNode(pub(crate) WnfsPrivateNode);
 

--- a/wnfs-wasm/src/fs/utils.rs
+++ b/wnfs-wasm/src/fs/utils.rs
@@ -104,3 +104,13 @@ pub(crate) fn create_ls_entry(name: &String, metadata: &Metadata) -> JsResult<Js
 
     Ok(value!(entry))
 }
+
+#[inline]
+pub(crate) fn expect_bytes<const N: usize>(bytes: Vec<u8>) -> JsResult<[u8; N]> {
+    bytes.try_into().map_err(|v: Vec<u8>| {
+        Error::new(&format!(
+            "Unexpected number of bytes received. Expected {N}, but got {}",
+            v.len()
+        ))
+    })
+}

--- a/wnfs/Cargo.toml
+++ b/wnfs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wnfs"
-version = "0.1.9"
+version = "0.1.10"
 description = "WebNative filesystem core implementation"
 keywords = ["wnfs", "webnative", "ipfs", "decentralisation"]
 categories = [

--- a/wnfs/examples/private.rs
+++ b/wnfs/examples/private.rs
@@ -80,7 +80,7 @@ where
     let forest_cid = store.put_serializable(&cbor_bytes).await.unwrap();
 
     // Private ref contains data and keys for fetching and decrypting the directory node in the private forest.
-    let private_ref = root_dir.header.get_private_ref().unwrap();
+    let private_ref = root_dir.header.get_private_ref();
 
     (forest_cid, private_ref)
 }

--- a/wnfs/src/common/utils.rs
+++ b/wnfs/src/common/utils.rs
@@ -107,7 +107,7 @@ pub(crate) mod test_setup {
             $crate::private::Namefilter::default()
         };
         [ hamt ] => {
-            Rc::new($crate::private::PrivateForest::new())
+            std::rc::Rc::new($crate::private::PrivateForest::new())
         };
         [ rng ] => {
             proptest::test_runner::TestRng::deterministic_rng(

--- a/wnfs/src/private/directory.rs
+++ b/wnfs/src/private/directory.rs
@@ -12,7 +12,8 @@ use super::{
 };
 
 use crate::{
-    dagcbor, error, utils, BlockStore, FsError, Id, Metadata, NodeType, PathNodes, PathNodesResult,
+    dagcbor, error, utils, BlockStore, FsError, HashOutput, Id, Metadata, NodeType, PathNodes,
+    PathNodesResult,
 };
 
 //--------------------------------------------------------------------------------------------------
@@ -95,6 +96,41 @@ impl PrivateDirectory {
         Self {
             version: Version::new(0, 2, 0),
             header: PrivateNodeHeader::new(parent_bare_name, rng),
+            metadata: Metadata::new(time),
+            entries: BTreeMap::new(),
+        }
+    }
+
+    /// TODO(appcypher): Add tests
+    /// Creates a new directory with provided seed and other details.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use wnfs::{PrivateDirectory, Namefilter};
+    /// use chrono::Utc;
+    /// use rand::{thread_rng, Rng};
+    ///
+    /// let rng = &mut thread_rng();
+    /// let seed = rng.gen::<[u8; 32]>();
+    /// let dir = PrivateDirectory::with_seed(
+    ///     Namefilter::default(),
+    ///     Utc::now(),
+    ///     seed,
+    ///     rng,
+    /// );
+    ///
+    /// println!("dir = {:?}", dir);
+    /// ```
+    pub fn with_seed<R: RngCore>(
+        parent_bare_name: Namefilter,
+        time: DateTime<Utc>,
+        ratchet_seed: HashOutput,
+        rng: &mut R,
+    ) -> Self {
+        Self {
+            version: Version::new(0, 2, 0),
+            header: PrivateNodeHeader::with_seed(parent_bare_name, ratchet_seed, rng),
             metadata: Metadata::new(time),
             entries: BTreeMap::new(),
         }

--- a/wnfs/src/private/directory.rs
+++ b/wnfs/src/private/directory.rs
@@ -304,7 +304,7 @@ impl PrivateDirectory {
         for (parent_dir, segment) in path_nodes.path.iter().rev() {
             let mut parent_dir = (**parent_dir).clone();
             parent_dir.advance_ratchet();
-            let child_private_ref = working_child_dir.header.get_private_ref()?;
+            let child_private_ref = working_child_dir.header.get_private_ref();
 
             parent_dir
                 .entries
@@ -328,7 +328,7 @@ impl PrivateDirectory {
         working_hamt = working_hamt
             .put(
                 working_child_dir.header.get_saturated_name(),
-                &working_child_dir.header.get_private_ref()?,
+                &working_child_dir.header.get_private_ref(),
                 &PrivateNode::Dir(Rc::clone(&working_child_dir)),
                 store,
                 rng,
@@ -605,7 +605,7 @@ impl PrivateDirectory {
             }
         };
 
-        let child_private_ref = file.header.get_private_ref()?;
+        let child_private_ref = file.header.get_private_ref();
         let hamt = hamt
             .put(
                 file.header.get_saturated_name(),
@@ -990,7 +990,7 @@ impl PrivateDirectory {
 
         directory
             .entries
-            .insert(filename.clone(), node.get_header().get_private_ref()?);
+            .insert(filename.clone(), node.get_header().get_private_ref());
 
         path_nodes.tail = Rc::new(directory);
 
@@ -1198,11 +1198,7 @@ impl PrivateDirectory {
     where
         S: serde::Serializer,
     {
-        let key = self
-            .header
-            .get_private_ref()
-            .map_err(SerError::custom)?
-            .revision_key;
+        let key = self.header.get_private_ref().revision_key;
 
         let mut entries = BTreeMap::new();
 
@@ -1292,18 +1288,18 @@ mod tests {
             PrivateDirectory::with_seed(Namefilter::default(), Utc::now(), ratchet_seed, inumber);
 
         assert_eq!(
-            dir1.header.get_private_ref().unwrap().revision_key,
-            dir2.header.get_private_ref().unwrap().revision_key
+            dir1.header.get_private_ref().revision_key,
+            dir2.header.get_private_ref().revision_key
         );
 
         assert_eq!(
-            dir1.header.get_private_ref().unwrap().content_key,
-            dir2.header.get_private_ref().unwrap().content_key
+            dir1.header.get_private_ref().content_key,
+            dir2.header.get_private_ref().content_key
         );
 
         assert_eq!(
-            dir1.header.get_private_ref().unwrap().saturated_name_hash,
-            dir2.header.get_private_ref().unwrap().saturated_name_hash
+            dir1.header.get_private_ref().saturated_name_hash,
+            dir2.header.get_private_ref().saturated_name_hash
         );
     }
 

--- a/wnfs/src/private/directory.rs
+++ b/wnfs/src/private/directory.rs
@@ -1280,7 +1280,7 @@ mod tests {
     use test_log::test;
 
     #[test(async_std::test)]
-    async fn can_create_deterministic_directories_with_user_provided_seeds() {
+    async fn can_create_directories_deterministically_with_user_provided_seeds() {
         let rng = &mut TestRng::deterministic_rng(RngAlgorithm::ChaCha);
         let ratchet_seed = utils::get_random_bytes::<32>(rng);
         let inumber = utils::get_random_bytes::<32>(rng);

--- a/wnfs/src/private/file.rs
+++ b/wnfs/src/private/file.rs
@@ -418,11 +418,7 @@ impl PrivateFile {
     where
         S: serde::Serializer,
     {
-        let key = self
-            .header
-            .get_private_ref()
-            .map_err(SerError::custom)?
-            .revision_key;
+        let key = self.header.get_private_ref().revision_key;
 
         (PrivateFileSerializable {
             r#type: NodeType::PrivateFile,

--- a/wnfs/src/private/forest.rs
+++ b/wnfs/src/private/forest.rs
@@ -69,7 +69,7 @@ impl PrivateForest {
     ///         rng,
     ///     ));
     ///
-    ///     let private_ref = &dir.header.get_private_ref().unwrap();
+    ///     let private_ref = &dir.header.get_private_ref();
     ///     let name = dir.header.get_saturated_name();
     ///     let node = PrivateNode::Dir(dir);
     ///
@@ -137,7 +137,7 @@ impl PrivateForest {
     ///         rng,
     ///     ));
     ///
-    ///     let private_ref = &dir.header.get_private_ref().unwrap();
+    ///     let private_ref = &dir.header.get_private_ref();
     ///     let name = dir.header.get_saturated_name();
     ///     let node = PrivateNode::Dir(dir);
     ///
@@ -207,7 +207,7 @@ impl PrivateForest {
     ///         rng,
     ///     ));
     ///
-    ///     let private_ref = &dir.header.get_private_ref().unwrap();
+    ///     let private_ref = &dir.header.get_private_ref();
     ///     let name = dir.header.get_saturated_name();
     ///     let node = PrivateNode::Dir(dir);
     ///     let forest = forest.put(name.clone(), private_ref, &node, store, rng).await.unwrap();
@@ -325,7 +325,7 @@ mod hamt_store_tests {
             rng,
         ));
 
-        let private_ref = dir.header.get_private_ref().unwrap();
+        let private_ref = dir.header.get_private_ref();
         let saturated_name = dir.header.get_saturated_name();
         let private_node = PrivateNode::Dir(dir.clone());
 
@@ -361,8 +361,8 @@ mod hamt_store_tests {
             Rc::new(dir)
         };
 
-        let private_ref = dir.header.get_private_ref().unwrap();
-        let private_ref_conflict = dir_conflict.header.get_private_ref().unwrap();
+        let private_ref = dir.header.get_private_ref();
+        let private_ref_conflict = dir_conflict.header.get_private_ref();
         let saturated_name = dir.header.get_saturated_name();
         let saturated_name_conflict = dir_conflict.header.get_saturated_name();
         let private_node = PrivateNode::Dir(dir.clone());

--- a/wnfs/src/private/hamt/node.rs
+++ b/wnfs/src/private/hamt/node.rs
@@ -756,13 +756,10 @@ mod hamt_node_unit_tests {
 
     #[test(async_std::test)]
     async fn node_can_insert_pair_and_retrieve() {
-        let mut store = MemoryBlockStore::default();
+        let store = MemoryBlockStore::default();
         let node = Rc::new(Node::<String, (i32, f64)>::default());
 
-        let node = node
-            .set("pill".into(), (10, 0.315), &mut store)
-            .await
-            .unwrap();
+        let node = node.set("pill".into(), (10, 0.315), &store).await.unwrap();
 
         let value = node.get(&"pill".into(), &store).await.unwrap().unwrap();
 

--- a/wnfs/src/private/mod.rs
+++ b/wnfs/src/private/mod.rs
@@ -6,6 +6,7 @@ mod key;
 pub mod namefilter;
 pub mod node;
 mod previous;
+mod privateref;
 
 pub use directory::*;
 pub use file::*;
@@ -15,3 +16,4 @@ pub use key::*;
 pub use namefilter::*;
 pub use node::*;
 pub use previous::*;
+pub use privateref::*;

--- a/wnfs/src/private/node.rs
+++ b/wnfs/src/private/node.rs
@@ -1,5 +1,8 @@
-use std::{cmp::Ordering, fmt::Debug, io::Cursor, rc::Rc};
-
+use super::{
+    hamt::Hasher, namefilter::Namefilter, Key, PrivateDirectory, PrivateFile, PrivateForest,
+    PrivateRef,
+};
+use crate::{utils, BlockStore, FsError, HashOutput, Id, NodeType, HASH_BYTE_SIZE};
 use anyhow::{bail, Result};
 use async_recursion::async_recursion;
 use chrono::{DateTime, Utc};
@@ -9,15 +12,10 @@ use libipld::{
     serde as ipld_serde, Ipld,
 };
 use rand_core::RngCore;
-use serde::{de::Error as DeError, ser::Error as SerError, Deserialize, Serialize};
+use serde::{Deserialize, Serialize};
 use sha3::Sha3_256;
 use skip_ratchet::{seek::JumpSize, Ratchet, RatchetSeeker};
-
-use crate::{utils, BlockStore, FsError, HashOutput, Id, NodeType, HASH_BYTE_SIZE};
-
-use super::{
-    hamt::Hasher, namefilter::Namefilter, Key, PrivateDirectory, PrivateFile, PrivateForest,
-};
+use std::{cmp::Ordering, fmt::Debug, io::Cursor, rc::Rc};
 
 //--------------------------------------------------------------------------------------------------
 // Type Definitions
@@ -87,27 +85,6 @@ pub struct PrivateNodeHeader {
     pub(crate) ratchet: Ratchet,
     /// Used for ancestry checks and as a key fot the HAMT.
     pub(crate) bare_name: Namefilter,
-}
-
-/// PrivateRef holds the information to fetch associated node from a HAMT and decrypt it if it is present.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct PrivateRef {
-    /// Sha3-256 hash of saturated namefilter.
-    pub(crate) saturated_name_hash: HashOutput,
-    /// Sha3-256 hash of the ratchet key.
-    pub(crate) content_key: ContentKey,
-    /// Skip-ratchet-derived key.
-    pub(crate) revision_key: RevisionKey,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub(crate) struct PrivateRefSerializable {
-    #[serde(rename = "name")]
-    pub(crate) saturated_name_hash: HashOutput,
-    #[serde(rename = "contentKey")]
-    pub(crate) content_key: ContentKey,
-    #[serde(rename = "revisionKey")]
-    pub(crate) revision_key: Vec<u8>,
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -629,118 +606,6 @@ impl From<ContentKey> for Key {
     }
 }
 
-impl PrivateRef {
-    /// Creates a PrivateRef from provided saturated name and revision key.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use wnfs::{private::{PrivateRef, RevisionKey}, private::Key};
-    /// use rand::{thread_rng, Rng};
-    ///
-    /// let rng = &mut thread_rng();
-    /// let private_ref = PrivateRef::with_revision_key(
-    ///     rng.gen::<[u8; 32]>(),
-    ///     RevisionKey::from(Key::new(rng.gen::<[u8; 32]>())),
-    /// );
-    ///
-    /// println!("Private ref: {:?}", private_ref);
-    /// ```
-    pub fn with_revision_key(saturated_name_hash: HashOutput, revision_key: RevisionKey) -> Self {
-        Self {
-            saturated_name_hash,
-            content_key: revision_key.derive_content_key(),
-            revision_key,
-        }
-    }
-
-    /// Creates a PrivateRef from provided namefilter, ratchet seed and inumber.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use wnfs::{private::PrivateRef, Namefilter};
-    /// use rand::{thread_rng, Rng};
-    ///
-    /// let rng = &mut thread_rng();
-    /// let private_ref = PrivateRef::with_seed(
-    ///     Namefilter::default(),
-    ///     rng.gen::<[u8; 32]>(),
-    ///     rng.gen::<[u8; 32]>(),
-    /// );
-    ///
-    /// println!("Private ref: {:?}", private_ref);
-    /// ```
-    pub fn with_seed(name: Namefilter, ratchet_seed: HashOutput, inumber: HashOutput) -> Self {
-        let h = PrivateNodeHeader::with_seed(name, ratchet_seed, inumber);
-        h.get_private_ref()
-    }
-
-    pub(crate) fn to_serializable(
-        &self,
-        revision_key: &RevisionKey,
-        rng: &mut impl RngCore,
-    ) -> Result<PrivateRefSerializable> {
-        // encrypt ratchet key
-        let revision_key = revision_key
-            .0
-            .encrypt(&Key::generate_nonce(rng), self.revision_key.0.as_bytes())?;
-        Ok(PrivateRefSerializable {
-            saturated_name_hash: self.saturated_name_hash,
-            content_key: self.content_key.clone(),
-            revision_key,
-        })
-    }
-
-    pub(crate) fn from_serializable(
-        private_ref: PrivateRefSerializable,
-        revision_key: &RevisionKey,
-    ) -> Result<Self> {
-        let revision_key = RevisionKey(Key::new(
-            revision_key
-                .0
-                .decrypt(&private_ref.revision_key)?
-                .try_into()
-                .map_err(|e: Vec<u8>| {
-                    FsError::InvalidDeserialization(format!(
-                        "Expected 32 bytes for ratchet key, but got {}",
-                        e.len()
-                    ))
-                })?,
-        ));
-        Ok(Self {
-            saturated_name_hash: private_ref.saturated_name_hash,
-            content_key: private_ref.content_key,
-            revision_key,
-        })
-    }
-
-    pub fn serialize<S>(
-        &self,
-        serializer: S,
-        revision_key: &RevisionKey,
-        rng: &mut impl RngCore,
-    ) -> Result<S::Ok, S::Error>
-    where
-        S: serde::Serializer,
-    {
-        self.to_serializable(revision_key, rng)
-            .map_err(SerError::custom)?
-            .serialize(serializer)
-    }
-
-    pub fn deserialize<'de, D>(
-        deserializer: D,
-        revision_key: &RevisionKey,
-    ) -> Result<Self, D::Error>
-    where
-        D: serde::Deserializer<'de>,
-    {
-        let private_ref = PrivateRefSerializable::deserialize(deserializer)?;
-        PrivateRef::from_serializable(private_ref, revision_key).map_err(DeError::custom)
-    }
-}
-
 impl RevisionKey {
     pub fn derive_content_key(&self) -> ContentKey {
         let RevisionKey(key) = self;
@@ -753,7 +618,7 @@ impl RevisionKey {
 //--------------------------------------------------------------------------------------------------
 
 #[cfg(test)]
-mod private_node_tests {
+mod tests {
     use proptest::test_runner::{RngAlgorithm, TestRng};
 
     use crate::MemoryBlockStore;

--- a/wnfs/src/private/node.rs
+++ b/wnfs/src/private/node.rs
@@ -506,6 +506,24 @@ impl PrivateNodeHeader {
         }
     }
 
+    /// Creates a new PrivateNodeHeader with provided seed.
+    pub(crate) fn with_seed<R: RngCore>(
+        parent_bare_name: Namefilter,
+        ratchet_seed: HashOutput,
+        rng: &mut R,
+    ) -> Self {
+        let inumber = utils::get_random_bytes::<HASH_BYTE_SIZE>(rng);
+        Self {
+            bare_name: {
+                let mut namefilter = parent_bare_name;
+                namefilter.add(&inumber);
+                namefilter
+            },
+            ratchet: Ratchet::zero(ratchet_seed),
+            inumber,
+        }
+    }
+
     /// Advances the ratchet.
     pub(crate) fn advance_ratchet(&mut self) {
         self.ratchet.inc();

--- a/wnfs/src/private/node.rs
+++ b/wnfs/src/private/node.rs
@@ -507,12 +507,11 @@ impl PrivateNodeHeader {
     }
 
     /// Creates a new PrivateNodeHeader with provided seed.
-    pub(crate) fn with_seed<R: RngCore>(
+    pub(crate) fn with_seed(
         parent_bare_name: Namefilter,
         ratchet_seed: HashOutput,
-        rng: &mut R,
+        inumber: HashOutput,
     ) -> Self {
-        let inumber = utils::get_random_bytes::<HASH_BYTE_SIZE>(rng);
         Self {
             bare_name: {
                 let mut namefilter = parent_bare_name;

--- a/wnfs/src/private/previous.rs
+++ b/wnfs/src/private/previous.rs
@@ -106,7 +106,7 @@ impl PrivateNodeHistory {
                 self.header.ratchet = previous_ratchet;
                 self.forest
                     .get(
-                        &self.header.get_private_ref()?,
+                        &self.header.get_private_ref(),
                         PrivateForest::resolve_lowest,
                         store,
                     )
@@ -528,7 +528,7 @@ mod private_history_tests {
         let hamt = hamt
             .put(
                 root_dir.header.get_saturated_name(),
-                &root_dir.header.get_private_ref().unwrap(),
+                &root_dir.header.get_private_ref(),
                 &PrivateNode::Dir(Rc::clone(&root_dir)),
                 store,
                 rng,
@@ -618,7 +618,7 @@ mod private_history_tests {
         let hamt = hamt
             .put(
                 root_dir.header.get_saturated_name(),
-                &root_dir.header.get_private_ref().unwrap(),
+                &root_dir.header.get_private_ref(),
                 &PrivateNode::Dir(Rc::clone(&root_dir)),
                 store,
                 rng,
@@ -715,7 +715,7 @@ mod private_history_tests {
         let hamt = hamt
             .put(
                 root_dir.header.get_saturated_name(),
-                &root_dir.header.get_private_ref().unwrap(),
+                &root_dir.header.get_private_ref(),
                 &PrivateNode::Dir(Rc::clone(&root_dir)),
                 store,
                 rng,
@@ -972,7 +972,7 @@ mod private_history_tests {
         let hamt = hamt
             .put(
                 root_dir.header.get_saturated_name(),
-                &root_dir.header.get_private_ref().unwrap(),
+                &root_dir.header.get_private_ref(),
                 &PrivateNode::Dir(Rc::clone(&root_dir)),
                 store,
                 rng,

--- a/wnfs/src/private/privateref.rs
+++ b/wnfs/src/private/privateref.rs
@@ -1,0 +1,198 @@
+use super::{ContentKey, Key, PrivateNodeHeader, RevisionKey};
+use crate::{FsError, HashOutput, Namefilter};
+use anyhow::Result;
+use rand_core::RngCore;
+use serde::{de::Error as DeError, ser::Error as SerError, Deserialize, Serialize};
+
+//--------------------------------------------------------------------------------------------------
+// Type Definitions
+//--------------------------------------------------------------------------------------------------
+
+/// PrivateRef holds the information to fetch associated node from a HAMT and decrypt it if it is present.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PrivateRef {
+    /// Sha3-256 hash of saturated namefilter.
+    pub(crate) saturated_name_hash: HashOutput,
+    /// Sha3-256 hash of the ratchet key.
+    pub(crate) content_key: ContentKey,
+    /// Skip-ratchet-derived key.
+    pub(crate) revision_key: RevisionKey,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(crate) struct PrivateRefSerializable {
+    #[serde(rename = "name")]
+    pub(crate) saturated_name_hash: HashOutput,
+    #[serde(rename = "contentKey")]
+    pub(crate) content_key: ContentKey,
+    #[serde(rename = "revisionKey")]
+    pub(crate) revision_key: Vec<u8>,
+}
+
+//--------------------------------------------------------------------------------------------------
+// Implementations
+//--------------------------------------------------------------------------------------------------
+
+impl PrivateRef {
+    /// Creates a PrivateRef from provided saturated name and revision key.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use wnfs::{private::{PrivateRef, RevisionKey}, private::Key};
+    /// use rand::{thread_rng, Rng};
+    ///
+    /// let rng = &mut thread_rng();
+    /// let private_ref = PrivateRef::with_revision_key(
+    ///     rng.gen::<[u8; 32]>(),
+    ///     RevisionKey::from(Key::new(rng.gen::<[u8; 32]>())),
+    /// );
+    ///
+    /// println!("Private ref: {:?}", private_ref);
+    /// ```
+    pub fn with_revision_key(saturated_name_hash: HashOutput, revision_key: RevisionKey) -> Self {
+        Self {
+            saturated_name_hash,
+            content_key: revision_key.derive_content_key(),
+            revision_key,
+        }
+    }
+
+    /// Creates a PrivateRef from provided namefilter, ratchet seed and inumber.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use wnfs::{private::PrivateRef, Namefilter};
+    /// use rand::{thread_rng, Rng};
+    ///
+    /// let rng = &mut thread_rng();
+    /// let private_ref = PrivateRef::with_seed(
+    ///     Namefilter::default(),
+    ///     rng.gen::<[u8; 32]>(),
+    ///     rng.gen::<[u8; 32]>(),
+    /// );
+    ///
+    /// println!("Private ref: {:?}", private_ref);
+    /// ```
+    pub fn with_seed(name: Namefilter, ratchet_seed: HashOutput, inumber: HashOutput) -> Self {
+        let h = PrivateNodeHeader::with_seed(name, ratchet_seed, inumber);
+        h.get_private_ref()
+    }
+
+    pub(crate) fn to_serializable(
+        &self,
+        revision_key: &RevisionKey,
+        rng: &mut impl RngCore,
+    ) -> Result<PrivateRefSerializable> {
+        // encrypt ratchet key
+        let revision_key = revision_key
+            .0
+            .encrypt(&Key::generate_nonce(rng), self.revision_key.0.as_bytes())?;
+        Ok(PrivateRefSerializable {
+            saturated_name_hash: self.saturated_name_hash,
+            content_key: self.content_key.clone(),
+            revision_key,
+        })
+    }
+
+    pub(crate) fn from_serializable(
+        private_ref: PrivateRefSerializable,
+        revision_key: &RevisionKey,
+    ) -> Result<Self> {
+        let revision_key = RevisionKey(Key::new(
+            revision_key
+                .0
+                .decrypt(&private_ref.revision_key)?
+                .try_into()
+                .map_err(|e: Vec<u8>| {
+                    FsError::InvalidDeserialization(format!(
+                        "Expected 32 bytes for ratchet key, but got {}",
+                        e.len()
+                    ))
+                })?,
+        ));
+        Ok(Self {
+            saturated_name_hash: private_ref.saturated_name_hash,
+            content_key: private_ref.content_key,
+            revision_key,
+        })
+    }
+
+    pub fn serialize<S>(
+        &self,
+        serializer: S,
+        revision_key: &RevisionKey,
+        rng: &mut impl RngCore,
+    ) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        self.to_serializable(revision_key, rng)
+            .map_err(SerError::custom)?
+            .serialize(serializer)
+    }
+
+    pub fn deserialize<'de, D>(
+        deserializer: D,
+        revision_key: &RevisionKey,
+    ) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let private_ref = PrivateRefSerializable::deserialize(deserializer)?;
+        PrivateRef::from_serializable(private_ref, revision_key).map_err(DeError::custom)
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+// Tests
+//--------------------------------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use crate::{
+        private::PrivateForest,
+        utils::{self, test_setup},
+        PrivateDirectory, PrivateNode,
+    };
+    use chrono::Utc;
+
+    use super::PrivateRef;
+
+    #[async_std::test]
+    async fn can_create_privateref_deterministically_with_user_provided_seeds() {
+        let (hamt, store, rng) = test_setup::init!(hamt, mut store, mut rng);
+        let ratchet_seed = utils::get_random_bytes::<32>(rng);
+        let inumber = utils::get_random_bytes::<32>(rng);
+
+        let dir = PrivateNode::from(PrivateDirectory::with_seed(
+            Default::default(),
+            Utc::now(),
+            ratchet_seed,
+            inumber,
+        ));
+
+        let header = dir.get_header();
+        let hamt = hamt
+            .put(
+                header.get_saturated_name(),
+                &header.get_private_ref(),
+                &dir,
+                store,
+                rng,
+            )
+            .await
+            .unwrap();
+
+        // Creating deterministic privateref.
+        let private_ref = PrivateRef::with_seed(Default::default(), ratchet_seed, inumber);
+        let retrieved_node = hamt
+            .get(&private_ref, PrivateForest::resolve_lowest, store)
+            .await
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(retrieved_node, dir);
+    }
+}


### PR DESCRIPTION
## Summary

In some cases, we want to be able to deterministically create a directory with seeds generated at userland, for example, from private keys. There is a hacky solution to this by passing a carefully designed rng, but that is likely to break in future versions.

This PR adds the API for accepting user-specified ratchet seed and inumber that solves the problem outlined above. 

<!-- Summary of the PR -->

This PR implements the following **features**

- [x] Support user-specified ratchet seed and inumber
- [x] Expose corresponding wasm/js API
- [x] Bump version

<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

## Test plan (required)
-  Testing
    
    ```bash
    rs-wnfs test --all
    ```

<!-- Make sure tests pass on Circle CI. -->

## Closing issues

<!-- Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such). -->

Fixes #86 