### PR TITLE
Fix calculations avoiding to exceed the 2^18 bytes block limit

### DIFF
--- a/wnfs/proptest-regressions/private/file.txt
+++ b/wnfs/proptest-regressions/private/file.txt
@@ -1,0 +1,8 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc 3d8ef3fd02b50b6a8e666913259bc43b153f42b7ce3f17a1654799b8777284b3 # shrinks to input = _CanIncludeAndStreamContentFromFileArgs { length: 262117 }
+cc ec425ece25d3c83eb22e70aef1e39e6585b3f1c6ffdeb8eff41d7ad96d80e886 # shrinks to input = _CanIncludeAndGetContentFromFileArgs { length: 262117 }

--- a/wnfs/src/common/error.rs
+++ b/wnfs/src/common/error.rs
@@ -74,6 +74,9 @@ pub enum FsError {
 
     #[error("Key does not exist in HAMT")]
     KeyNotFoundInHamt,
+
+    #[error("Maximum block size exceeded: Encountered block with {0} bytes")]
+    MaximumBlockSizeExceeded(usize),
 }
 
 pub fn error<T>(err: impl std::error::Error + Send + Sync + 'static) -> Result<T> {

--- a/wnfs/src/private/file.rs
+++ b/wnfs/src/private/file.rs
@@ -1,6 +1,6 @@
 use super::{
     encrypted::Encrypted, namefilter::Namefilter, Key, PrivateForest, PrivateNodeHeader,
-    RevisionKey, NONCE_SIZE,
+    RevisionKey, AUTHENTICATION_TAG_SIZE, NONCE_SIZE,
 };
 use crate::{
     dagcbor, utils, utils::get_random_bytes, BlockStore, FsError, Hasher, Id, Metadata, NodeType,
@@ -23,12 +23,13 @@ use std::{collections::BTreeSet, iter, rc::Rc};
 //--------------------------------------------------------------------------------------------------
 
 /// The maximum block size is 2 ^ 18 but the first 12 bytes are reserved for the cipher text's initialization vector.
-/// This leaves a maximum of (2 ^ 18) - 12 = 262,132 bytes for the actual data.
+/// The ciphertext then also contains a 16 byte authentication tag.
+/// This leaves a maximum of (2 ^ 18) - 12 - 16 = 262,116 bytes for the actual data.
 ///
 /// More on that [here][priv-file].
 ///
 /// [priv-file]: https://github.com/wnfs-wg/spec/blob/matheus23/file-sharding/spec/private-wnfs.md#314-private-file
-pub const MAX_BLOCK_CONTENT_SIZE: usize = MAX_BLOCK_SIZE - NONCE_SIZE;
+pub const MAX_BLOCK_CONTENT_SIZE: usize = MAX_BLOCK_SIZE - NONCE_SIZE - AUTHENTICATION_TAG_SIZE;
 
 //--------------------------------------------------------------------------------------------------
 // Type Definitions

--- a/wnfs/src/private/key.rs
+++ b/wnfs/src/private/key.rs
@@ -12,6 +12,7 @@ use crate::{utils, FsError};
 //--------------------------------------------------------------------------------------------------
 
 pub(crate) const NONCE_SIZE: usize = 12;
+pub(crate) const AUTHENTICATION_TAG_SIZE: usize = 16;
 pub const KEY_BYTE_SIZE: usize = 32;
 
 //--------------------------------------------------------------------------------------------------


### PR DESCRIPTION
I messed up a bit in the spec and forgot about AES-GCM's authentication tag, which is another 16 bytes of overhead added during encryption.

The spec PR: https://github.com/wnfs-wg/spec/pull/57

So, to sum it up: AES-GCM with a 12 bytes IV and a 256-bit key adds a 16 bytes authentication tag.
(That tag's purpose is to check that no process tampered with the ciphertext.)

---

I added a condition to the `MemoryBlockStore` to make sure none of our tests actually exceed the block limit in the future.
Accordingly, I added an error `MaximumBlockSizeExceeded`.
Lastly I fixed the calculation for the maximum length of plaintext for a private file block.