### PR TITLE
feat(api): self lookup & store at construction

### DIFF
--- a/wnfs/Cargo.toml
+++ b/wnfs/Cargo.toml
@@ -21,7 +21,6 @@ aes-gcm = "0.10"
 anyhow = "1.0"
 async-once-cell = "0.4"
 async-recursion = "1.0"
-async-std = { version = "1.11", features = ["attributes"] }
 async-stream = "0.3"
 async-trait = "0.1"
 bitvec = { version = "1.0", features = ["serde"] }
@@ -44,11 +43,13 @@ thiserror = "1.0"
 xxhash-rust = { version = "0.8", features = ["xxh3"] }
 
 [dev-dependencies]
+async-std = { version = "1.11", features = ["attributes"] }
 env_logger = "0.10"
 proptest = "1.0"
 rand = "0.8"
 test-log = "0.2"
 test-strategy = "0.2"
+tokio = { version = "1.0", features = ["full"] }
 
 [lib]
 name = "wnfs"

--- a/wnfs/examples/privateref.rs
+++ b/wnfs/examples/privateref.rs
@@ -81,7 +81,7 @@ async fn main() -> anyhow::Result<()> {
 
     println!("{:#?}", fetched_node);
 
-    // The private_ref might point to old revision of the root_dir.
+    // The private_ref might point to some old revision of the root_dir.
     // We can do the following to get the latest revision.
     let fetched_dir = {
         let tmp = fetched_node.unwrap().as_dir()?;

--- a/wnfs/examples/privateref.rs
+++ b/wnfs/examples/privateref.rs
@@ -1,0 +1,80 @@
+use chrono::Utc;
+use libipld::{serde::Serializer, Ipld};
+use rand::thread_rng;
+use sha3::Sha3_256;
+use skip_ratchet::Ratchet;
+use std::{io::Cursor, rc::Rc};
+use wnfs::{
+    ipld::{DagCborCodec, Decode, Encode},
+    private::{Key, PrivateForest, PrivateRef, RevisionKey},
+    utils, Hasher, MemoryBlockStore, Namefilter, PrivateDirectory, PrivateOpResult,
+};
+
+#[async_std::main]
+async fn main() -> anyhow::Result<()> {
+    // Prerequisites:
+    let store = &mut MemoryBlockStore::default();
+    let rng = &mut thread_rng();
+    let forest = Rc::new(PrivateForest::new());
+
+    // Some existing user key.
+    let some_key = Key::new(utils::get_random_bytes::<32>(rng));
+
+    // Creating ratchet_seed from our key. And intializing the inumber and namefilter.
+    let ratchet_seed = Sha3_256::hash(&some_key.as_bytes());
+    let inumber = utils::get_random_bytes::<32>(rng); // Needs to be random
+
+    // Create the directory from the ratchet_seed, inumber and namefilter.
+    let root_dir = Rc::new(PrivateDirectory::with_seed(
+        Namefilter::default(),
+        Utc::now(),
+        ratchet_seed,
+        inumber,
+    ));
+
+    // Add a /movies/anime to the directory.
+    let PrivateOpResult {
+        forest, root_dir, ..
+    } = root_dir
+        .mkdir(
+            &["movies".into(), "anime".into()],
+            true,
+            Utc::now(),
+            forest,
+            store,
+            rng,
+        )
+        .await?;
+
+    // We can create a revision_key from the ratcet_seed.
+    let ratchet = Ratchet::zero(ratchet_seed);
+    let revision_key = RevisionKey::from(Key::new(ratchet.derive_key()));
+
+    // Now let's serialize the root_dir's private_ref.
+    let private_ref = root_dir.header.get_private_ref();
+    println!("Private ref: {:?}", private_ref);
+    let cbor = encode_ipld(private_ref.serialize(Serializer, &revision_key, rng)?)?;
+
+    // We can deserialize the private_ref using the information we have.
+    let private_ref = decode_ipld(cbor, &revision_key)?;
+
+    // Now we can fetch the directory from the forest.
+    let dir = forest
+        .get(&private_ref, PrivateForest::resolve_lowest, store)
+        .await?;
+
+    println!("{:#?}", dir);
+
+    Ok(())
+}
+
+fn encode_ipld(ipld: Ipld) -> anyhow::Result<Vec<u8>> {
+    let mut bytes = Vec::new();
+    ipld.encode(DagCborCodec, &mut bytes)?;
+    Ok(bytes)
+}
+
+fn decode_ipld(bytes: Vec<u8>, revision_key: &RevisionKey) -> anyhow::Result<PrivateRef> {
+    let ipld = Ipld::decode(DagCborCodec, &mut Cursor::new(bytes))?;
+    PrivateRef::deserialize(ipld, revision_key).map_err(Into::into)
+}

--- a/wnfs/examples/privateref.rs
+++ b/wnfs/examples/privateref.rs
@@ -10,12 +10,15 @@ use wnfs::{
     utils, Hasher, MemoryBlockStore, Namefilter, PrivateDirectory, PrivateOpResult,
 };
 
-#[async_std::main]
+#[tokio::main(flavor = "multi_thread")]
 async fn main() -> anyhow::Result<()> {
-    // Prerequisites:
+    // ----------- Prerequisites -----------
+
     let store = &mut MemoryBlockStore::default();
     let rng = &mut thread_rng();
     let forest = Rc::new(PrivateForest::new());
+
+    // ----------- Create a private directory -----------
 
     // Some existing user key.
     let some_key = Key::new(utils::get_random_bytes::<32>(rng));
@@ -27,7 +30,7 @@ async fn main() -> anyhow::Result<()> {
     // Create a root directory from the ratchet_seed, inumber and namefilter. Directory gets saved in forest.
     let PrivateOpResult {
         forest, root_dir, ..
-    } = PrivateDirectory::with_seed_and_store(
+    } = PrivateDirectory::new_and_store_with_seed(
         Namefilter::default(),
         Utc::now(),
         ratchet_seed,
@@ -38,6 +41,8 @@ async fn main() -> anyhow::Result<()> {
     )
     .await
     .unwrap();
+
+    // ----------- Create a subdirectory -----------
 
     // Add a /movies/anime to the directory.
     let PrivateOpResult {
@@ -53,6 +58,8 @@ async fn main() -> anyhow::Result<()> {
         )
         .await?;
 
+    // --------- Generate a private ref (Method 1) -----------
+
     // We can create a revision_key from our ratchet_seed.
     let ratchet = Ratchet::zero(ratchet_seed);
     let revision_key = RevisionKey::from(Key::new(ratchet.derive_key()));
@@ -63,17 +70,19 @@ async fn main() -> anyhow::Result<()> {
     // We can deserialize the private_ref using the revision_key at hand.
     let private_ref = decode(cbor, &revision_key)?;
 
-    // Now we can fetch the directory from the forest.
+    // Now we can fetch the directory from the forest using the private_ref.
     let fetched_node = forest
         .get(&private_ref, PrivateForest::resolve_lowest, store)
         .await?;
 
     println!("{:#?}", fetched_node);
 
-    // We can also create a private_ref from scratch.
+    // --------- Generate a private ref (Method 2) -----------
+
+    // We can also create a private_ref from scratch if we remember the parameters.
     let private_ref = PrivateRef::with_seed(Namefilter::default(), ratchet_seed, inumber);
 
-    // And we can fetch the directory again using the new private_ref.
+    // And we can fetch the directory again using the generated private_ref.
     let fetched_node = forest
         .get(&private_ref, PrivateForest::resolve_lowest, store)
         .await?;
@@ -82,14 +91,11 @@ async fn main() -> anyhow::Result<()> {
 
     // The private_ref might point to some old revision of the root_dir.
     // We can do the following to get the latest revision.
-    let fetched_dir = {
-        let tmp = fetched_node.unwrap().as_dir()?;
-        tmp.get_node(&[], true, forest, store)
-            .await?
-            .result
-            .unwrap()
-            .as_dir()?
-    };
+    let fetched_dir = fetched_node
+        .unwrap()
+        .search_latest(&forest, store)
+        .await?
+        .as_dir()?;
 
     println!("{:#?}", fetched_dir);
 

--- a/wnfs/examples/privateref.rs
+++ b/wnfs/examples/privateref.rs
@@ -30,7 +30,7 @@ async fn main() -> anyhow::Result<()> {
     // Create a root directory from the ratchet_seed, inumber and namefilter. Directory gets saved in forest.
     let PrivateOpResult {
         forest, root_dir, ..
-    } = PrivateDirectory::new_and_store_with_seed(
+    } = PrivateDirectory::new_with_seed_and_store(
         Namefilter::default(),
         Utc::now(),
         ratchet_seed,

--- a/wnfs/examples/privateref.rs
+++ b/wnfs/examples/privateref.rs
@@ -1,13 +1,12 @@
 use chrono::Utc;
-use libipld::{serde::Serializer, Ipld};
 use rand::thread_rng;
-use rand_core::RngCore;
 use sha3::Sha3_256;
-use skip_ratchet::Ratchet;
 use std::{io::Cursor, rc::Rc};
 use wnfs::{
-    ipld::{DagCborCodec, Decode, Encode},
+    ipld::{DagCborCodec, Decode, Encode, Ipld, Serializer},
     private::{Key, PrivateForest, PrivateRef, RevisionKey},
+    ratchet::Ratchet,
+    rng::RngCore,
     utils, Hasher, MemoryBlockStore, Namefilter, PrivateDirectory, PrivateOpResult,
 };
 

--- a/wnfs/src/lib.rs
+++ b/wnfs/src/lib.rs
@@ -30,10 +30,15 @@ pub mod ipld {
         cbor::DagCborCodec,
         cid::Version,
         codec::{Codec, Decode, Encode},
-        Cid, IpldCodec,
+        serde::Serializer,
+        Cid, Ipld, IpldCodec,
     };
 }
 
 pub mod rng {
     pub use rand_core::RngCore;
+}
+
+pub mod ratchet {
+    pub use skip_ratchet::{Ratchet, RatchetSeeker};
 }

--- a/wnfs/src/private/directory.rs
+++ b/wnfs/src/private/directory.rs
@@ -15,6 +15,7 @@ use semver::Version;
 use serde::{de::Error as DeError, ser::Error as SerError, Deserialize, Deserializer, Serialize};
 use std::{
     collections::{BTreeMap, BTreeSet},
+    fmt::Debug,
     rc::Rc,
 };
 

--- a/wnfs/src/private/directory.rs
+++ b/wnfs/src/private/directory.rs
@@ -152,9 +152,11 @@ impl PrivateDirectory {
         rng: &mut R,
     ) -> Result<PrivateOpResult<()>> {
         let dir = Rc::new(Self {
+            persisted_as: OnceCell::new(),
             version: Version::new(0, 2, 0),
             header: PrivateNodeHeader::new(parent_bare_name, rng),
             metadata: Metadata::new(time),
+            previous: None,
             entries: BTreeMap::new(),
         });
 
@@ -185,8 +187,10 @@ impl PrivateDirectory {
         rng: &mut R,
     ) -> Result<PrivateOpResult<()>> {
         let dir = Rc::new(Self {
+            persisted_as: OnceCell::new(),
             version: Version::new(0, 2, 0),
             header: PrivateNodeHeader::with_seed(parent_bare_name, ratchet_seed, inumber),
+            previous: None,
             metadata: Metadata::new(time),
             entries: BTreeMap::new(),
         });

--- a/wnfs/src/private/directory.rs
+++ b/wnfs/src/private/directory.rs
@@ -177,7 +177,7 @@ impl PrivateDirectory {
         })
     }
 
-    pub async fn new_and_store_with_seed<B: BlockStore, R: RngCore>(
+    pub async fn new_with_seed_and_store<B: BlockStore, R: RngCore>(
         parent_bare_name: Namefilter,
         time: DateTime<Utc>,
         ratchet_seed: HashOutput,

--- a/wnfs/src/private/namefilter/bloomfilter.rs
+++ b/wnfs/src/private/namefilter/bloomfilter.rs
@@ -263,8 +263,13 @@ impl<'de, const N: usize, const K: usize> Deserialize<'de> for BloomFilter<N, K>
 impl<const N: usize, const K: usize> Debug for BloomFilter<N, K> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "0x")?;
-        for byte in self.as_bytes().iter() {
-            write!(f, "{byte:02X}")?;
+        for (i, byte) in self.as_bytes().iter().enumerate() {
+            if i > 32 {
+                write!(f, "..")?;
+                break;
+            } else {
+                write!(f, "{byte:02X}")?;
+            }
         }
 
         Ok(())

--- a/wnfs/src/private/node.rs
+++ b/wnfs/src/private/node.rs
@@ -353,7 +353,50 @@ impl PrivateNode {
     }
 
     /// Gets the latest version of the node using exponential search.
-    pub(crate) async fn search_latest(
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use std::rc::Rc;
+    /// use chrono::Utc;
+    /// use rand::thread_rng;
+    /// use wnfs::{
+    ///     private::{PrivateForest, PrivateRef, PrivateNode},
+    ///     BlockStore, MemoryBlockStore, Namefilter, PrivateDirectory, PrivateOpResult,
+    /// };
+    ///
+    /// #[async_std::main]
+    /// async fn main() {
+    ///     let store = &mut MemoryBlockStore::default();
+    ///     let rng = &mut thread_rng();
+    ///     let forest = Rc::new(PrivateForest::new());
+    ///
+    ///     let PrivateOpResult { forest, root_dir: init_dir, .. } = PrivateDirectory::new_and_store(
+    ///         Default::default(),
+    ///         Utc::now(),
+    ///         forest,
+    ///         store,
+    ///         rng
+    ///     ).await.unwrap();
+    ///
+    ///     let PrivateOpResult { forest, root_dir, .. } = Rc::clone(&init_dir)
+    ///         .mkdir(&["pictures".into(), "cats".into()], true, Utc::now(), forest, store, rng)
+    ///         .await
+    ///         .unwrap();
+    ///
+    ///     let latest_node = PrivateNode::Dir(init_dir).search_latest(&forest, store).await.unwrap();
+    ///
+    ///     let found_node = latest_node
+    ///         .as_dir()
+    ///         .unwrap()
+    ///         .lookup_node("pictures", true, &forest, store)
+    ///         .await
+    ///         .unwrap();
+    ///
+    ///     assert!(found_node.is_some());
+    /// }
+    /// ```
+    pub async fn search_latest(
         &self,
         forest: &PrivateForest,
         store: &impl BlockStore,

--- a/wnfs/src/private/node.rs
+++ b/wnfs/src/private/node.rs
@@ -73,7 +73,7 @@ pub struct RevisionKey(pub Key);
 ///
 /// println!("Header: {:?}", file.header);
 /// ```
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct PrivateNodeHeader {
     /// A unique identifier of the node.
     pub(crate) inumber: INumber,
@@ -604,6 +604,21 @@ impl PrivateNodeHeader {
     pub fn get_saturated_name(&self) -> Namefilter {
         let revision_key = RevisionKey::from(&self.ratchet);
         self.get_saturated_name_with_key(&revision_key.0)
+    }
+}
+
+impl Debug for PrivateNodeHeader {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let mut inumber_str = String::from("0x");
+        for byte in self.inumber {
+            inumber_str.push_str(&format!("{byte:02X}"));
+        }
+
+        f.debug_struct("PrivateRef")
+            .field("inumber", &inumber_str)
+            .field("ratchet", &self.ratchet)
+            .field("bare_name", &self.bare_name)
+            .finish()
     }
 }
 

--- a/wnfs/src/private/privateref.rs
+++ b/wnfs/src/private/privateref.rs
@@ -1,3 +1,5 @@
+use std::fmt::Debug;
+
 use super::{ContentKey, Key, PrivateNodeHeader, RevisionKey};
 use crate::{FsError, HashOutput, Namefilter};
 use anyhow::Result;
@@ -9,7 +11,7 @@ use serde::{de::Error as DeError, ser::Error as SerError, Deserialize, Serialize
 //--------------------------------------------------------------------------------------------------
 
 /// PrivateRef holds the information to fetch associated node from a private forest and decrypt it if it is present.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Clone, PartialEq, Eq)]
 pub struct PrivateRef {
     /// Sha3-256 hash of saturated namefilter.
     pub(crate) saturated_name_hash: HashOutput,
@@ -142,6 +144,21 @@ impl PrivateRef {
     {
         let private_ref = PrivateRefSerializable::deserialize(deserializer)?;
         PrivateRef::from_serializable(private_ref, revision_key).map_err(DeError::custom)
+    }
+}
+
+impl Debug for PrivateRef {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let mut sat_name_hash_str = String::from("0x");
+        for byte in self.saturated_name_hash {
+            sat_name_hash_str.push_str(&format!("{byte:02X}"));
+        }
+
+        f.debug_struct("PrivateRef")
+            .field("saturated_name_hash", &sat_name_hash_str)
+            .field("content_key", &self.content_key.0)
+            .field("revision_key", &self.revision_key.0)
+            .finish()
     }
 }
 


### PR DESCRIPTION
## Summary

<!-- Summary of the PR -->

This PR implements the following **bugs/features**

- [x] Storing dirs in private forest at construction time
- [x] Self lookup of dirs to get the latest revision

<!-- You can skip this if you're fixing a typo or adding an app to the Showcase. -->

Right now because of how PrivateDirectory constructor works, they don't store the dir right after creating. So the initial revision can be lost in that sense. Unlike `mkdir`, `write`methods which store the things you create in the forest during the operation. We are working on fixing that. This PR adds a fix is that puts the directory in the forest right after creating it.

In addition to that, we don't have a way to search_latest on the root directory. This PR adds support for self lookup by supplying an empty path segment to the lookup function.

<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

## Test plan (required)
-  Testing
    
    ```bash
    rs-wnfs test --all
    ```

