### PR TITLE
Fix metadata being passed out to JS as a float instead of a `BigInt`

### DIFF
--- a/wnfs-wasm/src/fs/metadata.rs
+++ b/wnfs-wasm/src/fs/metadata.rs
@@ -18,7 +18,9 @@ impl TryFrom<JsMetadata<'_>> for JsValue {
             Reflect::set(
                 &metadata,
                 &value!("created"),
-                &value!(i64::try_from(*i).map_err(error("Cannot convert created value"))?),
+                &value!(i64::try_from(*i)
+                    .map_err(error("Cannot convert 'created' metadata value"))?
+                    as f64),
             )?;
         }
 
@@ -26,7 +28,9 @@ impl TryFrom<JsMetadata<'_>> for JsValue {
             Reflect::set(
                 &metadata,
                 &value!("modified"),
-                &value!(i64::try_from(*i).map_err(error("Cannot convert modified value"))?),
+                &value!(i64::try_from(*i)
+                    .map_err(error("Cannot convert 'modified' metadata value"))?
+                    as f64),
             )?;
         }
 

--- a/wnfs-wasm/tests/public.spec.ts
+++ b/wnfs-wasm/tests/public.spec.ts
@@ -189,4 +189,31 @@ test.describe("PublicDirectory", () => {
     expect(picturesContent.length).toEqual(0);
     expect(imagesContent[0].name).toEqual("cats");
   });
+
+  test("A PublicDirectory has the correct metadata", async ({ page }) => {
+    const result = await page.evaluate(async () => {
+      const {
+        wnfs: { PublicDirectory },
+      } = await window.setup();
+
+      const time = new Date();
+      return new PublicDirectory(time).metadata();
+    });
+
+    expect(result.created).not.toBeUndefined();
+  });
+
+  test("A PublicFile has the correct metadata", async ({ page }) => {
+    const result = await page.evaluate(async () => {
+      const {
+        wnfs: { PublicFile },
+        mock: { sampleCID }
+      } = await window.setup();
+
+      const time = new Date();
+      return new PublicFile(time, sampleCID).metadata();
+    });
+
+    expect(result.created).not.toBeUndefined();
+  });
 });


### PR DESCRIPTION
## Summary

We used to convert the integers in metadata, which are `i128` internally, into `i64` and then pass that off to `wasm-bindgen`, which turned them into `BigInt`s on the javascript side.

`BigInt`s have poor support in many bundlers and still cause issues occasionally. For some reason it caused the integers to come out as `undefined` on the other end. This PR adds two regression tests that verified this.

This PR instead turns the internal `i128`s into `f64`s before passing them to `wasm-bindgen`, which means they come out as normal JS numbers on the other side.

## Test plan (required)

```
$ cd wnfs-wasm
$ yarn playwright test
```