### PR TITLE
feat(api): adds missing metadata functions for the private side

### DIFF
--- a/wnfs-wasm/src/fs/private/directory.rs
+++ b/wnfs-wasm/src/fs/private/directory.rs
@@ -7,11 +7,8 @@ use js_sys::{Array, Date, Promise, Uint8Array};
 use wasm_bindgen::{prelude::wasm_bindgen, JsValue};
 use wasm_bindgen_futures::future_to_promise;
 use wnfs::{
-    Id,
-    PrivateDirectory as WnfsPrivateDirectory,
-    PrivateNode as WnfsPrivateNode,
-    PrivateOpResult as WnfsPrivateOpResult,
-    HASH_BYTE_SIZE,
+    Id, PrivateDirectory as WnfsPrivateDirectory, PrivateNode as WnfsPrivateNode,
+    PrivateOpResult as WnfsPrivateOpResult, HASH_BYTE_SIZE,
 };
 
 use crate::{

--- a/wnfs-wasm/src/fs/private/directory.rs
+++ b/wnfs-wasm/src/fs/private/directory.rs
@@ -7,12 +7,16 @@ use js_sys::{Array, Date, Promise, Uint8Array};
 use wasm_bindgen::{prelude::wasm_bindgen, JsValue};
 use wasm_bindgen_futures::future_to_promise;
 use wnfs::{
-    Id, PrivateDirectory as WnfsPrivateDirectory, PrivateOpResult as WnfsPrivateOpResult,
+    Id,
+    PrivateDirectory as WnfsPrivateDirectory,
+    PrivateNode as WnfsPrivateNode,
+    PrivateOpResult as WnfsPrivateOpResult,
     HASH_BYTE_SIZE,
 };
 
 use crate::{
     fs::{
+        metadata::JsMetadata,
         utils::{self, error},
         BlockStore, ForeignBlockStore, JsResult, Namefilter, PrivateForest, PrivateNode, Rng,
     },
@@ -385,6 +389,17 @@ impl PrivateDirectory {
                 JsValue::NULL,
             )?)
         }))
+    }
+
+    /// Gets the metadata of the directory
+    pub fn metadata(&self) -> JsResult<JsValue> {
+        JsMetadata(self.0.get_metadata()).try_into()
+    }
+
+    /// Converts directory to a node.
+    #[wasm_bindgen(js_name = "asNode")]
+    pub fn as_node(&self) -> PrivateNode {
+        PrivateNode(WnfsPrivateNode::Dir(Rc::clone(&self.0)))
     }
 
     /// Gets a unique id for node.

--- a/wnfs-wasm/src/fs/private/file.rs
+++ b/wnfs-wasm/src/fs/private/file.rs
@@ -2,6 +2,7 @@
 
 use crate::{
     fs::{
+        metadata::JsMetadata,
         utils::{self, error},
         BlockStore, ForeignBlockStore, JsResult, Namefilter, PrivateForest, Rng,
     },
@@ -86,6 +87,11 @@ impl PrivateFile {
 
             Ok(value!(Uint8Array::from(content.as_slice())))
         }))
+    }
+
+    /// Gets the metadata of this file.
+    pub fn metadata(&self) -> JsResult<JsValue> {
+        JsMetadata(self.0.get_metadata()).try_into()
     }
 
     /// Gets a unique id for node.

--- a/wnfs-wasm/tests/private.spec.ts
+++ b/wnfs-wasm/tests/private.spec.ts
@@ -409,4 +409,32 @@ test.describe("PrivateFile", () => {
     expect(length).toEqual(5);
     expect(type).toEqual("Uint8Array");
   });
+
+  test("A PrivateDirectory has the correct metadata", async ({ page }) => {
+    const result = await page.evaluate(async () => {
+      const {
+        wnfs: { Namefilter, PrivateDirectory },
+        mock: { Rng },
+      } = await window.setup();
+
+      const time = new Date();
+      return new PrivateDirectory(new Namefilter(), time, new Rng()).metadata();
+    });
+
+    expect(result.created).not.toBeUndefined();
+  });
+
+  test("A PrivateFile has the correct metadata", async ({ page }) => {
+    const result = await page.evaluate(async () => {
+      const {
+        wnfs: { Namefilter, PrivateFile },
+        mock: { Rng }
+      } = await window.setup();
+
+      const time = new Date();
+      return new PrivateFile(new Namefilter(), time, new Rng()).metadata();
+    });
+
+    expect(result.created).not.toBeUndefined();
+  });
 });

--- a/wnfs/src/private/file.rs
+++ b/wnfs/src/private/file.rs
@@ -268,6 +268,11 @@ impl PrivateFile {
         })
     }
 
+    /// Gets the metadata of the file
+    pub fn get_metadata(&self) -> &Metadata {
+        &self.metadata
+    }
+
     /// Gets the entire content of a file.
     ///
     /// # Examples


### PR DESCRIPTION
Adds `get_metadata` function to `PrivateFile` in `wnfs` crate and `metadata` function for the private file and directories. Also adds the `as_node` function to the private directories in WASM.