### PR TITLE
refactor: Double random

### DIFF
--- a/wnfs/src/lib.rs
+++ b/wnfs/src/lib.rs
@@ -6,6 +6,7 @@
 //!
 //! This implementation is based off of the [typescript implementation](https://github.com/fission-suite/webnative/tree/matheus23/wnfs2/src/fs).
 //! It exposes an immutable API, extending WNFS immutable nature to the in-memory representation of the file system.
+#![deny(unsafe_code)]
 
 mod common;
 pub mod private;

--- a/wnfs/src/private/node.rs
+++ b/wnfs/src/private/node.rs
@@ -133,13 +133,6 @@ impl PrivateNode {
         }
     }
 
-    pub(crate) fn generate_double_random(rng: &mut impl RngCore) -> (HashOutput, HashOutput) {
-        (
-            crate::utils::get_random_bytes::<HASH_BYTE_SIZE>(rng),
-            crate::utils::get_random_bytes::<HASH_BYTE_SIZE>(rng),
-        )
-    }
-
     /// Updates bare name ancestry of private sub tree.
     #[async_recursion(?Send)]
     pub(crate) async fn update_ancestry(
@@ -532,7 +525,9 @@ impl From<PrivateDirectory> for PrivateNode {
 impl PrivateNodeHeader {
     /// Creates a new PrivateNodeHeader.
     pub(crate) fn new(parent_bare_name: Namefilter, rng: &mut impl RngCore) -> Self {
-        let (inumber, ratchet_seed) = PrivateNode::generate_double_random(rng);
+        let inumber = crate::utils::get_random_bytes::<HASH_BYTE_SIZE>(rng);
+        let ratchet_seed = crate::utils::get_random_bytes::<HASH_BYTE_SIZE>(rng);
+
         Self {
             bare_name: {
                 let mut namefilter = parent_bare_name;
@@ -709,13 +704,6 @@ mod tests {
     use crate::MemoryBlockStore;
 
     use super::*;
-
-    #[async_std::test]
-    async fn generate_double_random_is_ne() {
-        let rng = &mut TestRng::deterministic_rng(RngAlgorithm::ChaCha);
-        let (first, second) = PrivateNode::generate_double_random(rng);
-        assert_ne!(first, second);
-    }
 
     #[async_std::test]
     async fn serialized_private_node_can_be_deserialized() {

--- a/wnfs/src/private/node.rs
+++ b/wnfs/src/private/node.rs
@@ -133,15 +133,11 @@ impl PrivateNode {
         }
     }
 
-    /// Generates two random set of bytes.
     pub(crate) fn generate_double_random(rng: &mut impl RngCore) -> (HashOutput, HashOutput) {
-        const _DOUBLE_SIZE: usize = HASH_BYTE_SIZE * 2;
-        let [first, second] = unsafe {
-            std::mem::transmute::<[u8; _DOUBLE_SIZE], [[u8; HASH_BYTE_SIZE]; 2]>(
-                utils::get_random_bytes::<_DOUBLE_SIZE>(rng),
-            )
-        };
-        (first, second)
+        (
+            crate::utils::get_random_bytes::<HASH_BYTE_SIZE>(rng),
+            crate::utils::get_random_bytes::<HASH_BYTE_SIZE>(rng),
+        )
     }
 
     /// Updates bare name ancestry of private sub tree.
@@ -713,6 +709,13 @@ mod tests {
     use crate::MemoryBlockStore;
 
     use super::*;
+
+    #[async_std::test]
+    async fn generate_double_random_is_ne() {
+        let rng = &mut TestRng::deterministic_rng(RngAlgorithm::ChaCha);
+        let (first, second) = PrivateNode::generate_double_random(rng);
+        assert_ne!(first, second);
+    }
 
     #[async_std::test]
     async fn serialized_private_node_can_be_deserialized() {


### PR DESCRIPTION
## Summary

Re-factors double_Random and adds `#![deny(unsafe_code)]`

The old one used [transmute](https://doc.rust-lang.org/stable/std/mem/fn.transmute.html)

## Test plan (required)

I benched with two Rng's just in case and it's ~same and added a test

I even implemented the stdlib safer version (with little unsafe) for comparison in case it is still needed for some reason

https://github.com/pinkforest/double-random