### PR TITLE
chore: use `#!/usr/bin/env bash` instead of `#!/bin/bash`

### DIFF
--- a/scripts/rs-wnfs.sh
+++ b/scripts/rs-wnfs.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 # PATHS


### PR DESCRIPTION
This basically fixes the script for me in NixOS, where there's no such file `/bin/bash`. 
This should work on Mac, too.

`/usr/bin/env <name>` just searches for `<name>` in your `$PATH` and executes that.