### PR TITLE
chore: Allow clippy versions <1.67

### DIFF
--- a/clippy.toml
+++ b/clippy.toml
@@ -1,2 +1,1 @@
 cognitive-complexity-threshold = 10
-ignore-interior-mutability = ["bytes::Bytes", "wnfs::private::encrypted::Encrypted"]

--- a/wnfs/src/private/node.rs
+++ b/wnfs/src/private/node.rs
@@ -233,6 +233,7 @@ impl PrivateNode {
     /// The previous links is `None`, it doesn't have previous Cids.
     /// The node is malformed if the previous links are `Some`, but
     /// the `BTreeSet` inside is empty.
+    #[allow(clippy::mutable_key_type)]
     pub fn get_previous(&self) -> &BTreeSet<(usize, Encrypted<Cid>)> {
         match self {
             Self::File(file) => &file.content.previous,

--- a/wnfs/src/private/previous.rs
+++ b/wnfs/src/private/previous.rs
@@ -82,6 +82,7 @@ impl PrivateNodeHistory {
     /// Create a history iterator for a node given its header.
     ///
     /// See also `PrivateNodeHistory::of`.
+    #[allow(clippy::mutable_key_type)]
     pub fn from_header(
         header: PrivateNodeHeader,
         previous: BTreeSet<(usize, Encrypted<Cid>)>,


### PR DESCRIPTION
We previously used a feature (The `ignore-interior-mutability` clippy configuration) that was introduced in clippy 1.67: https://github.com/rust-lang/rust-clippy/blob/master/CHANGELOG.md#enhancements

This PR stops using that configuration and instead just ignores the warning at every use site.