### PR TITLE
feat(api): add privateforest merge and diff bindings

### DIFF
--- a/wnfs-wasm/src/fs/private/forest.rs
+++ b/wnfs-wasm/src/fs/private/forest.rs
@@ -1,23 +1,14 @@
-use std::rc::Rc;
-use js_sys::Promise;
-use wasm_bindgen::{prelude::wasm_bindgen, JsValue};
-use wasm_bindgen_futures::future_to_promise;
-use wnfs::{
-    libipld::Cid,
-    private::{
-        AesKey, PrivateForest as WnfsPrivateForest, PrivateRef as WnfsPrivateRef, TemporalKey,
-        KEY_BYTE_SIZE,
-    },
-    HASH_BYTE_SIZE,
-};
 use crate::{
-    fs::{
-        utils::{self, error},
-        BlockStore, ForeignBlockStore, JsResult, Rng,
-    },
+    fs::{utils::error, BlockStore, ForeignBlockStore, ForestChange, JsResult},
     value,
 };
-use super::PrivateNode;
+use js_sys::{Array, Promise, Uint8Array};
+use std::rc::Rc;
+use wasm_bindgen::prelude::wasm_bindgen;
+use wasm_bindgen_futures::future_to_promise;
+use wnfs::{
+    libipld::Cid, private::PrivateForest as WnfsPrivateForest, BlockStore as WnfsBlockStore,
+};
 
 //--------------------------------------------------------------------------------------------------
 // Type Definitions

--- a/wnfs-wasm/tests/private.spec.ts
+++ b/wnfs-wasm/tests/private.spec.ts
@@ -471,7 +471,7 @@ test.describe("PrivateForest", () => {
     const [metadataBefore, metadataAfter] = await page.evaluate(async () => {
       const {
         wnfs: { Namefilter, PrivateFile, PrivateNode, PrivateForest },
-        mock: { MemoryBlockStore, Rng }
+        mock: { MemoryBlockStore, Rng },
       } = await window.setup();
 
       const rng = new Rng();
@@ -510,8 +510,8 @@ test.describe("PrivateForest", () => {
       const file = new PrivateFile(new Namefilter(), time, rng).asNode();
       const dir = new PrivateDirectory(new Namefilter(), time, rng).asNode();
 
-      var [_, mainForest] = await mainForest.put(file, store, rng);
-      var [_, otherForest] = await otherForest.put(dir, store, rng);
+      var [_, mainForest] = await file.store(mainForest, store, rng);
+      var [_, otherForest] = await dir.store(otherForest, store, rng);
 
       const diff = await mainForest.diff(otherForest, store);
 
@@ -526,7 +526,7 @@ test.describe("PrivateForest", () => {
   test("merge combines changes in forests", async ({ page }) => {
     const result = await page.evaluate(async () => {
       const {
-        wnfs: { Namefilter, PrivateFile, PrivateDirectory, PrivateForest },
+        wnfs: { Namefilter, PrivateFile, PrivateDirectory, PrivateForest, PrivateNode },
         mock: { MemoryBlockStore, Rng },
       } = await window.setup();
 
@@ -540,12 +540,12 @@ test.describe("PrivateForest", () => {
       const file = new PrivateFile(new Namefilter(), time, rng).asNode();
       const dir = new PrivateDirectory(new Namefilter(), time, rng).asNode();
 
-      var [_, mainForest] = await mainForest.put(file, store, rng);
-      var [privateRef, otherForest] = await otherForest.put(dir, store, rng);
+      var [_, mainForest] = await file.store(mainForest, store, rng);
+      var [privateRef, otherForest] = await dir.store(otherForest, store, rng);
 
       const mergeForest = await mainForest.merge(otherForest, store);
 
-      return mergeForest.get(privateRef, store);
+      return await PrivateNode.load(privateRef, mergeForest, store);
     });
 
     expect(result).toBeDefined();

--- a/wnfs/src/private/forest.rs
+++ b/wnfs/src/private/forest.rs
@@ -228,7 +228,7 @@ where
     ///     );
     /// }
     /// ```
-    pub async fn merge<B: BlockStore>(&self, other: &Self, store: &mut B) -> Result<Self> {
+    pub async fn merge(&self, other: &Self, store: &mut impl BlockStore) -> Result<Self> {
         let merge_node = hamt::merge(
             Link::from(Rc::clone(&self.root)),
             Link::from(Rc::clone(&other.root)),


### PR DESCRIPTION
## Summary

This PR exposes the hamt merge and diff bindings

## Test plan (required)
-  Testing
    
    ```bash
    scripts/rs-wnfs.sh test --wasm
    ```

Fixes #169 