### PR TITLE
chore: Redundant futures-util manifest

### DIFF
--- a/wnfs-common/Cargo.toml
+++ b/wnfs-common/Cargo.toml
@@ -22,7 +22,6 @@ async-once-cell = "0.4"
 async-trait = "0.1"
 chrono = { version = "0.4.23", default-features = false, features = ["clock", "std"] }
 futures = "0.3"
-futures-util = "0.3"
 libipld = { version = "0.16", features = ["dag-cbor", "derive", "serde-codec"] }
 log = "0.4"
 multihash = "0.18"

--- a/wnfs-hamt/Cargo.toml
+++ b/wnfs-hamt/Cargo.toml
@@ -25,7 +25,6 @@ bitvec = { version = "1.0", features = ["serde"] }
 chrono = { version = "0.4.23", default-features = false, features = ["clock", "std"] }
 either = "1.8"
 futures = "0.3"
-futures-util = "0.3"
 libipld = { version = "0.16", features = ["dag-cbor", "derive", "serde-codec"] }
 log = "0.4"
 multihash = "0.18"

--- a/wnfs-namefilter/Cargo.toml
+++ b/wnfs-namefilter/Cargo.toml
@@ -23,7 +23,6 @@ async-trait = "0.1"
 bitvec = { version = "1.0", features = ["serde"] }
 chrono = { version = "0.4.23", default-features = false, features = ["clock", "std"] }
 futures = "0.3"
-futures-util = "0.3"
 libipld = { version = "0.16", features = ["dag-cbor", "derive", "serde-codec"] }
 multihash = "0.18"
 proptest = { version = "1.1", optional = true }

--- a/wnfs/Cargo.toml
+++ b/wnfs/Cargo.toml
@@ -28,7 +28,6 @@ bitvec = { version = "1.0", features = ["serde"] }
 chrono = { version = "0.4.23", default-features = false, features = ["clock", "std"] }
 either = "1.8"
 futures = "0.3"
-futures-util = "0.3"
 libipld = { version = "0.16", features = ["dag-cbor", "derive", "serde-codec"] }
 log = "0.4"
 multihash = "0.18"


### PR DESCRIPTION
futures-util already comes via futures and it's not used directly so can be cleaned up