### PR TITLE
feat: Redundant sha2

### DIFF
--- a/wnfs-common/Cargo.toml
+++ b/wnfs-common/Cargo.toml
@@ -30,8 +30,6 @@ once_cell = "1.16"
 proptest = { version = "1.1", optional = true }
 rand_core = "0.6"
 serde = { version = "1.0", features = ["rc"] }
-sha2 = "0.10"
-sha3 = "0.10"
 thiserror = "1.0"
 
 [dev-dependencies]

--- a/wnfs-hamt/Cargo.toml
+++ b/wnfs-hamt/Cargo.toml
@@ -34,7 +34,6 @@ proptest = { version = "1.1", optional = true }
 rand_core = "0.6"
 semver = { version = "1.0", features = ["serde"] }
 serde = { version = "1.0", features = ["rc"] }
-sha2 = "0.10"
 sha3 = "0.10"
 thiserror = "1.0"
 wnfs-common = { path = "../wnfs-common" }

--- a/wnfs-namefilter/Cargo.toml
+++ b/wnfs-namefilter/Cargo.toml
@@ -29,7 +29,6 @@ multihash = "0.18"
 proptest = { version = "1.1", optional = true }
 rand_core = "0.6"
 serde = { version = "1.0", features = ["rc"] }
-sha2 = "0.10"
 sha3 = "0.10"
 thiserror = "1.0"
 wnfs-common = { path = "../wnfs-common" }

--- a/wnfs/Cargo.toml
+++ b/wnfs/Cargo.toml
@@ -38,7 +38,6 @@ rand_core = "0.6"
 rsa = "0.7"
 semver = { version = "1.0", features = ["serde"] }
 serde = { version = "1.0", features = ["rc"] }
-sha2 = "0.10"
 sha3 = "0.10"
 skip_ratchet = { version = "0.1", features = ["serde"] }
 thiserror = "1.0"
@@ -53,6 +52,7 @@ env_logger = "0.10"
 proptest = "1.1"
 rand = "0.8"
 rsa = "0.7"
+sha2 = "0.10"
 test-log = "0.2"
 test-strategy = "0.3"
 tokio = { version = "1.0", features = ["full"] }


### PR DESCRIPTION
sha2 is only used in a test so can be in dev-dependencies, sha3 also can be concentrated in the manifests