### PR TITLE
chore: Redundant rsa

### DIFF
--- a/wnfs/Cargo.toml
+++ b/wnfs/Cargo.toml
@@ -35,7 +35,6 @@ multihash = "0.18"
 once_cell = "1.16"
 proptest = { version = "1.1", optional = true }
 rand_core = "0.6"
-rsa = "0.7"
 semver = { version = "1.0", features = ["serde"] }
 serde = { version = "1.0", features = ["rc"] }
 sha2 = "0.10"


### PR DESCRIPTION
This was already in `dev-dependencies` as it's only used for testing