### PR TITLE
fix: `find_latest_share_counter` finds the last share count

### DIFF
--- a/wnfs-wasm/src/fs/private/share.rs
+++ b/wnfs-wasm/src/fs/private/share.rs
@@ -110,7 +110,7 @@ pub fn create_share_label(
     ))
 }
 
-#[wasm_bindgen(js_name = "findShare")]
+#[wasm_bindgen(js_name = "findLatestShareCounter")]
 pub fn find_latest_share_counter(
     share_count: u32,
     limit: u32,

--- a/wnfs-wasm/src/fs/private/share.rs
+++ b/wnfs-wasm/src/fs/private/share.rs
@@ -111,7 +111,7 @@ pub fn create_share_label(
 }
 
 #[wasm_bindgen(js_name = "findShare")]
-pub fn find_share(
+pub fn find_latest_share_counter(
     share_count: u32,
     limit: u32,
     recipient_exchange_key: Vec<u8>,
@@ -123,7 +123,7 @@ pub fn find_share(
     let sharer_forest = Rc::clone(&sharer_forest.0);
 
     Ok(future_to_promise(async move {
-        let count = recipient::find_share(
+        let count = recipient::find_latest_share_counter(
             share_count.into(),
             limit.into(),
             &recipient_exchange_key,

--- a/wnfs-wasm/tests/server/index.d.ts
+++ b/wnfs-wasm/tests/server/index.d.ts
@@ -25,7 +25,7 @@ declare global {
         Namefilter: typeof import("../../pkg/index").Namefilter;
         SharePayload: typeof import("../../pkg/index").SharePayload;
         share: typeof import("../../pkg/index").share;
-        findShare: typeof import("../../pkg/index").findShare;
+        findLatestShareCounter: typeof import("../../pkg/index").findLatestShareCounter;
         receiveShare: typeof import("../../pkg/index").receiveShare;
         createShareLabel: typeof import("../../pkg/index").createShareLabel;
       };

--- a/wnfs-wasm/tests/server/index.ts
+++ b/wnfs-wasm/tests/server/index.ts
@@ -27,7 +27,7 @@ const setup = async () => {
     share,
     createShareLabel,
     receiveShare,
-    findShare,
+    findLatestShareCounter,
   } = await import("../../pkg/index");
 
   const mock = {
@@ -55,7 +55,7 @@ const setup = async () => {
     share,
     createShareLabel,
     receiveShare,
-    findShare,
+    findLatestShareCounter,
   };
 
   return { mock, wnfs, setPanicHook };

--- a/wnfs/src/private/share.rs
+++ b/wnfs/src/private/share.rs
@@ -326,9 +326,7 @@ pub mod recipient {
         sharer_forest: &PrivateForest,
         store: &impl BlockStore,
     ) -> Result<Option<u64>> {
-        for i in 0..limit {
-            let share_count = share_count_start + i;
-
+        for share_count in share_count_start..share_count_start + limit {
             let share_label =
                 sharer::create_share_label(share_count, sharer_root_did, recipient_exchange_key);
 
@@ -336,8 +334,8 @@ pub mod recipient {
                 .has(&Sha3_256::hash(&share_label), store)
                 .await?
             {
-                if i == 0 {
-                    // There don't seem to be any shares yet
+                if share_count == share_count_start {
+                    // There don't seem to be any shares
                     return Ok(None);
                 } else {
                     // We've hit the first unpopulated label,

--- a/wnfs/src/private/share.rs
+++ b/wnfs/src/private/share.rs
@@ -317,9 +317,9 @@ pub mod recipient {
     use wnfs_hamt::Hasher;
     use wnfs_namefilter::Namefilter;
 
-    /// Checks if a share count is available.
-    pub async fn find_share(
-        share_count: u64,
+    /// Seeks to the latest share counter that is populated.
+    pub async fn find_latest_share_counter(
+        share_count_start: u64,
         limit: u64,
         recipient_exchange_key: &[u8],
         sharer_root_did: &str,
@@ -327,21 +327,28 @@ pub mod recipient {
         store: &impl BlockStore,
     ) -> Result<Option<u64>> {
         for i in 0..limit {
-            let share_label = sharer::create_share_label(
-                share_count + i,
-                sharer_root_did,
-                recipient_exchange_key,
-            );
+            let share_count = share_count_start + i;
 
-            if sharer_forest
+            let share_label =
+                sharer::create_share_label(share_count, sharer_root_did, recipient_exchange_key);
+
+            if !sharer_forest
                 .has(&Sha3_256::hash(&share_label), store)
                 .await?
             {
-                return Ok(Some(share_count + i));
+                if i == 0 {
+                    // There don't seem to be any shares yet
+                    return Ok(None);
+                } else {
+                    // We've hit the first unpopulated label,
+                    // so the last one was the last valid share counter.
+                    return Ok(Some(share_count - 1));
+                }
             }
         }
 
-        Ok(None)
+        // We've exhausted the limit, this seems to be the last valid share count under the limit
+        Ok(Some(share_count_start + limit - 1))
     }
 
     /// Lets a recipient receive a share from a sharer using the sharer's forest and store.
@@ -388,16 +395,19 @@ pub mod recipient {
 
 #[cfg(test)]
 mod tests {
-    use super::{recipient, sharer, Recipient, Share, SharePayload, Sharer};
+    use super::{
+        recipient::{self, find_latest_share_counter},
+        sharer, Recipient, Share, SharePayload, Sharer, EXCHANGE_KEY_NAME,
+    };
     use crate::{
         private::{PrivateDirectory, PrivateForest, PrivateOpResult, RsaPublicKey},
         public::PublicLink,
-        PublicNode,
+        PublicNode, PublicOpResult,
     };
     use chrono::Utc;
     use proptest::test_runner::{RngAlgorithm, TestRng};
     use std::rc::Rc;
-    use wnfs_common::{dagcbor, MemoryBlockStore};
+    use wnfs_common::{dagcbor, BlockStore, MemoryBlockStore};
 
     mod helper {
         use crate::{
@@ -548,10 +558,104 @@ mod tests {
 
         let serialized = dagcbor::encode(&payload).unwrap();
 
-        assert!(serialized.len() < 190);
+        // Must be smaller than 190 bytes to fit within RSAES-OAEP limits
+        assert!(serialized.len() <= 190);
 
         let deserialized: SharePayload = dagcbor::decode(&serialized).unwrap();
 
         assert_eq!(payload, deserialized);
+    }
+
+    #[async_std::test]
+    async fn find_latest_share_counter_finds_highest_count() {
+        let sharer_store = &mut MemoryBlockStore::default();
+        let recipient_store = &mut MemoryBlockStore::default();
+        let forest = &mut Rc::new(PrivateForest::new());
+        let rng = &mut TestRng::deterministic_rng(RngAlgorithm::ChaCha);
+
+        let sharer_root_did = "did:key:z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK";
+
+        // Establish recipient exchange root.
+        let (_, recipient_exchange_root) = helper::create_recipient_exchange_root(recipient_store)
+            .await
+            .unwrap();
+
+        // Get exchange public key
+        let PublicOpResult {
+            result: recipient_exchange_key_cid,
+            ..
+        } = Rc::clone(&recipient_exchange_root)
+            .read(
+                &["device1".into(), EXCHANGE_KEY_NAME.into()],
+                recipient_store,
+            )
+            .await
+            .unwrap();
+
+        let recipient_exchange_key = recipient_store
+            .get_block(&recipient_exchange_key_cid)
+            .await
+            .unwrap();
+
+        // Test finding latest share before having shared
+        let max_share_count_before = find_latest_share_counter(
+            0,
+            100,
+            recipient_exchange_key.as_ref(),
+            sharer_root_did,
+            forest,
+            sharer_store,
+        )
+        .await
+        .unwrap();
+
+        // We expect no shares to be found at all without sharing
+        assert_eq!(max_share_count_before, None);
+
+        // Create something to share access to.
+        let PrivateOpResult { root_dir, .. } = PrivateDirectory::new_and_store(
+            Default::default(),
+            Utc::now(),
+            forest,
+            sharer_store,
+            rng,
+        )
+        .await
+        .unwrap();
+
+        // Create the share
+        let payload = SharePayload::from_node(&root_dir.as_node(), true, forest, sharer_store, rng)
+            .await
+            .unwrap();
+
+        let expected_max_share_count = 5;
+
+        for i in 0..=expected_max_share_count {
+            sharer::share::<RsaPublicKey>(
+                &payload,
+                i,
+                sharer_root_did,
+                forest,
+                sharer_store,
+                PublicLink::with_dir(Rc::clone(&recipient_exchange_root)),
+                recipient_store,
+            )
+            .await
+            .unwrap();
+        }
+
+        let max_share_count = find_latest_share_counter(
+            0,
+            100,
+            recipient_exchange_key.as_ref(),
+            sharer_root_did,
+            forest,
+            sharer_store,
+        )
+        .await
+        .unwrap();
+
+        // We expect the count to be the latest share
+        assert_eq!(max_share_count, Some(expected_max_share_count));
     }
 }


### PR DESCRIPTION
## Summary

Fixes #196 

The idea is to provide a function that finds the maximum share count for available shares. This allows callers to check all share counts they might have missed in between.

## Test plan (required)

I added another test that checks after a bunch of shares that the maximum share counter is returned.

