### PR TITLE
refactor(api): refactor out PrivateOpResult 

### DIFF
--- a/wnfs-common/src/link.rs
+++ b/wnfs-common/src/link.rs
@@ -81,7 +81,7 @@ impl<T: RemembersCid> Link<T> {
     /// Gets mut value stored in link. It attempts to get it from the store if it is not present in link.
     pub async fn resolve_value_mut(&mut self, store: &(impl BlockStore + ?Sized)) -> Result<&mut T>
     where
-        T: DeserializeOwned, // + Clone,
+        T: DeserializeOwned,
     {
         match self {
             Self::Encoded { cid, value_cache } => {
@@ -125,14 +125,11 @@ impl<T: RemembersCid> Link<T> {
         T: DeserializeOwned,
     {
         match self {
-            Self::Encoded {
-                ref cid,
-                value_cache,
-            } => match value_cache.into_inner() {
+            Self::Encoded { cid, value_cache } => match value_cache.into_inner() {
                 Some(cached) => Ok(cached),
                 None => {
-                    let value: T = store.get_deserializable(cid).await?;
-                    value.persisted_as().get_or_init(async { *cid }).await;
+                    let value: T = store.get_deserializable(&cid).await?;
+                    value.persisted_as().get_or_init(async { cid }).await;
                     Ok(value)
                 }
             },

--- a/wnfs/README.md
+++ b/wnfs/README.md
@@ -44,22 +44,20 @@ WNFS does not have an opinion on where you want to persist your content or the f
 Let's see an example of working with a public directory. Here we are going to use the memory-based blockstore provided by the library.
 
 ```rust
-use wnfs::{MemoryBlockStore, PublicDirectory, PublicOpResult};
-
+use wnfs::{MemoryBlockStore, PublicDirectory};
 use chrono::Utc;
-
 use std::rc::Rc;
 
 #[async_std::main]
 async fn main() {
     // Create a new public directory.
-    let dir = Rc::new(PublicDirectory::new(Utc::now()));
+    let dir = &mut Rc::new(PublicDirectory::new(Utc::now()));
 
     // Create a memory-based blockstore.
     let store = &mut MemoryBlockStore::default();
 
     // Add a /pictures/cats subdirectory.
-    let PublicOpResult { root_dir, .. } = dir
+    dir
         .mkdir(&["pictures".into(), "cats".into()], Utc::now(), store)
         .await
         .unwrap();
@@ -78,12 +76,10 @@ The private filesystem, on the other hand, is a bit more involved. [Hash Array M
 
 ```rust
 use wnfs::{
-    private::PrivateForest, MemoryBlockStore, Namefilter, PrivateDirectory, PrivateOpResult,
+    private::PrivateForest, MemoryBlockStore, Namefilter, PrivateDirectory,
 };
-
 use chrono::Utc;
 use rand::thread_rng;
-
 use std::rc::Rc;
 
 #[async_std::main]
@@ -94,18 +90,18 @@ async fn main() {
     // A random number generator the private filesystem can use.
     let rng = &mut thread_rng();
 
-    // Create private forest.
-    let forest = Rc::new(PrivateForest::new());
+    // Create a private forest.
+    let forest = &mut Rc::new(PrivateForest::new());
 
     // Create a new private directory.
-    let dir = Rc::new(PrivateDirectory::new(
+    let dir = &mut Rc::new(PrivateDirectory::new(
         Namefilter::default(),
         Utc::now(),
         rng,
     ));
 
     // Add a file to /pictures/cats directory.
-    let PrivateOpResult { root_dir, forest, .. } = dir
+    dir
         .mkdir(
             &["pictures".into(), "cats".into()],
             true,
@@ -118,7 +114,7 @@ async fn main() {
         .unwrap();
 
     // Add a file to /pictures/dogs/billie.jpg file.
-    let PrivateOpResult { root_dir, forest, .. } = root_dir
+    dir
         .write(
             &["pictures".into(), "dogs".into(), "billie.jpeg".into()],
             true,
@@ -132,7 +128,7 @@ async fn main() {
         .unwrap();
 
     // List all files in /pictures directory.
-    let PrivateOpResult { result, .. } = root_dir
+    let result = dir
         .ls(&["pictures".into()], true, forest, store)
         .await
         .unwrap();

--- a/wnfs/examples/private.rs
+++ b/wnfs/examples/private.rs
@@ -5,7 +5,7 @@ use chrono::Utc;
 use libipld::Cid;
 use rand::{thread_rng, RngCore};
 use std::rc::Rc;
-use wnfs::private::{PrivateDirectory, PrivateForest, PrivateNode, PrivateOpResult, PrivateRef};
+use wnfs::private::{PrivateDirectory, PrivateForest, PrivateNode, PrivateRef};
 use wnfs_common::{BlockStore, MemoryBlockStore};
 use wnfs_namefilter::Namefilter;
 
@@ -43,27 +43,26 @@ async fn get_forest_cid_and_private_ref(
     let forest = &mut Rc::new(PrivateForest::new());
 
     // Create a new directory.
-    let dir = Rc::new(PrivateDirectory::new(
+    let dir = &mut Rc::new(PrivateDirectory::new(
         Namefilter::default(),
         Utc::now(),
         rng,
     ));
 
     // Add a /pictures/cats subdirectory.
-    let PrivateOpResult { root_dir, .. } = dir
-        .mkdir(
-            &["pictures".into(), "cats".into()],
-            true,
-            Utc::now(),
-            forest,
-            store,
-            rng,
-        )
-        .await
-        .unwrap();
+    dir.mkdir(
+        &["pictures".into(), "cats".into()],
+        true,
+        Utc::now(),
+        forest,
+        store,
+        rng,
+    )
+    .await
+    .unwrap();
 
     // Private ref contains data and keys for fetching and decrypting the directory node in the private forest.
-    let private_ref = root_dir.store(forest, store, rng).await.unwrap();
+    let private_ref = dir.store(forest, store, rng).await.unwrap();
 
     // Persist encoded private forest to the block store.
     let forest_cid = store.put_async_serializable(forest).await.unwrap();

--- a/wnfs/examples/privateref.rs
+++ b/wnfs/examples/privateref.rs
@@ -3,7 +3,7 @@ use futures::StreamExt;
 use rand::thread_rng;
 use sha3::Sha3_256;
 use std::rc::Rc;
-use wnfs::private::{AesKey, PrivateDirectory, PrivateForest, PrivateOpResult, RevisionRef};
+use wnfs::private::{AesKey, PrivateDirectory, PrivateForest, RevisionRef};
 use wnfs_common::{dagcbor, utils, MemoryBlockStore};
 use wnfs_hamt::Hasher;
 use wnfs_namefilter::Namefilter;
@@ -28,7 +28,7 @@ async fn main() -> anyhow::Result<()> {
     let inumber = utils::get_random_bytes::<32>(rng); // Needs to be random
 
     // Create a root directory from the ratchet_seed, inumber and namefilter. Directory gets saved in forest.
-    let PrivateOpResult { root_dir, .. } = PrivateDirectory::new_with_seed_and_store(
+    let root_dir = &mut PrivateDirectory::new_with_seed_and_store(
         Namefilter::default(),
         Utc::now(),
         ratchet_seed,
@@ -43,7 +43,7 @@ async fn main() -> anyhow::Result<()> {
     // ----------- Create a subdirectory -----------
 
     // Add a /movies/anime to the directory.
-    let PrivateOpResult { root_dir, .. } = root_dir
+    root_dir
         .mkdir(
             &["movies".into(), "anime".into()],
             true,

--- a/wnfs/src/lib.rs
+++ b/wnfs/src/lib.rs
@@ -27,3 +27,14 @@ pub mod hamt {
 pub mod namefilter {
     pub use wnfs_namefilter::*;
 }
+
+//--------------------------------------------------------------------------------------------------
+// Types
+//--------------------------------------------------------------------------------------------------
+
+/// The result of an basic get operation.
+pub(crate) enum SearchResult<T> {
+    Missing(T, usize),
+    NotADir(T, usize),
+    Found(T),
+}

--- a/wnfs/src/private/directory.rs
+++ b/wnfs/src/private/directory.rs
@@ -261,7 +261,7 @@ impl PrivateDirectory {
     /// use rand::thread_rng;
     ///
     /// use wnfs::{
-    ///     private::{PrivateForest, PrivateRef, PrivateDirectory, PrivateOpResult},
+    ///     private::{PrivateForest, PrivateRef, PrivateDirectory},
     ///     common::{BlockStore, MemoryBlockStore},
     ///     namefilter::Namefilter,
     /// };
@@ -271,14 +271,13 @@ impl PrivateDirectory {
     ///     let store = &mut MemoryBlockStore::default();
     ///     let rng = &mut thread_rng();
     ///     let forest = &mut Rc::new(PrivateForest::new());
-    ///
-    ///     let dir = Rc::new(PrivateDirectory::new(
+    ///     let root_dir = &mut Rc::new(PrivateDirectory::new(
     ///         Namefilter::default(),
     ///         Utc::now(),
     ///         rng,
     ///     ));
     ///
-    ///     let PrivateOpResult { root_dir, .. } = dir
+    ///     root_dir
     ///         .mkdir(&["pictures".into(), "cats".into()], true, Utc::now(), forest, store, rng)
     ///         .await
     ///         .unwrap();
@@ -494,7 +493,7 @@ impl PrivateDirectory {
     /// use rand::thread_rng;
     ///
     /// use wnfs::{
-    ///     private::{PrivateForest, PrivateRef, PrivateDirectory, PrivateOpResult},
+    ///     private::{PrivateForest, PrivateRef, PrivateDirectory},
     ///     common::{BlockStore, MemoryBlockStore},
     ///     namefilter::Namefilter,
     /// };
@@ -504,19 +503,18 @@ impl PrivateDirectory {
     ///     let store = &mut MemoryBlockStore::default();
     ///     let rng = &mut thread_rng();
     ///     let forest = &mut Rc::new(PrivateForest::new());
-    ///
-    ///     let dir = Rc::new(PrivateDirectory::new(
+    ///     let root_dir = &mut Rc::new(PrivateDirectory::new(
     ///         Namefilter::default(),
     ///         Utc::now(),
     ///         rng,
     ///     ));
     ///
-    ///     let PrivateOpResult { root_dir, .. } = dir
+    ///     root_dir
     ///         .mkdir(&["pictures".into(), "cats".into()], true, Utc::now(), forest, store, rng)
     ///         .await
     ///         .unwrap();
     ///
-    ///     let PrivateOpResult { result, .. } = root_dir
+    ///     let result = root_dir
     ///         .get_node(&["pictures".into(), "cats".into()], true, forest, store)
     ///         .await
     ///         .unwrap();
@@ -553,7 +551,7 @@ impl PrivateDirectory {
     /// use rand::thread_rng;
     ///
     /// use wnfs::{
-    ///     private::{PrivateForest, PrivateRef, PrivateDirectory, PrivateOpResult},
+    ///     private::{PrivateForest, PrivateRef, PrivateDirectory},
     ///     common::{BlockStore, MemoryBlockStore},
     ///     namefilter::Namefilter,
     /// };
@@ -563,8 +561,7 @@ impl PrivateDirectory {
     ///     let store = &mut MemoryBlockStore::default();
     ///     let rng = &mut thread_rng();
     ///     let forest = &mut Rc::new(PrivateForest::new());
-    ///
-    ///     let dir = Rc::new(PrivateDirectory::new(
+    ///     let root_dir = &mut Rc::new(PrivateDirectory::new(
     ///         Namefilter::default(),
     ///         Utc::now(),
     ///         rng,
@@ -572,7 +569,7 @@ impl PrivateDirectory {
     ///
     ///     let content = b"print('hello world')";
     ///
-    ///     let PrivateOpResult { root_dir, .. } = dir
+    ///     root_dir
     ///         .write(
     ///             &["code".into(), "hello.py".into()],
     ///             true,
@@ -585,7 +582,7 @@ impl PrivateDirectory {
     ///         .await
     ///         .unwrap();
     ///
-    ///     let PrivateOpResult { result, .. } = root_dir
+    ///     let result = root_dir
     ///         .read(&["code".into(), "hello.py".into()], true, forest, store)
     ///         .await
     ///         .unwrap();
@@ -639,7 +636,7 @@ impl PrivateDirectory {
     /// use chrono::Utc;
     /// use rand::thread_rng;
     /// use wnfs::{
-    ///     private::{PrivateForest, PrivateRef, PrivateDirectory, PrivateOpResult},
+    ///     private::{PrivateForest, PrivateRef, PrivateDirectory},
     ///     common::{BlockStore, MemoryBlockStore},
     ///     namefilter::Namefilter,
     /// };
@@ -649,8 +646,7 @@ impl PrivateDirectory {
     ///     let store = &mut MemoryBlockStore::default();
     ///     let rng = &mut thread_rng();
     ///     let forest = &mut Rc::new(PrivateForest::new());
-    ///
-    ///     let dir = Rc::new(PrivateDirectory::new(
+    ///     let root_dir = &mut Rc::new(PrivateDirectory::new(
     ///         Namefilter::default(),
     ///         Utc::now(),
     ///         rng,
@@ -658,7 +654,7 @@ impl PrivateDirectory {
     ///
     ///     let content = b"print('hello world')";
     ///
-    ///     let PrivateOpResult { root_dir, .. } = dir
+    ///     root_dir
     ///         .write(
     ///             &["code".into(), "hello.py".into()],
     ///             true,
@@ -671,7 +667,7 @@ impl PrivateDirectory {
     ///         .await
     ///         .unwrap();
     ///
-    ///     let PrivateOpResult { result, .. } = root_dir
+    ///     let result = root_dir
     ///         .read(&["code".into(), "hello.py".into()], true, forest, store)
     ///         .await
     ///         .unwrap();
@@ -749,7 +745,7 @@ impl PrivateDirectory {
     /// use chrono::Utc;
     /// use rand::thread_rng;
     /// use wnfs::{
-    ///     private::{PrivateForest, PrivateRef, PrivateNode, PrivateDirectory, PrivateOpResult},
+    ///     private::{PrivateForest, PrivateRef, PrivateNode, PrivateDirectory},
     ///     common::{BlockStore, MemoryBlockStore},
     ///     namefilter::Namefilter,
     /// };
@@ -759,8 +755,7 @@ impl PrivateDirectory {
     ///     let store = &mut MemoryBlockStore::default();
     ///     let rng = &mut thread_rng();
     ///     let forest = &mut Rc::new(PrivateForest::new());
-    ///
-    ///     let PrivateOpResult { root_dir: init_dir, .. } = PrivateDirectory::new_and_store(
+    ///     let mut init_dir = PrivateDirectory::new_and_store(
     ///         Default::default(),
     ///         Utc::now(),
     ///         forest,
@@ -768,12 +763,14 @@ impl PrivateDirectory {
     ///         rng
     ///     ).await.unwrap();
     ///
-    ///     let PrivateOpResult { root_dir, .. } = Rc::clone(&init_dir)
+    ///     let dir_clone = &mut Rc::clone(&init_dir);
+    ///
+    ///     dir_clone
     ///         .mkdir(&["pictures".into(), "cats".into()], true, Utc::now(), forest, store, rng)
     ///         .await
     ///         .unwrap();
     ///
-    ///     root_dir.store(forest, store, rng).await.unwrap();
+    ///     dir_clone.store(forest, store, rng).await.unwrap();
     ///
     ///     let latest_dir = init_dir.search_latest(forest, store).await.unwrap();
     ///
@@ -808,7 +805,7 @@ impl PrivateDirectory {
     /// use rand::thread_rng;
     ///
     /// use wnfs::{
-    ///     private::{PrivateForest, PrivateRef, PrivateDirectory, PrivateOpResult},
+    ///     private::{PrivateForest, PrivateRef, PrivateDirectory},
     ///     common::{BlockStore, MemoryBlockStore},
     ///     namefilter::Namefilter,
     /// };
@@ -818,14 +815,13 @@ impl PrivateDirectory {
     ///     let store = &mut MemoryBlockStore::default();
     ///     let rng = &mut thread_rng();
     ///     let forest = &mut Rc::new(PrivateForest::new());
-    ///
-    ///     let dir = Rc::new(PrivateDirectory::new(
+    ///     let root_dir = &mut Rc::new(PrivateDirectory::new(
     ///         Namefilter::default(),
     ///         Utc::now(),
     ///         rng,
     ///     ));
     ///
-    ///     let PrivateOpResult { root_dir, .. } = dir
+    ///     root_dir
     ///         .mkdir(&["pictures".into(), "cats".into()], true, Utc::now(), forest, store, rng)
     ///         .await
     ///         .unwrap();
@@ -864,7 +860,7 @@ impl PrivateDirectory {
     /// use rand::thread_rng;
     ///
     /// use wnfs::{
-    ///     private::{PrivateForest, PrivateRef, PrivateDirectory, PrivateOpResult},
+    ///     private::{PrivateForest, PrivateRef, PrivateDirectory},
     ///     common::{BlockStore, MemoryBlockStore},
     ///     namefilter::Namefilter,
     /// };
@@ -874,14 +870,13 @@ impl PrivateDirectory {
     ///     let store = &mut MemoryBlockStore::default();
     ///     let rng = &mut thread_rng();
     ///     let forest = &mut Rc::new(PrivateForest::new());
-    ///
-    ///     let dir = Rc::new(PrivateDirectory::new(
+    ///     let root_dir = &mut Rc::new(PrivateDirectory::new(
     ///         Namefilter::default(),
     ///         Utc::now(),
     ///         rng,
     ///     ));
     ///
-    ///     let PrivateOpResult { root_dir, .. } = dir
+    ///     root_dir
     ///         .write(
     ///             &["code".into(), "hello.py".into()],
     ///             true,
@@ -894,12 +889,12 @@ impl PrivateDirectory {
     ///         .await
     ///         .unwrap();
     ///
-    ///     let PrivateOpResult { root_dir, .. } = root_dir
+    ///     root_dir
     ///         .mkdir(&["code".into(), "bin".into()], true, Utc::now(), forest, store, rng)
     ///         .await
     ///         .unwrap();
     ///
-    ///     let PrivateOpResult { result, .. } = root_dir
+    ///     let result = root_dir
     ///         .ls(&["code".into()], true, forest, store)
     ///         .await
     ///         .unwrap();
@@ -950,7 +945,7 @@ impl PrivateDirectory {
     /// use chrono::Utc;
     /// use rand::thread_rng;
     /// use wnfs::{
-    ///     private::{PrivateForest, PrivateRef, PrivateDirectory, PrivateOpResult},
+    ///     private::{PrivateForest, PrivateRef, PrivateDirectory},
     ///     common::{BlockStore, MemoryBlockStore},
     ///     namefilter::Namefilter,
     /// };
@@ -960,14 +955,13 @@ impl PrivateDirectory {
     ///     let store = &mut MemoryBlockStore::default();
     ///     let rng = &mut thread_rng();
     ///     let forest = &mut Rc::new(PrivateForest::new());
-    ///
-    ///     let dir = Rc::new(PrivateDirectory::new(
+    ///     let root_dir = &mut Rc::new(PrivateDirectory::new(
     ///         Namefilter::default(),
     ///         Utc::now(),
     ///         rng,
     ///     ));
     ///
-    ///     let PrivateOpResult { root_dir, .. } = dir
+    ///     root_dir
     ///         .write(
     ///             &["code".into(), "python".into(), "hello.py".into()],
     ///             true,
@@ -980,19 +974,19 @@ impl PrivateDirectory {
     ///         .await
     ///         .unwrap();
     ///
-    ///     let PrivateOpResult { root_dir, result } = root_dir
+    ///     let result = root_dir
     ///         .ls(&["code".into()], true, forest, store)
     ///         .await
     ///         .unwrap();
     ///
     ///     assert_eq!(result.len(), 1);
     ///
-    ///     let PrivateOpResult { root_dir, .. } = root_dir
+     ///     root_dir
     ///         .rm(&["code".into(), "python".into()], true, forest, store)
     ///         .await
     ///         .unwrap();
     ///
-    ///     let PrivateOpResult { result, .. } = root_dir
+    ///     let result = root_dir
     ///         .ls(&["code".into()], true, forest, store)
     ///         .await
     ///         .unwrap();
@@ -1061,12 +1055,11 @@ impl PrivateDirectory {
     ///
     /// ```
     /// use std::rc::Rc;
-    ///
     /// use chrono::Utc;
     /// use rand::thread_rng;
     ///
     /// use wnfs::{
-    ///     private::{PrivateForest, PrivateRef, PrivateDirectory, PrivateOpResult},
+    ///     private::{PrivateForest, PrivateRef, PrivateDirectory},
     ///     common::{BlockStore, MemoryBlockStore},
     ///     namefilter::Namefilter,
     /// };
@@ -1076,14 +1069,13 @@ impl PrivateDirectory {
     ///     let store = &mut MemoryBlockStore::default();
     ///     let rng = &mut thread_rng();
     ///     let forest = &mut Rc::new(PrivateForest::new());
-    ///
-    ///     let dir = Rc::new(PrivateDirectory::new(
+    ///     let root_dir = &mut Rc::new(PrivateDirectory::new(
     ///         Namefilter::default(),
     ///         Utc::now(),
     ///         rng,
     ///     ));
     ///
-    ///     let PrivateOpResult { root_dir, .. } = dir
+    ///     root_dir
     ///         .write(
     ///             &["code".into(), "python".into(), "hello.py".into()],
     ///             true,
@@ -1096,7 +1088,7 @@ impl PrivateDirectory {
     ///         .await
     ///         .unwrap();
     ///
-    ///     let PrivateOpResult { root_dir, result } = root_dir
+    ///     let result = root_dir
     ///         .basic_mv(
     ///             &["code".into(), "python".into(), "hello.py".into()],
     ///             &["code".into(), "hello.py".into()],
@@ -1109,7 +1101,7 @@ impl PrivateDirectory {
     ///         .await
     ///         .unwrap();
     ///
-    ///     let PrivateOpResult { result, .. } = root_dir
+    ///     let result = root_dir
     ///         .ls(&["code".into()], true, forest, store)
     ///         .await
     ///         .unwrap();
@@ -1155,7 +1147,7 @@ impl PrivateDirectory {
     /// use rand::thread_rng;
     ///
     /// use wnfs::{
-    ///     private::{PrivateForest, PrivateRef, PrivateDirectory, PrivateOpResult},
+    ///     private::{PrivateForest, PrivateRef, PrivateDirectory},
     ///     common::{BlockStore, MemoryBlockStore},
     ///     namefilter::Namefilter,
     /// };
@@ -1165,14 +1157,13 @@ impl PrivateDirectory {
     ///     let store = &mut MemoryBlockStore::default();
     ///     let rng = &mut thread_rng();
     ///     let forest = &mut Rc::new(PrivateForest::new());
-    ///
-    ///     let dir = Rc::new(PrivateDirectory::new(
+    ///     let root_dir = &mut Rc::new(PrivateDirectory::new(
     ///         Namefilter::default(),
     ///         Utc::now(),
     ///         rng,
     ///     ));
     ///
-    ///     let PrivateOpResult { root_dir, .. } = dir
+    ///     root_dir
     ///         .write(
     ///             &["code".into(), "python".into(), "hello.py".into()],
     ///             true,
@@ -1185,7 +1176,7 @@ impl PrivateDirectory {
     ///         .await
     ///         .unwrap();
     ///
-    ///     let PrivateOpResult { root_dir, result } = root_dir
+    ///     let result = root_dir
     ///         .cp(
     ///             &["code".into(), "python".into(), "hello.py".into()],
     ///             &["code".into(), "hello.py".into()],
@@ -1198,7 +1189,7 @@ impl PrivateDirectory {
     ///         .await
     ///         .unwrap();
     ///
-    ///     let PrivateOpResult { result, .. } = root_dir
+    ///     let result = root_dir
     ///         .ls(&["code".into()], true, forest, store)
     ///         .await
     ///         .unwrap();
@@ -1242,7 +1233,7 @@ impl PrivateDirectory {
     /// use chrono::Utc;
     /// use rand::thread_rng;
     /// use wnfs::{
-    ///     private::{PrivateForest, PrivateRef, PrivateNode, PrivateDirectory, PrivateOpResult},
+    ///     private::{PrivateForest, PrivateRef, PrivateNode, PrivateDirectory},
     ///     common::{BlockStore, MemoryBlockStore},
     ///     namefilter::Namefilter,
     /// };
@@ -1252,7 +1243,7 @@ impl PrivateDirectory {
     ///     let store = &mut MemoryBlockStore::default();
     ///     let rng = &mut thread_rng();
     ///     let forest = &mut Rc::new(PrivateForest::new());
-    ///     let dir = Rc::new(PrivateDirectory::new(
+    ///     let dir = &mut Rc::new(PrivateDirectory::new(
     ///         Namefilter::default(),
     ///         Utc::now(),
     ///         rng,

--- a/wnfs/src/private/file.rs
+++ b/wnfs/src/private/file.rs
@@ -77,7 +77,7 @@ pub struct PrivateFile {
 
 #[derive(Debug)]
 pub struct PrivateFileContent {
-    persisted_as: OnceCell<Cid>,
+    pub(crate) persisted_as: OnceCell<Cid>,
     pub(crate) previous: BTreeSet<(usize, Encrypted<Cid>)>,
     pub(crate) metadata: Metadata,
     pub(crate) content: FileContent,
@@ -561,19 +561,20 @@ impl PrivateFile {
     /// This doesn't have any effect if the current state hasn't been `.store()`ed yet.
     /// Otherwise, it clones itself, stores its current CID in the previous links and
     /// advances its ratchet.
-    pub(crate) fn prepare_next_revision(self: Rc<Self>) -> Result<Self> {
+    pub(crate) fn prepare_next_revision<'a>(self: &'a mut Rc<Self>) -> Result<&'a mut Self> {
+        println!("persisted_as: {:?}", self.content.persisted_as.get());
         let previous_cid = match self.content.persisted_as.get() {
             Some(cid) => *cid,
             None => {
                 // The current revision wasn't written yet.
                 // There's no point in advancing the revision even further.
-                return Ok(Rc::try_unwrap(self).unwrap_or_else(|rc| (*rc).clone()));
+                return Ok(Rc::make_mut(self));
             }
         };
 
         let temporal_key = self.header.derive_temporal_key();
+        let mut cloned = Rc::make_mut(self);
 
-        let mut cloned = Rc::try_unwrap(self).unwrap_or_else(|rc| (*rc).clone());
         // We make sure to clear any cached states.
         // `.clone()` does this too, but `try_unwrap` may circumvent clone.
         cloned.content.persisted_as = OnceCell::new();
@@ -582,7 +583,6 @@ impl PrivateFile {
             .content
             .previous
             .insert((1, Encrypted::from_value(previous_cid, &temporal_key)?));
-
         cloned.header.advance_ratchet();
 
         Ok(cloned)

--- a/wnfs/src/private/file.rs
+++ b/wnfs/src/private/file.rs
@@ -573,16 +573,12 @@ impl PrivateFile {
         };
 
         let temporal_key = self.header.derive_temporal_key();
+        let previous_link = (1, Encrypted::from_value(previous_cid, &temporal_key)?);
         let mut cloned = Rc::make_mut(self);
 
         // We make sure to clear any cached states.
-        // `.clone()` does this too, but `try_unwrap` may circumvent clone.
         cloned.content.persisted_as = OnceCell::new();
-        cloned.content.previous.clear();
-        cloned
-            .content
-            .previous
-            .insert((1, Encrypted::from_value(previous_cid, &temporal_key)?));
+        cloned.content.previous = [previous_link].into_iter().collect();
         cloned.header.advance_ratchet();
 
         Ok(cloned)

--- a/wnfs/src/private/file.rs
+++ b/wnfs/src/private/file.rs
@@ -632,7 +632,7 @@ impl PrivateFile {
     /// use chrono::Utc;
     /// use rand::thread_rng;
     /// use wnfs::{
-    ///     private::{PrivateForest, PrivateRef, PrivateFile, PrivateOpResult, PrivateNode},
+    ///     private::{PrivateForest, PrivateRef, PrivateFile, PrivateNode},
     ///     common::{BlockStore, MemoryBlockStore},
     ///     namefilter::Namefilter,
     /// };

--- a/wnfs/src/private/forest.rs
+++ b/wnfs/src/private/forest.rs
@@ -56,7 +56,7 @@ impl PrivateForest {
     /// use rand::thread_rng;
     /// use sha3::Sha3_256;
     /// use wnfs::{
-    ///     private::{PrivateForest, PrivateRef, PrivateDirectory, PrivateOpResult, PrivateNode},
+    ///     private::{PrivateForest, PrivateRef, PrivateDirectory, PrivateNode},
     ///     common::{BlockStore, MemoryBlockStore},
     ///     hamt::Hasher,
     ///     namefilter::Namefilter,
@@ -200,7 +200,7 @@ where
     /// use rand::{thread_rng, Rng};
     /// use futures::StreamExt;
     /// use wnfs::{
-    ///     private::{PrivateForest, RevisionRef, PrivateDirectory, PrivateOpResult, PrivateNode},
+    ///     private::{PrivateForest, RevisionRef, PrivateDirectory, PrivateNode},
     ///     common::{BlockStore, MemoryBlockStore},
     ///     namefilter::Namefilter,
     /// };

--- a/wnfs/src/private/link.rs
+++ b/wnfs/src/private/link.rs
@@ -68,6 +68,11 @@ impl PrivateLink {
                     None => PrivateNode::load(private_ref, forest, store).await?,
                 };
 
+                // We need to switch this PrivateLink to be a `Decrypted` again, since
+                // mutations on the `PrivateNode` may change the `private_ref`, e.g. by
+                // advancing the ratchet forward.
+                // So the `PrivateRef` should be managed by the `PrivateNode` itself
+                // rather than the `PrivateLink`.
                 *self = Self::Decrypted { node: private_node };
 
                 Ok(match self {

--- a/wnfs/src/private/node/node.rs
+++ b/wnfs/src/private/node/node.rs
@@ -331,7 +331,7 @@ impl PrivateNode {
     /// use chrono::Utc;
     /// use rand::thread_rng;
     /// use wnfs::{
-    ///     private::{PrivateForest, PrivateRef, PrivateNode, PrivateDirectory, PrivateOpResult},
+    ///     private::{PrivateForest, PrivateRef, PrivateNode, PrivateDirectory},
     ///     common::{BlockStore, MemoryBlockStore},
     ///     namefilter::Namefilter,
     /// };
@@ -342,7 +342,7 @@ impl PrivateNode {
     ///     let rng = &mut thread_rng();
     ///     let forest = &mut Rc::new(PrivateForest::new());
     ///
-    ///     let PrivateOpResult { root_dir: init_dir, .. } = PrivateDirectory::new_and_store(
+    ///     let mut init_dir = PrivateDirectory::new_and_store(
     ///         Default::default(),
     ///         Utc::now(),
     ///         forest,
@@ -350,12 +350,14 @@ impl PrivateNode {
     ///         rng
     ///     ).await.unwrap();
     ///
-    ///     let PrivateOpResult { root_dir, .. } = Rc::clone(&init_dir)
+    ///     let dir_clone = &mut Rc::clone(&init_dir);
+    ///
+    ///     dir_clone
     ///         .mkdir(&["pictures".into(), "cats".into()], true, Utc::now(), forest, store, rng)
     ///         .await
     ///         .unwrap();
     ///
-    ///     root_dir.store(forest, store, rng).await.unwrap();
+    ///     dir_clone.store(forest, store, rng).await.unwrap();
     ///
     ///     let latest_node = PrivateNode::Dir(init_dir).search_latest(forest, store).await.unwrap();
     ///
@@ -458,7 +460,7 @@ impl PrivateNode {
     /// use chrono::Utc;
     /// use rand::thread_rng;
     /// use wnfs::{
-    ///     private::{PrivateForest, PrivateRef, PrivateNode, PrivateDirectory, PrivateOpResult},
+    ///     private::{PrivateForest, PrivateRef, PrivateNode, PrivateDirectory},
     ///     common::{BlockStore, MemoryBlockStore},
     ///     namefilter::Namefilter,
     /// };

--- a/wnfs/src/private/previous.rs
+++ b/wnfs/src/private/previous.rs
@@ -501,7 +501,7 @@ impl PrivateNodeOnPathHistory {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::private::{PrivateDirectory, PrivateOpResult};
+    use crate::private::PrivateDirectory;
     use chrono::Utc;
     use proptest::test_runner::{RngAlgorithm, TestRng};
     use wnfs_common::MemoryBlockStore;
@@ -541,7 +541,7 @@ mod tests {
             mut rng,
             mut store,
             ref mut forest,
-            root_dir,
+            mut root_dir,
             discrepancy_budget,
         } = TestSetup::new();
 
@@ -552,7 +552,7 @@ mod tests {
 
         let past_ratchet = root_dir.header.ratchet.clone();
 
-        let PrivateOpResult { root_dir, .. } = root_dir
+        root_dir
             .write(
                 &["file.txt".into()],
                 true,
@@ -567,7 +567,7 @@ mod tests {
 
         root_dir.store(forest, store, rng).await.unwrap();
 
-        let PrivateOpResult { root_dir, .. } = root_dir
+        root_dir
             .mkdir(&["docs".into()], true, Utc::now(), forest, store, rng)
             .await
             .unwrap();
@@ -626,7 +626,7 @@ mod tests {
             mut rng,
             mut store,
             ref mut forest,
-            root_dir,
+            mut root_dir,
             discrepancy_budget,
         } = TestSetup::new();
 
@@ -639,14 +639,14 @@ mod tests {
 
         let path = ["Docs".into(), "Notes.md".into()];
 
-        let PrivateOpResult { root_dir, .. } = root_dir
+        root_dir
             .write(&path, true, Utc::now(), b"Hi".to_vec(), forest, store, rng)
             .await
             .unwrap();
 
         root_dir.store(forest, store, rng).await.unwrap();
 
-        let PrivateOpResult { root_dir, .. } = root_dir
+        root_dir
             .write(
                 &path,
                 true,
@@ -726,7 +726,7 @@ mod tests {
             mut rng,
             mut store,
             ref mut forest,
-            root_dir,
+            mut root_dir,
             discrepancy_budget,
         } = TestSetup::new();
 
@@ -739,27 +739,21 @@ mod tests {
 
         let path = ["Docs".into(), "Notes.md".into()];
 
-        let PrivateOpResult { root_dir, .. } = root_dir
+        root_dir
             .write(&path, true, Utc::now(), b"Hi".to_vec(), forest, store, rng)
             .await
             .unwrap();
 
         root_dir.store(forest, store, rng).await.unwrap();
 
-        let PrivateOpResult {
-            root_dir,
-            result: docs_dir,
-            ..
-        } = root_dir
+        let docs_dir = root_dir
             .get_node(&["Docs".into()], true, forest, store)
             .await
             .unwrap();
 
-        let docs_dir = docs_dir.unwrap().as_dir().unwrap();
+        let mut docs_dir = docs_dir.unwrap().as_dir().unwrap();
 
-        let PrivateOpResult {
-            root_dir: docs_dir, ..
-        } = docs_dir
+        docs_dir
             .write(
                 &["Notes.md".into()],
                 true,
@@ -839,7 +833,7 @@ mod tests {
             mut rng,
             mut store,
             ref mut forest,
-            root_dir,
+            mut root_dir,
             discrepancy_budget,
         } = TestSetup::new();
 
@@ -848,7 +842,7 @@ mod tests {
 
         let path = ["Docs".into(), "Notes.md".into()];
 
-        let PrivateOpResult { root_dir, .. } = root_dir
+        root_dir
             .write(
                 &path,
                 true,
@@ -865,20 +859,14 @@ mod tests {
 
         let past_ratchet = root_dir.header.ratchet.clone();
 
-        let PrivateOpResult {
-            root_dir,
-            result: docs_dir,
-            ..
-        } = root_dir
+        let docs_dir = root_dir
             .get_node(&["Docs".into()], true, forest, store)
             .await
             .unwrap();
 
-        let docs_dir = docs_dir.unwrap().as_dir().unwrap();
+        let mut docs_dir = docs_dir.unwrap().as_dir().unwrap();
 
-        let PrivateOpResult {
-            root_dir: docs_dir, ..
-        } = docs_dir
+        docs_dir
             .write(
                 &["Notes.md".into()],
                 true,
@@ -893,7 +881,7 @@ mod tests {
 
         docs_dir.store(forest, store, rng).await.unwrap();
 
-        let PrivateOpResult { root_dir, .. } = root_dir
+        root_dir
             .write(
                 &path,
                 true,
@@ -987,7 +975,7 @@ mod tests {
             mut rng,
             mut store,
             ref mut forest,
-            root_dir,
+            mut root_dir,
             discrepancy_budget,
         } = TestSetup::new();
 
@@ -996,7 +984,7 @@ mod tests {
 
         let path = ["Docs".into(), "Notes.md".into()];
 
-        let PrivateOpResult { root_dir, .. } = root_dir
+        root_dir
             .write(
                 &path,
                 true,
@@ -1013,11 +1001,11 @@ mod tests {
 
         let past_ratchet = root_dir.header.ratchet.clone();
 
-        let root_dir = Rc::new(root_dir.prepare_next_revision().unwrap());
+        let mut root_dir = Rc::new(root_dir.prepare_next_revision().unwrap().clone());
 
         root_dir.store(forest, store, rng).await.unwrap();
 
-        let PrivateOpResult { root_dir, .. } = root_dir
+        root_dir
             .write(
                 &path,
                 true,

--- a/wnfs/src/public/directory.rs
+++ b/wnfs/src/public/directory.rs
@@ -1,11 +1,7 @@
 //! Public fs directory node.
 
 use super::{PublicFile, PublicLink, PublicNode};
-use crate::{
-    error::FsError,
-    traits::{Id, PrepareMut},
-    utils,
-};
+use crate::{error::FsError, traits::Id, utils, SearchResult};
 use anyhow::{bail, ensure, Result};
 use async_once_cell::OnceCell;
 use async_recursion::async_recursion;
@@ -59,13 +55,6 @@ struct PublicDirectorySerializable {
     metadata: Metadata,
     userland: BTreeMap<String, Cid>,
     previous: Vec<Cid>,
-}
-
-/// The result of an basic get operation.
-enum SearchState<T> {
-    Missing(T, usize),
-    NotADir(T, usize),
-    Found(T),
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -131,31 +120,46 @@ impl PublicDirectory {
         &self.metadata
     }
 
+    /// Takes care of creating previous links, in case the current
+    /// directory was previously `.store()`ed.
+    /// In any case it'll try to give you ownership of the directory if possible,
+    /// otherwise it clones.
+    pub(crate) fn prepare_next_revision<'a>(self: &'a mut Rc<Self>) -> &'a mut Self {
+        let Some(previous_cid) = self.persisted_as.get().cloned() else {
+            return Rc::make_mut(self);
+        };
+
+        let cloned = Rc::make_mut(self);
+        cloned.persisted_as = OnceCell::new();
+        cloned.previous = [previous_cid].into_iter().collect();
+        cloned
+    }
+
     async fn get_leaf_dir<'a>(
         &'a self,
         path_segments: &[String],
         store: &impl BlockStore,
-    ) -> Result<SearchState<&'a Self>> {
+    ) -> Result<SearchResult<&'a Self>> {
         let mut working_dir = self;
         for (depth, segment) in path_segments.iter().enumerate() {
             match working_dir.lookup_node(segment, store).await? {
-                Some(PublicNode::Dir(ref directory)) => {
-                    working_dir = directory;
+                Some(PublicNode::Dir(directory)) => {
+                    working_dir = directory.as_ref();
                 }
-                Some(_) => return Ok(SearchState::NotADir(working_dir, depth)),
-                None => return Ok(SearchState::Missing(working_dir, depth)),
+                Some(_) => return Ok(SearchResult::NotADir(working_dir, depth)),
+                None => return Ok(SearchResult::Missing(working_dir, depth)),
             }
         }
 
-        Ok(SearchState::Found(working_dir))
+        Ok(SearchResult::Found(working_dir))
     }
 
     async fn get_leaf_dir_mut<'a>(
         self: &'a mut Rc<Self>,
         path_segments: &[String],
         store: &impl BlockStore,
-    ) -> Result<SearchState<&'a mut Self>> {
-        let mut working_dir = self.prepare_mut();
+    ) -> Result<SearchResult<&'a mut Self>> {
+        let mut working_dir = self.prepare_next_revision();
         for (depth, segment) in path_segments.iter().enumerate() {
             match working_dir.lookup_node(segment, store).await? {
                 Some(PublicNode::Dir(_)) => {
@@ -169,14 +173,14 @@ impl PublicDirectory {
                         .unwrap()
                         .as_dir_mut()
                         .unwrap()
-                        .prepare_mut()
+                        .prepare_next_revision()
                 }
-                Some(_) => return Ok(SearchState::NotADir(working_dir, depth)),
-                None => return Ok(SearchState::Missing(working_dir, depth)),
+                Some(_) => return Ok(SearchResult::NotADir(working_dir, depth)),
+                None => return Ok(SearchResult::Missing(working_dir, depth)),
             };
         }
 
-        Ok(SearchState::Found(working_dir))
+        Ok(SearchResult::Found(working_dir))
     }
 
     async fn get_or_create_leaf_dir_mut<'a>(
@@ -186,8 +190,8 @@ impl PublicDirectory {
         store: &impl BlockStore,
     ) -> Result<&'a mut Self> {
         match self.get_leaf_dir_mut(path_segments, store).await? {
-            SearchState::Found(dir) => Ok(dir),
-            SearchState::Missing(mut dir, depth) => {
+            SearchResult::Found(dir) => Ok(dir),
+            SearchResult::Missing(mut dir, depth) => {
                 for segment in &path_segments[depth..] {
                     dir = Rc::make_mut(
                         dir.userland
@@ -203,7 +207,7 @@ impl PublicDirectory {
 
                 Ok(dir)
             }
-            SearchState::NotADir(_, _) => bail!(FsError::NotADirectory),
+            SearchResult::NotADir(_, _) => bail!(FsError::NotADirectory),
         }
     }
 
@@ -246,7 +250,7 @@ impl PublicDirectory {
             bail!(FsError::InvalidPath);
         };
 
-        let SearchState::Found(dir) = self.get_leaf_dir(path, store).await? else {
+        let SearchResult::Found(dir) = self.get_leaf_dir(path, store).await? else {
             bail!(FsError::NotFound);
         };
 
@@ -292,7 +296,8 @@ impl PublicDirectory {
         })
     }
 
-    pub async fn lookup_node_mut<'a>(
+    /// Looks up a node by its path name in the current directory.
+    async fn lookup_node_mut<'a>(
         &'a mut self,
         path_segment: &str,
         store: &impl BlockStore,
@@ -378,7 +383,7 @@ impl PublicDirectory {
     pub async fn read(&self, path_segments: &[String], store: &impl BlockStore) -> Result<Cid> {
         let (path, filename) = utils::split_last(path_segments)?;
         match self.get_leaf_dir(path, store).await? {
-            SearchState::Found(dir) => match dir.lookup_node(filename, store).await? {
+            SearchResult::Found(dir) => match dir.lookup_node(filename, store).await? {
                 Some(PublicNode::File(file)) => Ok(file.userland),
                 Some(_) => error(FsError::NotAFile),
                 None => error(FsError::NotFound),
@@ -428,7 +433,7 @@ impl PublicDirectory {
 
         match dir.lookup_node_mut(filename, store).await? {
             Some(PublicNode::File(file)) => {
-                let file = file.prepare_mut();
+                let file = file.prepare_next_revision();
                 file.userland = content_cid;
                 file.metadata.upsert_mtime(time);
             }
@@ -534,7 +539,7 @@ impl PublicDirectory {
         store: &impl BlockStore,
     ) -> Result<Vec<(String, Metadata)>> {
         match self.get_leaf_dir(path_segments, store).await? {
-            SearchState::Found(dir) => {
+            SearchResult::Found(dir) => {
                 let mut result = vec![];
                 for (name, link) in dir.userland.iter() {
                     match link.resolve_value(store).await? {
@@ -548,7 +553,7 @@ impl PublicDirectory {
                 }
                 Ok(result)
             }
-            SearchState::NotADir(_, _) => bail!(FsError::NotADirectory),
+            SearchResult::NotADir(_, _) => bail!(FsError::NotADirectory),
             _ => bail!(FsError::NotFound),
         }
     }
@@ -608,7 +613,7 @@ impl PublicDirectory {
     ) -> Result<PublicNode> {
         let (path, node_name) = utils::split_last(path_segments)?;
 
-        let SearchState::Found(dir) = self.get_leaf_dir_mut(path, store).await? else {
+        let SearchResult::Found(dir) = self.get_leaf_dir_mut(path, store).await? else {
             bail!(FsError::NotFound)
         };
 
@@ -678,7 +683,7 @@ impl PublicDirectory {
         let (path, filename) = utils::split_last(path_segments_to)?;
         let mut removed_node = self.rm(path_segments_from, store).await?;
 
-        let SearchState::Found(dir) = self.get_leaf_dir_mut(path, store).await? else {
+        let SearchResult::Found(dir) = self.get_leaf_dir_mut(path, store).await? else {
             bail!(FsError::NotFound);
         };
 
@@ -693,23 +698,6 @@ impl PublicDirectory {
             .insert(filename.clone(), PublicLink::new(removed_node));
 
         Ok(())
-    }
-}
-
-impl PrepareMut for PublicDirectory {
-    /// Takes care of creating previous links, in case the current
-    /// directory was previously `.store()`ed.
-    /// In any case it'll try to give you ownership of the directory if possible,
-    /// otherwise it clones.
-    fn prepare_mut<'a>(self: &'a mut Rc<PublicDirectory>) -> &'a mut PublicDirectory {
-        let Some(previous_cid) = self.persisted_as.get().cloned() else {
-            return Rc::make_mut(self);
-        };
-
-        let cloned = Rc::make_mut(self);
-        cloned.persisted_as = OnceCell::new();
-        cloned.previous = [previous_cid].into_iter().collect();
-        cloned
     }
 }
 
@@ -1147,15 +1135,14 @@ mod tests {
         let time = Utc::now();
         let store = &mut MemoryBlockStore::default();
         let root_dir = &mut Rc::new(PublicDirectory::new(time));
-
         let previous_cid = root_dir.store(store).await.unwrap();
-        let root_dir_clone = &mut Rc::clone(root_dir);
-        root_dir_clone
+
+        root_dir
             .mkdir(&["test".into()], time, store)
             .await
             .unwrap();
 
-        let ipld = root_dir_clone.async_serialize_ipld(store).await.unwrap();
+        let ipld = root_dir.async_serialize_ipld(store).await.unwrap();
         match ipld {
             Ipld::Map(map) => match map.get("previous") {
                 Some(Ipld::List(previous)) => {
@@ -1168,15 +1155,15 @@ mod tests {
     }
 
     #[async_std::test]
-    async fn prepare_mut_shortcuts_if_possible() {
+    async fn prepare_next_revision_shortcuts_if_possible() {
         let time = Utc::now();
         let store = &mut MemoryBlockStore::default();
         let root_dir = &mut Rc::new(PublicDirectory::new(time));
 
         let previous_cid = &root_dir.store(store).await.unwrap();
-        let next_root_dir = root_dir.prepare_mut();
+        let next_root_dir = root_dir.prepare_next_revision();
         let next_root_dir_clone = &mut Rc::new(next_root_dir.clone());
-        let yet_another_dir = next_root_dir_clone.prepare_mut();
+        let yet_another_dir = next_root_dir_clone.prepare_next_revision();
 
         assert_eq!(
             yet_another_dir.previous.iter().collect::<Vec<_>>(),

--- a/wnfs/src/public/directory.rs
+++ b/wnfs/src/public/directory.rs
@@ -1137,10 +1137,7 @@ mod tests {
         let root_dir = &mut Rc::new(PublicDirectory::new(time));
         let previous_cid = root_dir.store(store).await.unwrap();
 
-        root_dir
-            .mkdir(&["test".into()], time, store)
-            .await
-            .unwrap();
+        root_dir.mkdir(&["test".into()], time, store).await.unwrap();
 
         let ipld = root_dir.async_serialize_ipld(store).await.unwrap();
         match ipld {

--- a/wnfs/src/traits.rs
+++ b/wnfs/src/traits.rs
@@ -1,5 +1,3 @@
-use std::rc::Rc;
-
 //--------------------------------------------------------------------------------------------------
 // Traits
 //--------------------------------------------------------------------------------------------------
@@ -8,10 +6,4 @@ use std::rc::Rc;
 pub trait Id {
     /// Gets an identifier for the node.
     fn get_id(&self) -> String;
-}
-
-/// This trait exists to allow types that can be `Rc::make_mut`'d to do additional things like
-/// setting up revision correctly before the `Rc::make_mut` call.
-pub(crate) trait PrepareMut {
-    fn prepare_mut<'a>(self: &'a mut Rc<Self>) -> &'a mut Self;
 }


### PR DESCRIPTION
## Summary

Removed the need for `PrivateOpResult` type for capturing results of operating on an immutable `PrivateDirectory`

## Test plan (required)

```bash 
scripts/rs-wnfs.sh test
```
