### PR TITLE
chore: Use version & path dependencies inter-workspace at the same time

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -7,14 +7,8 @@
   "packages": {
     "wnfs": {},
     "wnfs-wasm": {},
-    "wnfs-common": {
-      "release-as": "0.1.18"
-    },
-    "wnfs-hamt": {
-      "release-as": "0.1.18"
-    },
-    "wnfs-namefilter": {
-      "release-as": "0.1.18"
-    }
+    "wnfs-common": {},
+    "wnfs-hamt": {},
+    "wnfs-namefilter": {}
   }
 }

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -7,8 +7,14 @@
   "packages": {
     "wnfs": {},
     "wnfs-wasm": {},
-    "wnfs-common": {},
-    "wnfs-hamt": {},
-    "wnfs-namefilter": {}
+    "wnfs-common": {
+      "release-as": "0.1.18"
+    },
+    "wnfs-hamt": {
+      "release-as": "0.1.18"
+    },
+    "wnfs-namefilter": {
+      "release-as": "0.1.18"
+    }
   }
 }

--- a/wnfs-hamt/Cargo.toml
+++ b/wnfs-hamt/Cargo.toml
@@ -35,14 +35,14 @@ semver = { version = "1.0", features = ["serde"] }
 serde = { version = "1.0", features = ["rc"] }
 sha3 = "0.10"
 thiserror = "1.0"
-wnfs-common = { path = "../wnfs-common" }
+wnfs-common = { path = "../wnfs-common", version = "0.1.18" }
 
 [dev-dependencies]
 async-std = { version = "1.11", features = ["attributes"] }
 proptest = "1.1"
 rand = "0.8"
 test-strategy = "0.3"
-wnfs-common = { path = "../wnfs-common", features = ["test_utils"] }
+wnfs-common = { path = "../wnfs-common", version = "0.1.18", features = ["test_utils"] }
 
 [features]
 test_utils = ["proptest"]

--- a/wnfs-namefilter/Cargo.toml
+++ b/wnfs-namefilter/Cargo.toml
@@ -30,7 +30,7 @@ rand_core = "0.6"
 serde = { version = "1.0", features = ["rc"] }
 sha3 = "0.10"
 thiserror = "1.0"
-wnfs-common = { path = "../wnfs-common" }
+wnfs-common = { path = "../wnfs-common", version = "0.1.18" }
 xxhash-rust = { version = "0.8", features = ["xxh3"] }
 
 [dev-dependencies]

--- a/wnfs/Cargo.toml
+++ b/wnfs/Cargo.toml
@@ -36,9 +36,9 @@ serde = { version = "1.0", features = ["rc"] }
 sha3 = "0.10"
 skip_ratchet = { version = "0.1", features = ["serde"] }
 thiserror = "1.0"
-wnfs-common = { path = "../wnfs-common" }
-wnfs-hamt = { path = "../wnfs-hamt" }
-wnfs-namefilter = { path = "../wnfs-namefilter" }
+wnfs-common = { path = "../wnfs-common", version = "0.1.18" }
+wnfs-hamt = { path = "../wnfs-hamt", version = "0.1.18" }
+wnfs-namefilter = { path = "../wnfs-namefilter", version = "0.1.18" }
 xxhash-rust = { version = "0.8", features = ["xxh3"] }
 
 [dev-dependencies]


### PR DESCRIPTION
Hoping this & some additional tagging may fix stuff.
It certainly doesn't break anything, so worth a try?