### PR TITLE
feat: `open_file_mut` function for getting `&mut PrivateFile` references

### DIFF
--- a/wnfs/src/private/directory.rs
+++ b/wnfs/src/private/directory.rs
@@ -633,7 +633,7 @@ impl PrivateDirectory {
     /// async fn main() {
     ///    let store = &mut MemoryBlockStore::default();
     ///    let rng = &mut thread_rng();
-    ///    let mut forest : &mut Rc<PrivateForest> = &mut Rc::new(PrivateForest::new());
+    ///    let forest = &mut Rc::new(PrivateForest::new());
     ///    let root_dir = &mut Rc::new(PrivateDirectory::new(
     ///         Namefilter::default(),
     ///         Utc::now(),
@@ -646,27 +646,23 @@ impl PrivateDirectory {
     ///            true,
     ///            Utc::now(),
     ///            content.to_vec(),
-    ///            &mut forest,
+    ///            forest,
     ///            store,
     ///            rng
     ///        )
     ///        .await
     ///        .unwrap();
-    ///    let mut file_forest = &mut Rc::clone(forest);
-    ///    let mut file = {
-    ///        root_dir
-    ///            .open_file_mut(&["code".into(), "hello.py".into()], true, Utc::now(), forest, store, rng)
-    ///            .await
-    ///            .unwrap()
-    ///    };
+    ///    let mut file = root_dir
+    ///        .open_file_mut(&["code".into(), "hello.py".into()], true, Utc::now(), forest, store, rng)
+    ///        .await
+    ///        .unwrap();
     ///    file.set_content(
     ///        Utc::now(),
     ///        &b"print('hello world 2')"[..],
-    ///        file_forest,
+    ///        forest,
     ///        store,
     ///        rng,
-    ///    );
-    ///    let forest = &forest.merge(&file_forest, store).await.unwrap();
+    ///    ).await.unwrap();
     ///    let result = root_dir
     ///        .read(&["code".into(), "hello.py".into()], true, forest, store)
     ///        .await
@@ -679,14 +675,14 @@ impl PrivateDirectory {
         path_segments: &[String],
         search_latest: bool,
         time: DateTime<Utc>,
-        forest: &'a mut Rc<PrivateForest>,
-        store: &'a mut impl BlockStore,
+        forest: &mut Rc<PrivateForest>,
+        store: &mut impl BlockStore,
         rng: &mut impl RngCore,
     ) -> Result<&'a mut PrivateFile> {
         let (path, filename) = crate::utils::split_last(path_segments)?;
-        let SearchResult::Found(dir) = self.get_leaf_dir_mut(path, search_latest, forest, store).await? else {
-            bail!(FsError::NotFound);
-        };
+        let dir = self
+            .get_or_create_leaf_dir_mut(path, time, search_latest, forest, store, rng)
+            .await?;
 
         if !dir.content.entries.contains_key(filename.as_str()) {
             let parent_bare_name = dir.header.bare_name.clone();

--- a/wnfs/src/private/directory.rs
+++ b/wnfs/src/private/directory.rs
@@ -633,7 +633,7 @@ impl PrivateDirectory {
     /// async fn main() {
     ///    let store = &mut MemoryBlockStore::default();
     ///    let rng = &mut thread_rng();
-    ///    let forest = &mut Rc::new(PrivateForest::new());
+    ///    let mut forest : &mut Rc<PrivateForest> = &mut Rc::new(PrivateForest::new());
     ///    let root_dir = &mut Rc::new(PrivateDirectory::new(
     ///         Namefilter::default(),
     ///         Utc::now(),
@@ -646,12 +646,13 @@ impl PrivateDirectory {
     ///            true,
     ///            Utc::now(),
     ///            content.to_vec(),
-    ///            forest,
+    ///            &mut forest,
     ///            store,
     ///            rng
     ///        )
     ///        .await
     ///        .unwrap();
+    ///    let mut file_forest = &mut Rc::clone(forest);
     ///    let mut file = {
     ///        root_dir
     ///            .open_file_mut(&["code".into(), "hello.py".into()], true, Utc::now(), forest, store, rng)
@@ -661,10 +662,11 @@ impl PrivateDirectory {
     ///    file.set_content(
     ///        Utc::now(),
     ///        &b"print('hello world 2')"[..],
-    ///        forest,
+    ///        file_forest,
     ///        store,
     ///        rng,
     ///    );
+    ///    let forest = &forest.merge(&file_forest, store).await.unwrap();
     ///    let result = root_dir
     ///        .read(&["code".into(), "hello.py".into()], true, forest, store)
     ///        .await

--- a/wnfs/src/private/file.rs
+++ b/wnfs/src/private/file.rs
@@ -399,6 +399,22 @@ impl PrivateFile {
         Ok(content)
     }
 
+    /// Sets the content of a file.
+    pub async fn set_content(
+        &mut self,
+        time: DateTime<Utc>,
+        content: impl AsyncRead + Unpin,
+        forest: &mut Rc<PrivateForest>,
+        store: &mut impl BlockStore,
+        rng: &mut impl RngCore,
+    ) -> Result<()> {
+        self.content.metadata = Metadata::new(time);
+        self.content.content =
+            Self::prepare_content_streaming(&self.header.bare_name, content, forest, store, rng)
+                .await?;
+        Ok(())
+    }
+
     /// Determines where to put the content of a file. This can either be inline or stored up in chunks in a private forest.
     pub(super) async fn prepare_content(
         bare_name: &Namefilter,


### PR DESCRIPTION
## Summary

<!-- Summary of the PR -->

- [x] Adds open_file_mut so you can change the content of files and write them back

<!-- You can skip this if you're fixing a typo or adding an app to the Showcase. -->

Explain the **motivation** for making this change. What existing problem does the pull request solve?
See #210- prep for integrating with Filecoin

## Test plan (required)

This doesn't pass doctests- I'm pretty sure without adding some interior mutability, we can't make the desired workflow in #210 work. open to being told I'm wrong. The doctest error is illustrative, and I gave more details in #210.

## Closing issues

Closes #210 

## After Merge

- [ ] Does this change invalidate any docs or tutorials? _If so ensure the changes needed are either made or recorded_
- [ ] Does this change require a release to be made? Is so please create and deploy the release
(none of the above)