### PR TITLE
feat: Add `PrivateDirectory::entires`, `PrivateFile::read_at` and make `PrivateFile::get_content_size_upper_bound` public

### DIFF
--- a/wnfs/src/private/directory.rs
+++ b/wnfs/src/private/directory.rs
@@ -1002,6 +1002,10 @@ impl PrivateDirectory {
         }
     }
 
+    pub fn entries<'a>(self: &'a Rc<Self>) -> impl Iterator<Item = &'a String> {
+        self.content.entries.iter().map(|x| x.0)
+    }
+
     /// Removes a file or directory from the directory.
     ///
     /// # Examples

--- a/wnfs/src/private/directory.rs
+++ b/wnfs/src/private/directory.rs
@@ -1002,7 +1002,11 @@ impl PrivateDirectory {
         }
     }
 
-    pub fn entries<'a>(self: &'a Rc<Self>) -> impl Iterator<Item = &'a String> {
+    /// Get the names of directory's immediate children.
+    ///
+    /// Other than [PrivateDirectory::ls] this returns only the names, without loading the
+    /// metadata for each node from the store.
+    pub fn get_entries<'a>(self: &'a Rc<Self>) -> impl Iterator<Item = &'a String> {
         self.content.entries.iter().map(|x| x.0)
     }
 


### PR DESCRIPTION
This PR contains changes I needed to made while hacking on [wnfs-fuse](https://github.com/Frando/wnfs-fuse) at IPFSThing.

- Public getter method on `PrivateDirectory` to get the entries. `ls` exists, but loads all the metadata, which is expensive if not needed
- Make `PrivateFile::get_content_size_upper_bound` public (to have something to report as filesize - even if inaccurate). It might be a good idea to add the actual filesize to the metadata instead.
- Add a new method `PrivateFile::read_at` to read `size` bytes from `offset`. This makes use of `stream_content` internally and does the block and offset calculations