### PR TITLE
Symlink Metadata and Double Packing Avoidance

### DIFF
--- a/wnfs-common/src/metadata.rs
+++ b/wnfs-common/src/metadata.rs
@@ -235,14 +235,7 @@ impl TryFrom<&str> for NodeType {
 
 impl From<&NodeType> for String {
     fn from(r#type: &NodeType) -> Self {
-        match r#type {
-            NodeType::PrivateDirectory => "wnfs/priv/dir".into(),
-            NodeType::PrivateFile => "wnfs/priv/file".into(),
-            NodeType::PublicDirectory => "wnfs/pub/dir".into(),
-            NodeType::PublicFile => "wnfs/pub/file".into(),
-            NodeType::TemporalSharePointer => "wnfs/share/temporal".into(),
-            NodeType::SnapshotSharePointer => "wnfs/share/snapshot".into(),
-        }
+        r#type.to_string()
     }
 }
 

--- a/wnfs/src/private/directory.rs
+++ b/wnfs/src/private/directory.rs
@@ -6,7 +6,7 @@ use crate::{error::FsError, traits::Id, SearchResult};
 use anyhow::{bail, ensure, Result};
 use async_once_cell::OnceCell;
 use chrono::{DateTime, Utc};
-use libipld::Cid;
+use libipld::{Cid, Ipld};
 use rand_core::RngCore;
 use semver::Version;
 use serde::{de::Error as DeError, ser::Error as SerError, Deserialize, Deserializer, Serialize};
@@ -911,6 +911,51 @@ impl PrivateDirectory {
         let _ = self
             .get_or_create_leaf_dir_mut(path_segments, time, search_latest, forest, store, rng)
             .await?;
+
+        Ok(())
+    }
+
+    /// Write a Symlink to the filesystem with the reference path at the path segments specified
+    pub async fn write_symlink(
+        self: &mut Rc<Self>,
+        path: String,
+        path_segments: &[String],
+        search_latest: bool,
+        time: DateTime<Utc>,
+        forest: &PrivateForest,
+        store: &impl BlockStore,
+        rng: &mut impl RngCore,
+    ) -> Result<()> {
+        let (path_segments, filename) = crate::utils::split_last(path_segments)?;
+
+        let dir = self
+            .get_or_create_leaf_dir_mut(path_segments, time, search_latest, forest, store, rng)
+            .await?;
+
+        match dir
+            .lookup_node_mut(filename, search_latest, forest, store)
+            .await?
+        {
+            Some(PrivateNode::File(file)) => {
+                let file = file.prepare_next_revision()?;
+                file.content.content = super::FileContent::Inline { data: vec![] };
+                file.content.metadata.upsert_mtime(time);
+                // Write the path into the Metadata HashMap
+                file.content.metadata.0.insert(String::from("symlink"), Ipld::String(path));
+            }
+            Some(PrivateNode::Dir(_)) => bail!(FsError::DirectoryAlreadyExists),
+            None => {
+                let file = PrivateFile::new_symlink(
+                    path,
+                    dir.header.bare_name.clone(),
+                    time,
+                    rng,
+                )
+                .await?;
+                let link = PrivateLink::with_file(file);
+                dir.content.entries.insert(filename.to_string(), link);
+            }
+        };
 
         Ok(())
     }

--- a/wnfs/src/private/directory.rs
+++ b/wnfs/src/private/directory.rs
@@ -916,6 +916,50 @@ impl PrivateDirectory {
     }
 
     /// Write a Symlink to the filesystem with the reference path at the path segments specified
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use std::rc::Rc;
+    ///
+    /// use chrono::Utc;
+    /// use rand::thread_rng;
+    /// use wnfs::{
+    ///     private::{PrivateForest, PrivateRef, PrivateDirectory},
+    ///     common::{BlockStore, MemoryBlockStore},
+    ///     namefilter::Namefilter,
+    /// };
+    ///
+    /// #[async_std::main]
+    /// async fn main() {
+    ///     let store = &mut MemoryBlockStore::default();
+    ///     let rng = &mut thread_rng();
+    ///     let forest = &mut Rc::new(PrivateForest::new());
+    ///     let root_dir = &mut Rc::new(PrivateDirectory::new(
+    ///         Namefilter::default(),
+    ///         Utc::now(),
+    ///         rng,
+    ///     ));
+    ///     let sym_path = "/pictures/meows".to_string();
+    ///     let path_segments = &["pictures".into(), "cats".into()];
+    ///
+    ///     root_dir
+    ///         .write_symlink(sym_path.clone(), path_segments, true, Utc::now(), forest, store, rng)
+    ///         .await
+    ///         .unwrap();
+    ///
+    ///     let symlink = root_dir.get_node(path_segments, true, forest, store)
+    ///         .await
+    ///         .unwrap()
+    ///         .expect("Symlink should be present")
+    ///         .as_file()
+    ///         .unwrap();
+    ///
+    ///     let path = symlink.symlink_origin();
+    ///     assert!(path.is_some());
+    ///     assert_eq!(path, Some(sym_path));
+    /// }
+    /// ```
     #[allow(clippy::too_many_arguments)]
     pub async fn write_symlink(
         self: &mut Rc<Self>,
@@ -1370,6 +1414,64 @@ impl PrivateDirectory {
     }
 
     /// Copies a file or directory from one path to another without modifying it
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use std::rc::Rc;
+    ///
+    /// use chrono::Utc;
+    /// use rand::thread_rng;
+    ///
+    /// use wnfs::{
+    ///     private::{PrivateForest, PrivateRef, PrivateDirectory},
+    ///     common::{BlockStore, MemoryBlockStore},
+    ///     namefilter::Namefilter,
+    /// };
+    ///
+    /// #[async_std::main]
+    /// async fn main() {
+    ///     let store = &mut MemoryBlockStore::default();
+    ///     let rng = &mut thread_rng();
+    ///     let forest = &mut Rc::new(PrivateForest::new());
+    ///     let root_dir = &mut Rc::new(PrivateDirectory::new(
+    ///         Namefilter::default(),
+    ///         Utc::now(),
+    ///         rng,
+    ///     ));
+    ///
+    ///     root_dir
+    ///         .write(
+    ///             &["code".into(), "python".into(), "hello.py".into()],
+    ///             true,
+    ///             Utc::now(),
+    ///             b"print('hello world')".to_vec(),
+    ///             forest,
+    ///             store,
+    ///             rng
+    ///         )
+    ///         .await
+    ///         .unwrap();
+    ///
+    ///     let result = root_dir
+    ///         .cp_link(
+    ///             &["code".into(), "python".into(), "hello.py".into()],
+    ///             &["code".into(), "hello.py".into()],
+    ///             true,
+    ///             forest,
+    ///             store
+    ///         )
+    ///         .await
+    ///         .unwrap();
+    ///
+    ///     let result = root_dir
+    ///         .ls(&["code".into()], true, forest, store)
+    ///         .await
+    ///         .unwrap();
+    ///
+    ///     assert_eq!(result.len(), 2);
+    /// }
+    /// ```
     #[allow(clippy::too_many_arguments)]
     pub async fn cp_link(
         self: &mut Rc<Self>,

--- a/wnfs/src/private/directory.rs
+++ b/wnfs/src/private/directory.rs
@@ -916,6 +916,7 @@ impl PrivateDirectory {
     }
 
     /// Write a Symlink to the filesystem with the reference path at the path segments specified
+    #[allow(clippy::too_many_arguments)]
     pub async fn write_symlink(
         self: &mut Rc<Self>,
         path: String,
@@ -941,17 +942,15 @@ impl PrivateDirectory {
                 file.content.content = super::FileContent::Inline { data: vec![] };
                 file.content.metadata.upsert_mtime(time);
                 // Write the path into the Metadata HashMap
-                file.content.metadata.0.insert(String::from("symlink"), Ipld::String(path));
+                file.content
+                    .metadata
+                    .0
+                    .insert(String::from("symlink"), Ipld::String(path));
             }
             Some(PrivateNode::Dir(_)) => bail!(FsError::DirectoryAlreadyExists),
             None => {
-                let file = PrivateFile::new_symlink(
-                    path,
-                    dir.header.bare_name.clone(),
-                    time,
-                    rng,
-                )
-                .await?;
+                let file =
+                    PrivateFile::new_symlink(path, dir.header.bare_name.clone(), time, rng).await?;
                 let link = PrivateLink::with_file(file);
                 dir.content.entries.insert(filename.to_string(), link);
             }

--- a/wnfs/src/private/directory.rs
+++ b/wnfs/src/private/directory.rs
@@ -1123,6 +1123,33 @@ impl PrivateDirectory {
         Ok(())
     }
 
+    /// Attaches a node to the specified directory without modifying the node.
+    #[allow(clippy::too_many_arguments)]
+    async fn attach_link(
+        self: &mut Rc<Self>,
+        node: PrivateNode,
+        path_segments: &[String],
+        search_latest: bool,
+        forest: &mut Rc<PrivateForest>,
+        store: &impl BlockStore,
+    ) -> Result<()> {
+        let (path, node_name) = crate::utils::split_last(path_segments)?;
+        let SearchResult::Found(dir) = self.get_leaf_dir_mut(path, search_latest, forest, store).await? else {
+            bail!(FsError::NotFound);
+        };
+
+        ensure!(
+            !dir.content.entries.contains_key(node_name),
+            FsError::FileAlreadyExists
+        );
+
+        dir.content
+            .entries
+            .insert(node_name.clone(), PrivateLink::from(node));
+
+        Ok(())
+    }
+
     /// Moves a file or directory from one path to another.
     ///
     /// # Examples
@@ -1294,6 +1321,30 @@ impl PrivateDirectory {
             forest,
             store,
             rng,
+        )
+        .await
+    }
+
+    /// Copies a file or directory from one path to another without modifying it
+    #[allow(clippy::too_many_arguments)]
+    pub async fn cp_link(
+        self: &mut Rc<Self>,
+        path_segments_from: &[String],
+        path_segments_to: &[String],
+        search_latest: bool,
+        forest: &mut Rc<PrivateForest>,
+        store: &impl BlockStore,
+    ) -> Result<()> {
+        let result = self
+            .get_node(path_segments_from, search_latest, forest, store)
+            .await?;
+        
+        self.attach_link(
+            result.ok_or(FsError::NotFound)?,
+            path_segments_to,
+            search_latest,
+            forest,
+            store,
         )
         .await
     }

--- a/wnfs/src/private/directory.rs
+++ b/wnfs/src/private/directory.rs
@@ -1382,7 +1382,7 @@ impl PrivateDirectory {
         let result = self
             .get_node(path_segments_from, search_latest, forest, store)
             .await?;
-        
+
         self.attach_link(
             result.ok_or(FsError::NotFound)?,
             path_segments_to,

--- a/wnfs/src/private/file.rs
+++ b/wnfs/src/private/file.rs
@@ -7,8 +7,8 @@ use anyhow::Result;
 use async_once_cell::OnceCell;
 use async_stream::try_stream;
 use chrono::{DateTime, Utc};
-use futures::{future, AsyncRead, Stream, StreamExt, TryStreamExt};
-use libipld::{Cid, IpldCodec};
+use futures::{future, AsyncRead, Stream, StreamExt};
+use libipld::{Cid, IpldCodec, Ipld};
 use rand_core::RngCore;
 use semver::Version;
 use serde::{de::Error as DeError, Deserialize, Deserializer, Serialize};
@@ -380,6 +380,33 @@ impl PrivateFile {
         Ok(bytes)
     }
 
+    /// Create a new Symlink PrivateFile
+    pub async fn new_symlink(
+        path: String,
+        parent_bare_name: Namefilter,
+        time: DateTime<Utc>,
+        rng: &mut impl RngCore,
+    ) -> Result<Self> {
+        // Header stays the same
+        let header = PrivateNodeHeader::new(parent_bare_name, rng);
+        // Symlinks have no file content
+        let content = FileContent::Inline { data: vec![] };
+        // Create a new Metadata object
+        let mut metadata: Metadata = Metadata::new(time);
+        // Write the original path into the Metadata HashMap
+        metadata.0.insert(String::from("symlink"), Ipld::String(path));
+        // Return self with PrivateFileContent
+        Ok(Self {
+            header,
+            content: PrivateFileContent {
+                persisted_as: OnceCell::new(),
+                metadata,
+                previous: BTreeSet::new(),
+                content,
+            },
+        })
+    }
+
     /// Gets the metadata of the file
     pub fn get_metadata(&self) -> &Metadata {
         &self.content.metadata
@@ -739,6 +766,18 @@ impl PrivateFile {
     /// Wraps the file in a [`PrivateNode`].
     pub fn as_node(self: &Rc<Self>) -> PrivateNode {
         PrivateNode::File(Rc::clone(self))
+    }
+
+    /// If the Metadata contains Symlink data, return it
+    pub fn symlink_origin(&self) -> Option<String> {
+        let meta = self.get_metadata();
+        // If the Metadata contains a String key for the symlink
+        if let Some(Ipld::String(path)) = meta.0.get("symlink") {
+            Some(path.to_string())
+        }
+        else {
+            None
+        }
     }
 }
 

--- a/wnfs/src/private/file.rs
+++ b/wnfs/src/private/file.rs
@@ -8,7 +8,7 @@ use async_once_cell::OnceCell;
 use async_stream::try_stream;
 use chrono::{DateTime, Utc};
 use futures::{future, AsyncRead, Stream, StreamExt};
-use libipld::{Cid, IpldCodec, Ipld};
+use libipld::{Cid, Ipld, IpldCodec};
 use rand_core::RngCore;
 use semver::Version;
 use serde::{de::Error as DeError, Deserialize, Deserializer, Serialize};
@@ -394,7 +394,9 @@ impl PrivateFile {
         // Create a new Metadata object
         let mut metadata: Metadata = Metadata::new(time);
         // Write the original path into the Metadata HashMap
-        metadata.0.insert(String::from("symlink"), Ipld::String(path));
+        metadata
+            .0
+            .insert(String::from("symlink"), Ipld::String(path));
         // Return self with PrivateFileContent
         Ok(Self {
             header,
@@ -774,8 +776,7 @@ impl PrivateFile {
         // If the Metadata contains a String key for the symlink
         if let Some(Ipld::String(path)) = meta.0.get("symlink") {
             Some(path.to_string())
-        }
-        else {
+        } else {
             None
         }
     }

--- a/wnfs/src/private/file.rs
+++ b/wnfs/src/private/file.rs
@@ -7,7 +7,7 @@ use anyhow::Result;
 use async_once_cell::OnceCell;
 use async_stream::try_stream;
 use chrono::{DateTime, Utc};
-use futures::{future, AsyncRead, Stream, StreamExt};
+use futures::{future, AsyncRead, Stream, StreamExt, TryStreamExt};
 use libipld::{Cid, Ipld, IpldCodec};
 use rand_core::RngCore;
 use semver::Version;

--- a/wnfs/src/private/node/header.rs
+++ b/wnfs/src/private/node/header.rs
@@ -45,7 +45,7 @@ pub struct PrivateNodeHeader {
     /// A unique identifier of the node.
     pub(crate) inumber: INumber,
     /// Used both for versioning and deriving keys for that enforces privacy.
-    pub ratchet: Ratchet,
+    pub(crate) ratchet: Ratchet,
     /// Used for ancestry checks and as a key for the private forest.
     pub(crate) bare_name: Namefilter,
 }

--- a/wnfs/src/private/node/header.rs
+++ b/wnfs/src/private/node/header.rs
@@ -45,7 +45,7 @@ pub struct PrivateNodeHeader {
     /// A unique identifier of the node.
     pub(crate) inumber: INumber,
     /// Used both for versioning and deriving keys for that enforces privacy.
-    pub(crate) ratchet: Ratchet,
+    pub ratchet: Ratchet,
     /// Used for ancestry checks and as a key for the private forest.
     pub(crate) bare_name: Namefilter,
 }


### PR DESCRIPTION
Enclosed in this pull request are two relatively trivial changes to PrivateDirectory and PrivateFile which allow us to get more out of our rs-wnfs use case. 

1. The `attach` and `cp` functions within `PrivateDirectory` now have `attach_link` and `cp_link` versions. The issue we encountered while implementing this tool in [Tomb](https://github.com/banyancomputer/tomb) is that despite our being able to correctly identify when files are duplicates of one another, copying them using the `cp` function still creates a new `PrivateNode` in the `PrivateForest` which, when encrypted and sent to the `BlockStore` employed, does not result in CID collisions and results in the double packing of the same file on disk. This is because the `cp` function described updates the ancestry and rotates the key associated with the `PrivateNode` being copied. This is not something we want to do, we want these CID collisions to occur in our use case so at to minimize our disk footprint. Thus, `attach_link` and `cp_link` were made as lightweight versions of the original function which maintain ancestry and keys across this linking/copying. 
2. The `write_symlink` function in `PrivateDirectory` and `symlink_origin` function in `PrivateFile` are also new. They create an interface for writing a `PrivateFile` to a `PrivateDirectory` where the contents of the file itself are empty, but encoded in the `Metadata` is information, a single `String` value associated with the key "symlink". `write_symlink` provides an interface for creating such `PrivateFile`s, `symlink_origin` provides an interface for retrieving an `Option<String>` for a given `PrivateFile`, which will either be the symlink path it points to, or nothing at all if it does not contain said `Metadata`. 

Strictly speaking, if any of these changes are unwelcome we can implement them ourselves using a trait that is applied to the `PrivateDirectory` structure. 