### PR TITLE
feat: make changes to BlockStore trait based on feedback

### DIFF
--- a/wnfs-common/Cargo.toml
+++ b/wnfs-common/Cargo.toml
@@ -20,6 +20,7 @@ authors = ["The Fission Authors"]
 anyhow = "1.0"
 async-once-cell = "0.4"
 async-trait = "0.1"
+bytes = { version = "1.4.0", features = ["serde"] }
 chrono = { version = "0.4.23", default-features = false, features = ["clock", "std"] }
 futures = "0.3"
 libipld = { version = "0.16", features = ["dag-cbor", "derive", "serde-codec"] }

--- a/wnfs-common/src/blockstore.rs
+++ b/wnfs-common/src/blockstore.rs
@@ -4,10 +4,38 @@ use async_trait::async_trait;
 use libipld::{
     cid::Version,
     multihash::{Code, MultihashDigest},
-    serde as ipld_serde, Cid, IpldCodec,
+    serde as ipld_serde, Cid,
 };
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use std::{borrow::Cow, cell::RefCell, collections::HashMap};
+
+//--------------------------------------------------------------------------------------------------
+// Constants
+//--------------------------------------------------------------------------------------------------
+
+/// The value representing the DAG-JSON codec.
+///
+/// - https://ipld.io/docs/codecs/#known-codecs
+/// - https://github.com/multiformats/multicodec/blob/master/table.csv
+pub const CODEC_DAG_JSON: u64 = 0x0129;
+
+/// The value representing the DAG-CBOR codec.
+///
+/// - https://ipld.io/docs/codecs/#known-codecs
+/// - https://github.com/multiformats/multicodec/blob/master/table.csv
+pub const CODEC_DAG_CBOR: u64 = 0x71;
+
+/// The value representing the DAG-Protobuf codec.
+///
+/// - https://ipld.io/docs/codecs/#known-codecs
+/// - https://github.com/multiformats/multicodec/blob/master/table.csv
+pub const CODEC_DAG_PB: u64 = 0x70;
+
+/// The value representing the raw codec.
+///
+/// - https://ipld.io/docs/codecs/#known-codecs
+/// - https://github.com/multiformats/multicodec/blob/master/table.csv
+pub const CODEC_RAW: u64 = 0x55;
 
 //--------------------------------------------------------------------------------------------------
 // Type Definitions
@@ -17,7 +45,7 @@ use std::{borrow::Cow, cell::RefCell, collections::HashMap};
 #[async_trait(?Send)]
 pub trait BlockStore: Sized {
     async fn get_block(&self, cid: &Cid) -> Result<Cow<Vec<u8>>>;
-    async fn put_block(&self, bytes: Vec<u8>, codec: IpldCodec) -> Result<Cid>;
+    async fn put_block(&self, bytes: Vec<u8>, codec: u64) -> Result<Cid>;
 
     async fn get_deserializable<V: DeserializeOwned>(&self, cid: &Cid) -> Result<V> {
         let bytes = self.get_block(cid).await?;
@@ -27,26 +55,29 @@ pub trait BlockStore: Sized {
 
     async fn put_serializable<V: Serialize>(&self, value: &V) -> Result<Cid> {
         let bytes = dagcbor::encode(&ipld_serde::to_ipld(value)?)?;
-        self.put_block(bytes, IpldCodec::DagCbor).await
+        // let codec = utils::u64_to_ipld(CODEC_DAG_CBOR)?;
+        self.put_block(bytes, CODEC_DAG_CBOR).await
     }
 
     async fn put_async_serializable<V: AsyncSerialize>(&self, value: &V) -> Result<Cid> {
         let ipld = value.async_serialize_ipld(self).await?;
         let bytes = dagcbor::encode(&ipld)?;
-        self.put_block(bytes, IpldCodec::DagCbor).await
+        self.put_block(bytes, CODEC_DAG_CBOR).await
     }
 
     // This should be the same in all implementations of BlockStore
-    fn create_cid(&self, bytes: &Vec<u8>, codec: IpldCodec) -> Result<Cid> {
+    fn create_cid(&self, bytes: &Vec<u8>, codec: u64) -> Result<Cid> {
         // If there are too many bytes, abandon this task
         if bytes.len() > MAX_BLOCK_SIZE {
             bail!(BlockStoreError::MaximumBlockSizeExceeded(bytes.len()))
         }
+
         // Compute the SHA256 hash of the bytes
         let hash = Code::Sha2_256.digest(bytes);
+
         // Represent the hash as a V1 CID
-        let cid = Cid::new(Version::V1, codec.into(), hash)?;
-        // Return Ok with the CID
+        let cid = Cid::new(Version::V1, codec, hash)?;
+
         Ok(cid)
     }
 }
@@ -82,7 +113,7 @@ impl BlockStore for MemoryBlockStore {
     }
 
     /// Stores an array of bytes in the block store.
-    async fn put_block(&self, bytes: Vec<u8>, codec: IpldCodec) -> Result<Cid> {
+    async fn put_block(&self, bytes: Vec<u8>, codec: u64) -> Result<Cid> {
         // Try to build the CID from the bytes and codec
         let cid = self.create_cid(&bytes, codec)?;
         // Insert the bytes into the HashMap using the CID as the key

--- a/wnfs-common/src/utils.rs
+++ b/wnfs-common/src/utils.rs
@@ -1,6 +1,7 @@
 use crate::HashOutput;
 use anyhow::Result;
 use futures::{AsyncRead, AsyncReadExt};
+use libipld::IpldCodec;
 #[cfg(any(test, feature = "test_utils"))]
 use proptest::{
     strategy::{Strategy, ValueTree},
@@ -125,4 +126,9 @@ pub fn to_hash_output(bytes: &[u8]) -> HashOutput {
     let mut nibbles = [0u8; 32];
     nibbles[..bytes.len()].copy_from_slice(bytes);
     nibbles
+}
+
+/// Tries to convert a u64 value to IPLD codec.
+pub fn u64_to_ipld(value: u64) -> Result<IpldCodec> {
+    Ok(value.try_into()?)
 }

--- a/wnfs-hamt/README.md
+++ b/wnfs-hamt/README.md
@@ -49,7 +49,7 @@ The implementation is based on [fvm_ipld_hamt](https://github.com/filecoin-proje
 use wnfs_hamt::Node;
 use wnfs_common::MemoryBlockStore;
 
-let store = &mut MemoryBlockStore::default();
+let store = &MemoryBlockStore::default();
 let scores: Node<String, usize> = Rc::new(Node::default());
 
 scores.set("Mandy", 30, store).await?;

--- a/wnfs-hamt/src/diff.rs
+++ b/wnfs-hamt/src/diff.rs
@@ -47,7 +47,7 @@ pub struct KeyValueChange<K, V> {
 ///
 /// #[async_std::main]
 /// async fn main() {
-///     let store = &mut MemoryBlockStore::new();
+///     let store = &MemoryBlockStore::new();
 ///     let main_node = &mut Rc::new(Node::<[u8; 4], String>::default());
 ///     for i in 0u32..3 {
 ///         main_node
@@ -333,7 +333,7 @@ mod tests {
 
     #[async_std::test]
     async fn can_diff_main_node_with_added_removed_pairs() {
-        let store = &mut MemoryBlockStore::default();
+        let store = &MemoryBlockStore::default();
 
         let main_node = &mut Rc::new(Node::<[u8; 4], String>::default());
         for i in 0u32..3 {
@@ -404,7 +404,7 @@ mod tests {
 
     #[async_std::test]
     async fn can_diff_main_node_with_no_changes() {
-        let store = &mut MemoryBlockStore::default();
+        let store = &MemoryBlockStore::default();
 
         let main_node = &mut Rc::new(Node::<_, _>::default());
         for i in 0_u32..3 {
@@ -435,7 +435,7 @@ mod tests {
 
     #[async_std::test]
     async fn can_diff_nodes_with_different_structure_and_modified_changes() {
-        let store = &mut MemoryBlockStore::default();
+        let store = &MemoryBlockStore::default();
 
         // A node that adds the first 3 pairs of HASH_KV_PAIRS.
         let other_node = &mut Rc::new(Node::<_, _, MockHasher>::default());
@@ -582,7 +582,7 @@ mod proptests {
         ),
     ) {
         task::block_on(async {
-            let store = &mut MemoryBlockStore::default();
+            let store = &MemoryBlockStore::default();
             let (ops, strategy_changes) = ops_changes;
 
             let other_node = &mut strategies::node_from_operations(&ops, store).await.unwrap();
@@ -624,7 +624,7 @@ mod proptests {
         #[strategy(generate_kvs("[a-z0-9]{1,3}", 0u64..1000, 0..100))] kvs2: Vec<(String, u64)>,
     ) {
         task::block_on(async {
-            let store = &mut MemoryBlockStore::default();
+            let store = &MemoryBlockStore::default();
 
             let node1 = strategies::node_from_kvs(kvs1, store).await.unwrap();
             let node2 = strategies::node_from_kvs(kvs2, store).await.unwrap();
@@ -648,7 +648,7 @@ mod proptests {
         #[strategy(generate_kvs("[a-z0-9]{1,3}", 0u64..1000, 0..100))] kvs2: Vec<(String, u64)>,
     ) {
         task::block_on(async {
-            let store = &mut MemoryBlockStore::default();
+            let store = &MemoryBlockStore::default();
 
             let node1 = strategies::node_from_kvs(kvs1, store).await.unwrap();
             let node2 = strategies::node_from_kvs(kvs2, store).await.unwrap();

--- a/wnfs-hamt/src/hamt.rs
+++ b/wnfs-hamt/src/hamt.rs
@@ -91,7 +91,7 @@ impl<K, V, H: Hasher> Hamt<K, V, H> {
     ///
     /// #[async_std::main]
     /// async fn main() {
-    ///     let store = &mut MemoryBlockStore::default();
+    ///     let store = &MemoryBlockStore::default();
     ///
     ///     let main_hamt = Hamt::<String, usize>::with_root({
     ///         let mut node = Rc::new(Node::default());
@@ -228,7 +228,7 @@ mod tests {
 
     #[async_std::test]
     async fn hamt_can_encode_decode_as_cbor() {
-        let store = &mut MemoryBlockStore::default();
+        let store = &MemoryBlockStore::default();
         let root = Rc::new(Node::default());
         let hamt: Hamt<String, i32> = Hamt::with_root(root);
 

--- a/wnfs-hamt/src/merge.rs
+++ b/wnfs-hamt/src/merge.rs
@@ -76,7 +76,7 @@ mod proptests {
         #[strategy(generate_kvs("[a-z0-9]{1,3}", 0u64..1000, 0..100))] kvs3: Vec<(String, u64)>,
     ) {
         task::block_on(async {
-            let store = &mut MemoryBlockStore::default();
+            let store = &MemoryBlockStore::default();
 
             let node1 = strategies::node_from_kvs(kvs1, store).await.unwrap();
             let node2 = strategies::node_from_kvs(kvs2, store).await.unwrap();
@@ -132,7 +132,7 @@ mod proptests {
         #[strategy(generate_kvs("[a-z0-9]{1,3}", 0u64..1000, 0..100))] kvs2: Vec<(String, u64)>,
     ) {
         task::block_on(async {
-            let store = &mut MemoryBlockStore::default();
+            let store = &MemoryBlockStore::default();
 
             let node1 = strategies::node_from_kvs(kvs1, store).await.unwrap();
             let node2 = strategies::node_from_kvs(kvs2, store).await.unwrap();
@@ -165,7 +165,7 @@ mod proptests {
         #[strategy(generate_kvs("[a-z0-9]{1,3}", 0u64..1000, 0..100))] kvs2: Vec<(String, u64)>,
     ) {
         task::block_on(async {
-            let store = &mut MemoryBlockStore::default();
+            let store = &MemoryBlockStore::default();
 
             let node1 = strategies::node_from_kvs(kvs1, store).await.unwrap();
             let node2 = strategies::node_from_kvs(kvs2, store).await.unwrap();

--- a/wnfs-hamt/src/node.rs
+++ b/wnfs-hamt/src/node.rs
@@ -45,7 +45,7 @@ pub type BitMaskType = [u8; HAMT_BITMASK_BYTE_SIZE];
 /// use wnfs_hamt::Node;
 /// use wnfs_common::MemoryBlockStore;
 ///
-/// let store = &mut MemoryBlockStore::new();
+/// let store = &MemoryBlockStore::new();
 /// let node = Rc::new(Node::<String, usize>::default());
 ///
 /// assert!(node.is_empty());
@@ -79,7 +79,7 @@ where
     ///
     /// #[async_std::main]
     /// async fn main() {
-    ///     let store = &mut MemoryBlockStore::new();
+    ///     let store = &MemoryBlockStore::new();
     ///     let mut node = Rc::new(Node::<String, usize>::default());
     ///
     ///     node.set("key".into(), 42, store).await.unwrap();
@@ -111,7 +111,7 @@ where
     ///
     /// #[async_std::main]
     /// async fn main() {
-    ///     let store = &mut MemoryBlockStore::new();
+    ///     let store = &MemoryBlockStore::new();
     ///     let mut node = Rc::new(Node::<String, usize>::default());
     ///
     ///     node.set("key".into(), 42, store).await.unwrap();
@@ -145,7 +145,7 @@ where
     ///
     /// #[async_std::main]
     /// async fn main() {
-    ///     let store = &mut MemoryBlockStore::new();
+    ///     let store = &MemoryBlockStore::new();
     ///     let mut node = Rc::new(Node::<String, usize>::default());
     ///
     ///     node.set("key".into(), 42, store).await.unwrap();
@@ -185,7 +185,7 @@ where
     ///
     /// #[async_std::main]
     /// async fn main() {
-    ///     let store = &mut MemoryBlockStore::new();
+    ///     let store = &MemoryBlockStore::new();
     ///     let mut node = Rc::new(Node::<String, usize>::default());
     ///
     ///     node.set("key".into(), 42, store).await.unwrap();
@@ -224,7 +224,7 @@ where
     ///
     /// #[async_std::main]
     /// async fn main() {
-    ///     let store = &mut MemoryBlockStore::new();
+    ///     let store = &MemoryBlockStore::new();
     ///     let mut node = Rc::new(Node::<String, usize>::default());
     ///
     ///     node.set("key".into(), 42, store).await.unwrap();
@@ -260,7 +260,7 @@ where
     ///
     /// #[async_std::main]
     /// async fn main() {
-    ///     let store = &mut MemoryBlockStore::new();
+    ///     let store = &MemoryBlockStore::new();
     ///
     ///     let mut node = Rc::new(Node::<String, usize>::default());
     ///     assert!(node.is_empty());
@@ -488,7 +488,7 @@ where
     ///
     /// #[async_std::main]
     /// async fn main() {
-    ///     let store = &mut MemoryBlockStore::new();
+    ///     let store = &MemoryBlockStore::new();
     ///     let mut node = Rc::new(Node::<[u8; 4], String>::default());
     ///     for i in 0..99_u32 {
     ///         node
@@ -544,7 +544,7 @@ where
     ///
     /// #[async_std::main]
     /// async fn main() {
-    ///     let store = &mut MemoryBlockStore::new();
+    ///     let store = &MemoryBlockStore::new();
     ///
     ///     let mut node = Rc::new(Node::<[u8; 4], String>::default());
     ///     for i in 0..100_u32 {
@@ -625,7 +625,7 @@ where
     ///
     /// #[async_std::main]
     /// async fn main() {
-    ///     let store = &mut MemoryBlockStore::new();
+    ///     let store = &MemoryBlockStore::new();
     ///
     ///     let mut node = Rc::new(Node::<[u8; 4], String>::default());
     ///     for i in 0..100_u32 {
@@ -848,7 +848,7 @@ mod tests {
 
     #[async_std::test]
     async fn get_value_fetches_deeply_linked_value() {
-        let store = &mut MemoryBlockStore::default();
+        let store = &MemoryBlockStore::default();
 
         // Insert 4 values to trigger the creation of a linked node.
         let working_node = &mut Rc::new(Node::<String, String, MockHasher>::default());
@@ -871,7 +871,7 @@ mod tests {
 
     #[async_std::test]
     async fn remove_value_canonicalizes_linked_node() {
-        let store = &mut MemoryBlockStore::default();
+        let store = &MemoryBlockStore::default();
 
         // Insert 4 values to trigger the creation of a linked node.
         let working_node = &mut Rc::new(Node::<String, String, MockHasher>::default());
@@ -910,7 +910,7 @@ mod tests {
 
     #[async_std::test]
     async fn set_value_splits_when_bucket_threshold_reached() {
-        let store = &mut MemoryBlockStore::default();
+        let store = &MemoryBlockStore::default();
 
         // Insert 3 values into the HAMT.
         let working_node = &mut Rc::new(Node::<String, String, MockHasher>::default());
@@ -955,7 +955,7 @@ mod tests {
 
     #[async_std::test]
     async fn get_value_index_gets_correct_index() {
-        let store = &mut MemoryBlockStore::default();
+        let store = &MemoryBlockStore::default();
         let hash_expected_idx_samples = [
             (&[0x00], 0),
             (&[0x20], 1),
@@ -1018,7 +1018,7 @@ mod tests {
         let insert_key: String = "GL59 Tg4phDb  bv".into();
         let remove_key: String = "hK i3b4V4152EPOdA".into();
 
-        let store = &mut MemoryBlockStore::default();
+        let store = &MemoryBlockStore::default();
         let node0: &mut Rc<Node<String, u64>> = &mut Rc::new(Node::default());
 
         node0.set(insert_key.clone(), 0, store).await.unwrap();
@@ -1029,7 +1029,7 @@ mod tests {
 
     #[async_std::test]
     async fn node_history_independence_regression() {
-        let store = &mut MemoryBlockStore::default();
+        let store = &MemoryBlockStore::default();
 
         let node1: &mut Rc<Node<String, u64>> = &mut Rc::new(Node::default());
         let node2: &mut Rc<Node<String, u64>> = &mut Rc::new(Node::default());
@@ -1056,7 +1056,7 @@ mod tests {
 
     #[async_std::test]
     async fn can_map_over_leaf_nodes() {
-        let store = &mut MemoryBlockStore::default();
+        let store = &MemoryBlockStore::default();
 
         let node = &mut Rc::new(Node::<[u8; 4], String>::default());
         for i in 0..99_u32 {
@@ -1075,7 +1075,7 @@ mod tests {
 
     #[async_std::test]
     async fn can_fetch_node_at_hashprefix() {
-        let store = &mut MemoryBlockStore::default();
+        let store = &MemoryBlockStore::default();
 
         let node = &mut Rc::new(Node::<String, String, MockHasher>::default());
         for (digest, kv) in HASH_KV_PAIRS.iter() {
@@ -1100,7 +1100,7 @@ mod tests {
 
     #[async_std::test]
     async fn can_generate_hashmap_from_node() {
-        let store = &mut MemoryBlockStore::default();
+        let store = &MemoryBlockStore::default();
 
         let node = &mut Rc::new(Node::<[u8; 4], String>::default());
         const NUM_VALUES: u32 = 1000;
@@ -1142,7 +1142,7 @@ mod proptests {
         #[strategy(0..1000u64)] value: u64,
     ) {
         async_std::task::block_on(async move {
-            let store = &mut MemoryBlockStore::default();
+            let store = &MemoryBlockStore::default();
             let node = &mut node_from_operations(&operations, store).await.unwrap();
 
             node.set(key.clone(), value, store).await.unwrap();
@@ -1164,7 +1164,7 @@ mod proptests {
         #[strategy(small_key())] key: String,
     ) {
         async_std::task::block_on(async move {
-            let store = &mut MemoryBlockStore::default();
+            let store = &MemoryBlockStore::default();
             let node = &mut node_from_operations(&operations, store).await.unwrap();
 
             node.remove(&key, store).await.unwrap();
@@ -1185,7 +1185,7 @@ mod proptests {
         >,
     ) {
         async_std::task::block_on(async move {
-            let store = &mut MemoryBlockStore::default();
+            let store = &MemoryBlockStore::default();
             let node = node_from_operations(&operations, store).await.unwrap();
 
             let encoded_node = dagcbor::async_encode(&node, store).await.unwrap();
@@ -1205,7 +1205,7 @@ mod proptests {
         async_std::task::block_on(async move {
             let (original, shuffled) = pair;
 
-            let store = &mut MemoryBlockStore::default();
+            let store = &MemoryBlockStore::default();
 
             let node1 = node_from_operations(&original, store).await.unwrap();
             let node2 = node_from_operations(&shuffled, store).await.unwrap();

--- a/wnfs-hamt/src/pointer.rs
+++ b/wnfs-hamt/src/pointer.rs
@@ -253,7 +253,7 @@ mod tests {
 
     #[async_std::test]
     async fn pointer_can_encode_decode_as_cbor() {
-        let store = &mut MemoryBlockStore::default();
+        let store = &MemoryBlockStore::default();
         let pointer: Pointer<String, i32, Sha3_256> = Pointer::Values(vec![
             Pair {
                 key: "James".into(),

--- a/wnfs-hamt/src/strategies/operations.rs
+++ b/wnfs-hamt/src/strategies/operations.rs
@@ -170,7 +170,7 @@ where
 ///     let mut runner = &mut TestRunner::deterministic();
 ///     let ops = strategies::operations(any::<[u8; 32]>(), any::<String>(), 10).sample(runner);
 ///
-///     let store = &mut MemoryBlockStore::new();
+///     let store = &MemoryBlockStore::new();
 ///     let node = strategies::node_from_operations(&ops, store).await.unwrap();
 ///
 ///     println!("{:?}", node);

--- a/wnfs-wasm/Cargo.toml
+++ b/wnfs-wasm/Cargo.toml
@@ -19,6 +19,7 @@ authors = ["The Fission Authors"]
 [dependencies]
 anyhow = "1.0"
 async-trait = "0.1"
+bytes = "1.4.0"
 cfg-if = "1.0"
 chrono = { version = "0.4", default-features = false, features = ["clock", "std", "wasmbind"] }
 console_error_panic_hook = { version = "0.1", optional = true }
@@ -41,12 +42,5 @@ path = "src/lib.rs"
 [features]
 default = ["js"]
 wasm = ["wnfs/wasm"]
-js = [
-  "chrono/wasmbind",
-  "console_error_panic_hook",
-  "js-sys",
-  "wasm",
-  "wasm-bindgen",
-  "wasm-bindgen-futures"
-]
+js = ["chrono/wasmbind", "console_error_panic_hook", "js-sys", "wasm", "wasm-bindgen", "wasm-bindgen-futures"]
 web = ["wasm", "web-sys"]

--- a/wnfs-wasm/Cargo.toml
+++ b/wnfs-wasm/Cargo.toml
@@ -24,6 +24,7 @@ chrono = { version = "0.4", default-features = false, features = ["clock", "std"
 console_error_panic_hook = { version = "0.1", optional = true }
 getrandom = { version = "0.2", features = ["js"] }
 js-sys = { version = "0.3", optional = true }
+libipld-core = { version = "0.16" }
 rand_core = "0.6"
 wasm-bindgen = { version = "0.2.84", optional = true, features = ["serde-serialize"] }
 wasm-bindgen-futures = { version = "0.4", optional = true }

--- a/wnfs-wasm/src/fs/blockstore.rs
+++ b/wnfs-wasm/src/fs/blockstore.rs
@@ -4,13 +4,11 @@ use super::utils::anyhow_error;
 use anyhow::Result;
 use async_trait::async_trait;
 use js_sys::{Promise, Uint8Array};
+use libipld_core::cid::Cid;
 use std::borrow::Cow;
 use wasm_bindgen::prelude::wasm_bindgen;
 use wasm_bindgen_futures::JsFuture;
-use wnfs::{
-    common::BlockStore as WnfsBlockStore,
-    libipld::{Cid, IpldCodec},
-};
+use wnfs::common::BlockStore as WnfsBlockStore;
 
 //--------------------------------------------------------------------------------------------------
 // Externs
@@ -22,7 +20,7 @@ extern "C" {
     pub type BlockStore;
 
     #[wasm_bindgen(method, js_name = "putBlock")]
-    pub(crate) fn put_block(store: &BlockStore, bytes: Vec<u8>, code: Code) -> Promise;
+    pub(crate) fn put_block(store: &BlockStore, bytes: Vec<u8>, codec: u32) -> Promise;
 
     #[wasm_bindgen(method, js_name = "getBlock")]
     pub(crate) fn get_block(store: &BlockStore, cid: Vec<u8>) -> Promise;
@@ -31,20 +29,6 @@ extern "C" {
 //--------------------------------------------------------------------------------------------------
 // Type Definitions
 //--------------------------------------------------------------------------------------------------
-
-/// Represents the format the content a CID points to.
-///
-/// The variants are based on the ipld and multiformats specification.
-///
-/// - https://ipld.io/docs/codecs/#known-codecs
-/// - https://github.com/multiformats/multicodec/blob/master/table.csv
-#[wasm_bindgen]
-pub enum Code {
-    DagProtobuf = 0x70,
-    DagCbor = 0x71,
-    DagJson = 0x0129,
-    Raw = 0x55,
-}
 
 /// A block store provided by the host (JavaScript) for custom implementation like connection to the IPFS network.
 #[wasm_bindgen]
@@ -57,8 +41,8 @@ pub struct ForeignBlockStore(pub(crate) BlockStore);
 #[async_trait(?Send)]
 impl WnfsBlockStore for ForeignBlockStore {
     /// Stores an array of bytes in the block store.
-    async fn put_block(&self, bytes: Vec<u8>, codec: IpldCodec) -> Result<Cid> {
-        let value = JsFuture::from(self.0.put_block(bytes, codec.into()))
+    async fn put_block(&self, bytes: Vec<u8>, codec: u64) -> Result<Cid> {
+        let value = JsFuture::from(self.0.put_block(bytes, codec.try_into()?))
             .await
             .map_err(anyhow_error("Cannot get block: {:?}"))?;
 
@@ -78,16 +62,5 @@ impl WnfsBlockStore for ForeignBlockStore {
         // Convert the value to a vector of bytes.
         let bytes = Uint8Array::new(&value).to_vec();
         Ok(Cow::Owned(bytes))
-    }
-}
-
-impl From<IpldCodec> for Code {
-    fn from(codec: IpldCodec) -> Self {
-        match codec {
-            IpldCodec::DagPb => Code::DagProtobuf,
-            IpldCodec::DagCbor => Code::DagCbor,
-            IpldCodec::DagJson => Code::DagJson,
-            IpldCodec::Raw => Code::Raw,
-        }
     }
 }

--- a/wnfs-wasm/src/fs/metadata.rs
+++ b/wnfs-wasm/src/fs/metadata.rs
@@ -1,8 +1,9 @@
 use super::utils::error;
 use crate::value;
 use js_sys::{Object, Reflect};
+use libipld_core::ipld::Ipld;
 use wasm_bindgen::JsValue;
-use wnfs::{common::Metadata, libipld::Ipld};
+use wnfs::common::Metadata;
 
 //--------------------------------------------------------------------------------------------------
 // Type Definitions

--- a/wnfs-wasm/src/fs/private/forest.rs
+++ b/wnfs-wasm/src/fs/private/forest.rs
@@ -3,12 +3,11 @@ use crate::{
     value,
 };
 use js_sys::{Array, Promise, Uint8Array};
+use libipld_core::cid::Cid;
 use std::rc::Rc;
 use wasm_bindgen::prelude::wasm_bindgen;
 use wasm_bindgen_futures::future_to_promise;
-use wnfs::{
-    common::BlockStore as WnfsBlockStore, libipld::Cid, private::PrivateForest as WnfsPrivateForest,
-};
+use wnfs::{common::BlockStore as WnfsBlockStore, private::PrivateForest as WnfsPrivateForest};
 
 //--------------------------------------------------------------------------------------------------
 // Type Definitions

--- a/wnfs-wasm/src/fs/private/node.rs
+++ b/wnfs-wasm/src/fs/private/node.rs
@@ -7,12 +7,12 @@ use crate::{
     value,
 };
 use js_sys::{Error, Promise, Uint8Array};
+use libipld_core::cid::Cid;
 use std::{collections::BTreeSet, rc::Rc};
 use wasm_bindgen::prelude::wasm_bindgen;
 use wasm_bindgen_futures::future_to_promise;
 use wnfs::{
     hamt::{ChangeType, KeyValueChange},
-    libipld::Cid,
     namefilter::Namefilter as WnfsNamefilter,
     private::PrivateNode as WnfsPrivateNode,
     traits::Id,

--- a/wnfs-wasm/src/fs/private/privateref.rs
+++ b/wnfs-wasm/src/fs/private/privateref.rs
@@ -1,8 +1,8 @@
 use crate::fs::utils::{self, error};
+use libipld_core::cid::Cid;
 use wasm_bindgen::prelude::wasm_bindgen;
 use wnfs::{
     common::HASH_BYTE_SIZE,
-    libipld::Cid,
     private::{PrivateRef as WnfsPrivateRef, TemporalKey, KEY_BYTE_SIZE},
 };
 

--- a/wnfs-wasm/src/fs/private/share.rs
+++ b/wnfs-wasm/src/fs/private/share.rs
@@ -4,11 +4,11 @@ use crate::{
     value,
 };
 use js_sys::{Array, Promise, Reflect};
+use libipld_core::cid::Cid;
 use std::rc::Rc;
 use wasm_bindgen::prelude::wasm_bindgen;
 use wasm_bindgen_futures::future_to_promise;
 use wnfs::{
-    libipld::Cid,
     private::share::{recipient, sharer, SharePayload as WnfsSharePayload},
     public::PublicLink,
 };

--- a/wnfs-wasm/src/fs/public/directory.rs
+++ b/wnfs-wasm/src/fs/public/directory.rs
@@ -10,12 +10,12 @@ use crate::{
 };
 use chrono::{DateTime, Utc};
 use js_sys::{Array, Date, Promise, Uint8Array};
+use libipld_core::cid::Cid;
 use std::rc::Rc;
 use wasm_bindgen::{prelude::wasm_bindgen, JsValue};
 use wasm_bindgen_futures::future_to_promise;
 use wnfs::{
     common::BlockStore as WnfsBlockStore,
-    libipld::Cid,
     public::{PublicDirectory as WnfsPublicDirectory, PublicNode as WnfsPublicNode},
     traits::Id,
 };

--- a/wnfs-wasm/src/fs/public/file.rs
+++ b/wnfs-wasm/src/fs/public/file.rs
@@ -6,12 +6,12 @@ use crate::{
 };
 use chrono::{DateTime, Utc};
 use js_sys::{Error, Promise, Uint8Array};
+use libipld_core::cid::Cid;
 use std::rc::Rc;
 use wasm_bindgen::{prelude::wasm_bindgen, JsValue};
 use wasm_bindgen_futures::future_to_promise;
 use wnfs::{
     common::BlockStore as WnfsBlockStore,
-    libipld::Cid,
     public::{PublicFile as WnfsPublicFile, PublicNode as WnfsPublicNode},
     traits::Id,
 };

--- a/wnfs-wasm/tests/mock.ts
+++ b/wnfs-wasm/tests/mock.ts
@@ -33,9 +33,9 @@ class MemoryBlockStore {
   }
 
   /** Retrieves an array of bytes from the block store with given CID. */
-  async putBlock(bytes: Uint8Array, code: number): Promise<Uint8Array> {
+  async putBlock(bytes: Uint8Array, codec: number): Promise<Uint8Array> {
     const hash = await sha256.digest(bytes);
-    const cid = CID.create(1, code, hash);
+    const cid = CID.create(1, codec, hash);
     this.store.set(cid.toString(), bytes);
     return cid.bytes;
   }

--- a/wnfs/Cargo.toml
+++ b/wnfs/Cargo.toml
@@ -26,7 +26,7 @@ async-stream = "0.3"
 async-trait = "0.1"
 chrono = { version = "0.4", default-features = false, features = ["clock", "std"] }
 futures = "0.3"
-libipld = { version = "0.16" } # TODO(appcypher): Change this to libipld_core once BlockStore codec has been changed to u64 value or enum
+libipld-core = { version = "0.16" }
 multihash = "0.19"
 once_cell = "1.16"
 proptest = { version = "1.1", optional = true }

--- a/wnfs/Cargo.toml
+++ b/wnfs/Cargo.toml
@@ -24,6 +24,7 @@ async-once-cell = "0.4"
 async-recursion = "1.0"
 async-stream = "0.3"
 async-trait = "0.1"
+bytes = "1.4.0"
 chrono = { version = "0.4", default-features = false, features = ["clock", "std"] }
 futures = "0.3"
 libipld-core = { version = "0.16" }

--- a/wnfs/examples/private.rs
+++ b/wnfs/examples/private.rs
@@ -1,8 +1,9 @@
 //! This example shows how to add a directory to a private forest (a HAMT) where encrypted ciphertexts are stored.
 //! It also shows how to retrieve encrypted nodes from the forest using `PrivateRef`s.
 
+use anyhow::Result;
 use chrono::Utc;
-use libipld::Cid;
+use libipld_core::cid::Cid;
 use rand::{thread_rng, RngCore};
 use std::rc::Rc;
 use wnfs::private::{PrivateDirectory, PrivateForest, PrivateNode, PrivateRef};
@@ -10,35 +11,34 @@ use wnfs_common::{BlockStore, MemoryBlockStore};
 use wnfs_namefilter::Namefilter;
 
 #[async_std::main]
-async fn main() {
+async fn main() -> Result<()> {
     // Create an in-memory block store.
-    let store = &mut MemoryBlockStore::default();
+    let store = &MemoryBlockStore::default();
 
     // Create a random number generator the private filesystem can use.
     let rng = &mut thread_rng();
 
     // Create a new private forest and get the cid to it.
-    let (forest_cid, private_ref) = create_forest_and_add_directory(store, rng).await;
+    let (forest_cid, private_ref) = create_forest_and_add_directory(store, rng).await?;
 
     // Deserialize private forest from the blockstore.
     let forest = store
         .get_deserializable::<PrivateForest>(&forest_cid)
-        .await
-        .unwrap();
+        .await?;
 
     // Fetch and decrypt a directory from the private forest using provided private ref.
-    let dir = PrivateNode::load(&private_ref, &forest, store)
-        .await
-        .unwrap();
+    let dir = PrivateNode::load(&private_ref, &forest, store).await?;
 
     // Print the directory.
     println!("{:#?}", dir);
+
+    Ok(())
 }
 
 async fn create_forest_and_add_directory(
     store: &impl BlockStore,
     rng: &mut impl RngCore,
-) -> (Cid, PrivateRef) {
+) -> Result<(Cid, PrivateRef)> {
     // Create the private forest (a HAMT), a map-like structure where file and directory ciphertexts are stored.
     let forest = &mut Rc::new(PrivateForest::new());
 
@@ -58,14 +58,13 @@ async fn create_forest_and_add_directory(
         store,
         rng,
     )
-    .await
-    .unwrap();
+    .await?;
 
     // Private ref contains data and keys for fetching and decrypting the directory node in the private forest.
-    let private_ref = dir.store(forest, store, rng).await.unwrap();
+    let private_ref = dir.store(forest, store, rng).await?;
 
     // Persist encoded private forest to the block store.
-    let forest_cid = store.put_async_serializable(forest).await.unwrap();
+    let forest_cid = store.put_async_serializable(forest).await?;
 
-    (forest_cid, private_ref)
+    Ok((forest_cid, private_ref))
 }

--- a/wnfs/examples/privateref.rs
+++ b/wnfs/examples/privateref.rs
@@ -12,7 +12,7 @@ use wnfs_namefilter::Namefilter;
 async fn main() -> anyhow::Result<()> {
     // ----------- Prerequisites -----------
 
-    let store = &mut MemoryBlockStore::default();
+    let store = &MemoryBlockStore::default();
     let rng = &mut thread_rng();
     let forest = &mut Rc::new(PrivateForest::new());
 

--- a/wnfs/examples/public.rs
+++ b/wnfs/examples/public.rs
@@ -1,13 +1,15 @@
 //! This example shows how the different operations you can perform under a public filesystem.
 //! More importantly, it shows the immutable nature of the filesystem.
 
+use anyhow::Result;
 use chrono::Utc;
+use libipld_core::cid::Cid;
 use std::rc::Rc;
-use wnfs::{libipld::Cid, public::PublicDirectory};
+use wnfs::public::PublicDirectory;
 use wnfs_common::MemoryBlockStore;
 
 #[async_std::main]
-async fn main() {
+async fn main() -> Result<()> {
     // Create an in-memory blockstore.
     let store = MemoryBlockStore::default();
 
@@ -17,8 +19,7 @@ async fn main() {
     // Add a /pictures/cats subdirectory.
     root_dir
         .mkdir(&["pictures".into(), "cats".into()], Utc::now(), &store)
-        .await
-        .unwrap();
+        .await?;
 
     // Add a file to /pictures/dogs directory.
     root_dir
@@ -28,18 +29,18 @@ async fn main() {
             Utc::now(),
             &store,
         )
-        .await
-        .unwrap();
+        .await?;
 
     // Delete /pictures/cats directory.
     root_dir
         .rm(&["pictures".into(), "cats".into()], &store)
-        .await
-        .unwrap();
+        .await?;
 
     // List all the children of /pictures directory.
     let result = root_dir.ls(&["pictures".into()], &store).await.unwrap();
 
     // Print the result.
     println!("Files in /pictures: {:#?}", result);
+
+    Ok(())
 }

--- a/wnfs/examples/tiered_blockstores.rs
+++ b/wnfs/examples/tiered_blockstores.rs
@@ -6,7 +6,7 @@
 use anyhow::Result;
 use async_trait::async_trait;
 use chrono::Utc;
-use libipld::{Cid, IpldCodec};
+use libipld_core::cid::Cid;
 use rand::thread_rng;
 use std::{borrow::Cow, rc::Rc};
 use wnfs::private::{PrivateDirectory, PrivateForest, PrivateNode};
@@ -14,7 +14,7 @@ use wnfs_common::{BlockStore, MemoryBlockStore};
 use wnfs_namefilter::Namefilter;
 
 #[async_std::main]
-async fn main() {
+async fn main() -> Result<()> {
     // Create a block store that holds all 'hot' data:
     let mut hot_store = MemoryBlockStore::default();
 
@@ -44,14 +44,12 @@ async fn main() {
     // on the path we may have already created before.
     let file = directory
         .open_file_mut(&file_path, true, Utc::now(), forest, &mut hot_store, rng)
-        .await
-        .unwrap();
+        .await?;
 
     // `set_content` actually writes the data blocks to the blockstore in chunks,
     // so for this we provide the `cold_store`.
     file.set_content(Utc::now(), &video[..], forest, &mut cold_store, rng)
-        .await
-        .unwrap();
+        .await?;
 
     // When storing the hierarchy data blocks, we use the `hot_store`:
     let private_ref = directory.store(forest, &mut hot_store, rng).await.unwrap();
@@ -61,18 +59,11 @@ async fn main() {
     let private_root_cid = hot_store.put_async_serializable(forest).await.unwrap();
 
     // We can now read out our data back:
-    let forest: Rc<PrivateForest> = Rc::new(
-        hot_store
-            .get_deserializable(&private_root_cid)
-            .await
-            .unwrap(),
-    );
+    let forest: Rc<PrivateForest> = Rc::new(hot_store.get_deserializable(&private_root_cid).await?);
 
     let directory = PrivateNode::load(&private_ref, &forest, &hot_store)
-        .await
-        .unwrap()
-        .as_dir()
-        .unwrap();
+        .await?
+        .as_dir()?;
 
     // Reading the file's data will fail when only provided the hot store:
     assert!(directory
@@ -92,9 +83,11 @@ async fn main() {
         .await
         .unwrap();
 
-    println!("{}", String::from_utf8(result.clone()).unwrap());
+    println!("{}", String::from_utf8(result.clone())?);
 
-    assert_eq!(result, video.to_vec())
+    assert_eq!(result, video.to_vec());
+
+    Ok(())
 }
 
 struct TieredBlockStore<H: BlockStore, C: BlockStore> {
@@ -113,7 +106,7 @@ impl<H: BlockStore, C: BlockStore> BlockStore for TieredBlockStore<H, C> {
         }
     }
 
-    async fn put_block(&self, bytes: Vec<u8>, codec: IpldCodec) -> Result<Cid> {
+    async fn put_block(&self, bytes: Vec<u8>, codec: u64) -> Result<Cid> {
         self.hot.put_block(bytes, codec).await
     }
 }

--- a/wnfs/examples/tiered_blockstores.rs
+++ b/wnfs/examples/tiered_blockstores.rs
@@ -5,10 +5,11 @@
 
 use anyhow::Result;
 use async_trait::async_trait;
+use bytes::Bytes;
 use chrono::Utc;
 use libipld_core::cid::Cid;
 use rand::thread_rng;
-use std::{borrow::Cow, rc::Rc};
+use std::rc::Rc;
 use wnfs::private::{PrivateDirectory, PrivateForest, PrivateNode};
 use wnfs_common::{BlockStore, MemoryBlockStore};
 use wnfs_namefilter::Namefilter;
@@ -97,7 +98,7 @@ struct TieredBlockStore<H: BlockStore, C: BlockStore> {
 
 #[async_trait(?Send)]
 impl<H: BlockStore, C: BlockStore> BlockStore for TieredBlockStore<H, C> {
-    async fn get_block(&self, cid: &Cid) -> Result<Cow<Vec<u8>>> {
+    async fn get_block(&self, cid: &Cid) -> Result<Bytes> {
         match self.hot.get_block(cid).await {
             Ok(block) => Ok(block),
             // We could technically get better about this
@@ -106,7 +107,7 @@ impl<H: BlockStore, C: BlockStore> BlockStore for TieredBlockStore<H, C> {
         }
     }
 
-    async fn put_block(&self, bytes: Vec<u8>, codec: u64) -> Result<Cid> {
+    async fn put_block(&self, bytes: impl Into<Bytes>, codec: u64) -> Result<Cid> {
         self.hot.put_block(bytes, codec).await
     }
 }

--- a/wnfs/src/lib.rs
+++ b/wnfs/src/lib.rs
@@ -15,7 +15,6 @@ pub(crate) mod root_tree;
 pub mod traits;
 mod utils;
 
-pub use libipld;
 pub mod rand_core {
     pub use rand_core::RngCore;
 }

--- a/wnfs/src/private/directory.rs
+++ b/wnfs/src/private/directory.rs
@@ -7,7 +7,7 @@ use crate::{error::FsError, traits::Id, SearchResult, WNFS_VERSION};
 use anyhow::{bail, ensure, Result};
 use async_once_cell::OnceCell;
 use chrono::{DateTime, Utc};
-use libipld::Cid;
+use libipld_core::cid::Cid;
 use rand_core::RngCore;
 use std::{
     collections::{BTreeMap, BTreeSet},
@@ -16,7 +16,7 @@ use std::{
 };
 use wnfs_common::{
     utils::{self, error},
-    BlockStore, HashOutput, Metadata, PathNodes, PathNodesResult,
+    BlockStore, HashOutput, Metadata, PathNodes, PathNodesResult, CODEC_RAW,
 };
 use wnfs_namefilter::Namefilter;
 
@@ -151,7 +151,7 @@ impl PrivateDirectory {
         ratchet_seed: HashOutput,
         inumber: HashOutput,
         forest: &mut Rc<PrivateForest>,
-        store: &mut B,
+        store: &B,
         rng: &mut R,
     ) -> Result<Rc<Self>> {
         let dir = Rc::new(Self::with_seed(
@@ -255,7 +255,7 @@ impl PrivateDirectory {
     ///
     /// #[async_std::main]
     /// async fn main() {
-    ///     let store = &mut MemoryBlockStore::default();
+    ///     let store = &MemoryBlockStore::default();
     ///     let rng = &mut thread_rng();
     ///     let forest = &mut Rc::new(PrivateForest::new());
     ///     let root_dir = &mut Rc::new(PrivateDirectory::new(
@@ -487,7 +487,7 @@ impl PrivateDirectory {
     ///
     /// #[async_std::main]
     /// async fn main() {
-    ///     let store = &mut MemoryBlockStore::default();
+    ///     let store = &MemoryBlockStore::default();
     ///     let rng = &mut thread_rng();
     ///     let forest = &mut Rc::new(PrivateForest::new());
     ///     let root_dir = &mut Rc::new(PrivateDirectory::new(
@@ -545,7 +545,7 @@ impl PrivateDirectory {
     ///
     /// #[async_std::main]
     /// async fn main() {
-    ///     let store = &mut MemoryBlockStore::default();
+    ///     let store = &MemoryBlockStore::default();
     ///     let rng = &mut thread_rng();
     ///     let forest = &mut Rc::new(PrivateForest::new());
     ///     let root_dir = &mut Rc::new(PrivateDirectory::new(
@@ -711,7 +711,7 @@ impl PrivateDirectory {
     ///
     /// #[async_std::main]
     /// async fn main() {
-    ///     let store = &mut MemoryBlockStore::default();
+    ///     let store = &MemoryBlockStore::default();
     ///     let rng = &mut thread_rng();
     ///     let forest = &mut Rc::new(PrivateForest::new());
     ///     let root_dir = &mut Rc::new(PrivateDirectory::new(
@@ -811,7 +811,7 @@ impl PrivateDirectory {
     ///
     /// #[async_std::main]
     /// async fn main() {
-    ///     let store = &mut MemoryBlockStore::default();
+    ///     let store = &MemoryBlockStore::default();
     ///     let rng = &mut thread_rng();
     ///     let forest = &mut Rc::new(PrivateForest::new());
     ///     let mut init_dir = PrivateDirectory::new_and_store(
@@ -871,7 +871,7 @@ impl PrivateDirectory {
     ///
     /// #[async_std::main]
     /// async fn main() {
-    ///     let store = &mut MemoryBlockStore::default();
+    ///     let store = &MemoryBlockStore::default();
     ///     let rng = &mut thread_rng();
     ///     let forest = &mut Rc::new(PrivateForest::new());
     ///     let root_dir = &mut Rc::new(PrivateDirectory::new(
@@ -926,7 +926,7 @@ impl PrivateDirectory {
     ///
     /// #[async_std::main]
     /// async fn main() {
-    ///     let store = &mut MemoryBlockStore::default();
+    ///     let store = &MemoryBlockStore::default();
     ///     let rng = &mut thread_rng();
     ///     let forest = &mut Rc::new(PrivateForest::new());
     ///     let root_dir = &mut Rc::new(PrivateDirectory::new(
@@ -1019,7 +1019,7 @@ impl PrivateDirectory {
     ///
     /// #[async_std::main]
     /// async fn main() {
-    ///     let store = &mut MemoryBlockStore::default();
+    ///     let store = &MemoryBlockStore::default();
     ///     let rng = &mut thread_rng();
     ///     let forest = &mut Rc::new(PrivateForest::new());
     ///     let root_dir = &mut Rc::new(PrivateDirectory::new(
@@ -1133,7 +1133,7 @@ impl PrivateDirectory {
     ///
     /// #[async_std::main]
     /// async fn main() {
-    ///     let store = &mut MemoryBlockStore::default();
+    ///     let store = &MemoryBlockStore::default();
     ///     let rng = &mut thread_rng();
     ///     let forest = &mut Rc::new(PrivateForest::new());
     ///     let root_dir = &mut Rc::new(PrivateDirectory::new(
@@ -1221,7 +1221,7 @@ impl PrivateDirectory {
     ///
     /// #[async_std::main]
     /// async fn main() {
-    ///     let store = &mut MemoryBlockStore::default();
+    ///     let store = &MemoryBlockStore::default();
     ///     let rng = &mut thread_rng();
     ///     let forest = &mut Rc::new(PrivateForest::new());
     ///     let root_dir = &mut Rc::new(PrivateDirectory::new(
@@ -1307,7 +1307,7 @@ impl PrivateDirectory {
     ///
     /// #[async_std::main]
     /// async fn main() {
-    ///     let store = &mut MemoryBlockStore::default();
+    ///     let store = &MemoryBlockStore::default();
     ///     let rng = &mut thread_rng();
     ///     let forest = &mut Rc::new(PrivateForest::new());
     ///     let dir = &mut Rc::new(PrivateDirectory::new(
@@ -1449,7 +1449,7 @@ impl PrivateDirectoryContent {
                 let block = snapshot_key.encrypt(&bytes, rng)?;
 
                 // Store content section in blockstore and get Cid.
-                store.put_block(block, libipld::IpldCodec::Raw).await
+                store.put_block(block, CODEC_RAW).await
             })
             .await?)
     }
@@ -1522,7 +1522,7 @@ mod tests {
             Utc::now(),
             rng,
         ));
-        let store = &mut MemoryBlockStore::default();
+        let store = &MemoryBlockStore::default();
         let forest = &mut Rc::new(PrivateForest::new());
 
         let content = b"Hello, World!".to_vec();
@@ -1575,7 +1575,7 @@ mod tests {
             Utc::now(),
             rng,
         ));
-        let store = &mut MemoryBlockStore::default();
+        let store = &MemoryBlockStore::default();
         let forest = &mut Rc::new(PrivateForest::new());
 
         root_dir
@@ -1656,7 +1656,7 @@ mod tests {
             Utc::now(),
             rng,
         ));
-        let store = &mut MemoryBlockStore::default();
+        let store = &MemoryBlockStore::default();
         let forest = &mut Rc::new(PrivateForest::new());
 
         root_dir
@@ -1687,7 +1687,7 @@ mod tests {
             Utc::now(),
             rng,
         ));
-        let store = &mut MemoryBlockStore::default();
+        let store = &MemoryBlockStore::default();
         let forest = &mut Rc::new(PrivateForest::new());
 
         root_dir
@@ -1745,7 +1745,7 @@ mod tests {
             Utc::now(),
             rng,
         ));
-        let store = &mut MemoryBlockStore::default();
+        let store = &MemoryBlockStore::default();
         let forest = &mut Rc::new(PrivateForest::new());
 
         root_dir
@@ -1805,7 +1805,7 @@ mod tests {
             Utc::now(),
             rng,
         ));
-        let store = &mut MemoryBlockStore::default();
+        let store = &MemoryBlockStore::default();
         let forest = &mut Rc::new(PrivateForest::new());
 
         root_dir
@@ -1831,7 +1831,7 @@ mod tests {
 
     #[test(async_std::test)]
     async fn search_latest_finds_the_most_recent() {
-        let store = &mut MemoryBlockStore::default();
+        let store = &MemoryBlockStore::default();
         let forest = &mut Rc::new(PrivateForest::new());
         let rng = &mut rand::thread_rng();
         let root_dir = &mut Rc::new(PrivateDirectory::new(
@@ -1885,7 +1885,7 @@ mod tests {
     #[async_std::test]
     async fn cp_can_copy_sub_directory_to_another_valid_location_with_updated_ancestry() {
         let rng = &mut TestRng::deterministic_rng(RngAlgorithm::ChaCha);
-        let store = &mut MemoryBlockStore::default();
+        let store = &MemoryBlockStore::default();
         let forest = &mut Rc::new(PrivateForest::new());
         let root_dir = &mut Rc::new(PrivateDirectory::new(
             Namefilter::default(),
@@ -1983,7 +1983,7 @@ mod tests {
     #[async_std::test]
     async fn mv_can_move_sub_directory_to_another_valid_location_with_updated_ancestry() {
         let rng = &mut TestRng::deterministic_rng(RngAlgorithm::ChaCha);
-        let store = &mut MemoryBlockStore::default();
+        let store = &MemoryBlockStore::default();
         let forest = &mut Rc::new(PrivateForest::new());
         let root_dir = &mut Rc::new(PrivateDirectory::new(
             Namefilter::default(),
@@ -2080,7 +2080,7 @@ mod tests {
     #[async_std::test]
     async fn mv_cannot_move_sub_directory_to_invalid_location() {
         let rng = &mut TestRng::deterministic_rng(RngAlgorithm::ChaCha);
-        let store = &mut MemoryBlockStore::default();
+        let store = &MemoryBlockStore::default();
         let forest = &mut Rc::new(PrivateForest::new());
         let root_dir = &mut Rc::new(PrivateDirectory::new(
             Namefilter::default(),
@@ -2123,7 +2123,7 @@ mod tests {
     #[async_std::test]
     async fn mv_can_rename_directories() {
         let rng = &mut TestRng::deterministic_rng(RngAlgorithm::ChaCha);
-        let store = &mut MemoryBlockStore::default();
+        let store = &MemoryBlockStore::default();
         let forest = &mut Rc::new(PrivateForest::new());
         let root_dir = &mut Rc::new(PrivateDirectory::new(
             Namefilter::default(),
@@ -2176,7 +2176,7 @@ mod tests {
     #[async_std::test]
     async fn mv_fails_moving_directories_to_files() {
         let rng = &mut TestRng::deterministic_rng(RngAlgorithm::ChaCha);
-        let store = &mut MemoryBlockStore::default();
+        let store = &MemoryBlockStore::default();
         let forest = &mut Rc::new(PrivateForest::new());
         let root_dir = &mut Rc::new(PrivateDirectory::new(
             Namefilter::default(),
@@ -2227,7 +2227,7 @@ mod tests {
     #[async_std::test]
     async fn write_doesnt_generate_previous_link() {
         let rng = &mut TestRng::deterministic_rng(RngAlgorithm::ChaCha);
-        let store = &mut MemoryBlockStore::new();
+        let store = &MemoryBlockStore::new();
         let forest = &mut Rc::new(PrivateForest::new());
         let old_dir = &mut Rc::new(PrivateDirectory::new(
             Namefilter::default(),
@@ -2256,7 +2256,7 @@ mod tests {
     #[async_std::test]
     async fn store_before_write_generates_previous_link() {
         let rng = &mut TestRng::deterministic_rng(RngAlgorithm::ChaCha);
-        let store = &mut MemoryBlockStore::new();
+        let store = &MemoryBlockStore::new();
         let forest = &mut Rc::new(PrivateForest::new());
         let old_dir = &mut Rc::new(PrivateDirectory::new(
             Namefilter::default(),

--- a/wnfs/src/private/forest.rs
+++ b/wnfs/src/private/forest.rs
@@ -4,7 +4,7 @@ use anyhow::Result;
 use async_stream::stream;
 use async_trait::async_trait;
 use futures::Stream;
-use libipld::Cid;
+use libipld_core::cid::Cid;
 use serde::{Deserialize, Deserializer, Serializer};
 use sha3::Sha3_256;
 use std::{collections::BTreeSet, rc::Rc};
@@ -64,7 +64,7 @@ impl PrivateForest {
     ///
     /// #[async_std::main]
     /// async fn main() {
-    ///     let store = &mut MemoryBlockStore::default();
+    ///     let store = &MemoryBlockStore::default();
     ///     let rng = &mut thread_rng();
     ///     let forest = &mut Rc::new(PrivateForest::new());
     ///     let dir = Rc::new(PrivateDirectory::new(
@@ -218,7 +218,7 @@ where
     ///
     /// #[async_std::main]
     /// async fn main() {
-    ///     let store = &mut MemoryBlockStore::default();
+    ///     let store = &MemoryBlockStore::default();
     ///     let rng = &mut thread_rng();
     ///
     ///     let ratchet_seed = rng.gen::<[u8; 32]>();
@@ -321,7 +321,7 @@ mod tests {
     use wnfs_hamt::{HashNibbles, Node};
 
     mod helper {
-        use libipld::{Cid, Multihash};
+        use libipld_core::{cid::Cid, multihash::Multihash};
         use once_cell::sync::Lazy;
         use rand::{thread_rng, RngCore};
         use wnfs_common::{utils, HashOutput};
@@ -393,7 +393,7 @@ mod tests {
 
     #[async_std::test]
     async fn inserted_items_can_be_fetched() {
-        let store = &mut MemoryBlockStore::new();
+        let store = &MemoryBlockStore::new();
         let forest = &mut Rc::new(PrivateForest::new());
         let rng = &mut TestRng::deterministic_rng(RngAlgorithm::ChaCha);
 
@@ -414,7 +414,7 @@ mod tests {
 
     #[async_std::test]
     async fn multivalue_conflict_can_be_fetched_individually() {
-        let store = &mut MemoryBlockStore::new();
+        let store = &MemoryBlockStore::new();
         let forest = &mut Rc::new(PrivateForest::new());
         let rng = &mut TestRng::deterministic_rng(RngAlgorithm::ChaCha);
 
@@ -470,7 +470,7 @@ mod tests {
 
     #[async_std::test]
     async fn can_merge_nodes_with_different_structure_and_modified_changes() {
-        let store = &mut MemoryBlockStore::new();
+        let store = &MemoryBlockStore::new();
         let rng = &mut TestRng::deterministic_rng(RngAlgorithm::ChaCha);
 
         // A node that adds the first 3 pairs of HASH_KV_PAIRS.

--- a/wnfs/src/private/node/header.rs
+++ b/wnfs/src/private/node/header.rs
@@ -1,13 +1,13 @@
 use super::TemporalKey;
 use crate::private::RevisionRef;
 use anyhow::Result;
-use libipld::{Cid, IpldCodec};
+use libipld_core::cid::Cid;
 use rand_core::RngCore;
 use serde::{Deserialize, Serialize};
 use sha3::Sha3_256;
 use skip_ratchet::Ratchet;
 use std::fmt::Debug;
-use wnfs_common::{utils, BlockStore, HashOutput, HASH_BYTE_SIZE};
+use wnfs_common::{utils, BlockStore, HashOutput, CODEC_RAW, HASH_BYTE_SIZE};
 use wnfs_hamt::Hasher;
 use wnfs_namefilter::Namefilter;
 
@@ -218,7 +218,7 @@ impl PrivateNodeHeader {
         let temporal_key = self.derive_temporal_key();
         let cbor_bytes = serde_ipld_dagcbor::to_vec(self)?;
         let ciphertext = temporal_key.key_wrap_encrypt(&cbor_bytes)?;
-        store.put_block(ciphertext, IpldCodec::Raw).await
+        store.put_block(ciphertext, CODEC_RAW).await
     }
 
     /// Loads a private node header from a given CID linking to the ciphertext block

--- a/wnfs/src/private/node/node.rs
+++ b/wnfs/src/private/node/node.rs
@@ -12,7 +12,7 @@ use async_once_cell::OnceCell;
 use async_recursion::async_recursion;
 use chrono::{DateTime, Utc};
 use futures::StreamExt;
-use libipld::Cid;
+use libipld_core::cid::Cid;
 use rand_core::RngCore;
 use skip_ratchet::{seek::JumpSize, RatchetSeeker};
 use std::{cmp::Ordering, collections::BTreeSet, fmt::Debug, rc::Rc};
@@ -332,7 +332,7 @@ impl PrivateNode {
     ///
     /// #[async_std::main]
     /// async fn main() {
-    ///     let store = &mut MemoryBlockStore::default();
+    ///     let store = &MemoryBlockStore::default();
     ///     let rng = &mut thread_rng();
     ///     let forest = &mut Rc::new(PrivateForest::new());
     ///
@@ -449,7 +449,7 @@ impl PrivateNode {
     ///
     /// #[async_std::main]
     /// async fn main() {
-    ///     let store = &mut MemoryBlockStore::default();
+    ///     let store = &MemoryBlockStore::default();
     ///     let rng = &mut thread_rng();
     ///     let forest = &mut Rc::new(PrivateForest::new());
     ///     let dir = Rc::new(PrivateDirectory::new(
@@ -572,7 +572,7 @@ mod tests {
         let rng = &mut TestRng::deterministic_rng(RngAlgorithm::ChaCha);
         let content = b"Lorem ipsum dolor sit amet";
         let forest = &mut Rc::new(PrivateForest::new());
-        let store = &mut MemoryBlockStore::new();
+        let store = &MemoryBlockStore::new();
 
         let file = Rc::new(
             PrivateFile::with_content(

--- a/wnfs/src/private/node/serializable.rs
+++ b/wnfs/src/private/node/serializable.rs
@@ -1,5 +1,5 @@
 use crate::private::{encrypted::Encrypted, FileContent, PrivateRefSerializable};
-use libipld::Cid;
+use libipld_core::cid::Cid;
 use semver::Version;
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;

--- a/wnfs/src/private/previous.rs
+++ b/wnfs/src/private/previous.rs
@@ -4,7 +4,7 @@ use super::{
 };
 use crate::error::FsError;
 use anyhow::{bail, Result};
-use libipld::Cid;
+use libipld_core::cid::Cid;
 use skip_ratchet::{ratchet::PreviousIterator, Ratchet};
 use std::{collections::BTreeSet, rc::Rc};
 use wnfs_common::{BlockStore, PathNodes, PathNodesResult};

--- a/wnfs/src/private/privateref.rs
+++ b/wnfs/src/private/privateref.rs
@@ -2,7 +2,7 @@ use super::{PrivateNodeHeader, SnapshotKey, TemporalKey, KEY_BYTE_SIZE};
 use crate::error::{AesError, FsError};
 use aes_kw::KekAes256;
 use anyhow::Result;
-use libipld::Cid;
+use libipld_core::cid::Cid;
 use serde::{de::Error as DeError, ser::Error as SerError, Deserialize, Serialize};
 use std::fmt::Debug;
 use wnfs_common::HashOutput;
@@ -228,7 +228,7 @@ mod tests {
     #[async_std::test]
     async fn can_create_revisionref_deterministically_with_user_provided_seeds() {
         let rng = &mut TestRng::deterministic_rng(RngAlgorithm::ChaCha);
-        let store = &mut MemoryBlockStore::default();
+        let store = &MemoryBlockStore::default();
         let forest = &mut Rc::new(PrivateForest::new());
         let ratchet_seed = utils::get_random_bytes::<32>(rng);
         let inumber = utils::get_random_bytes::<32>(rng);

--- a/wnfs/src/public/directory.rs
+++ b/wnfs/src/public/directory.rs
@@ -9,7 +9,7 @@ use async_once_cell::OnceCell;
 use async_recursion::async_recursion;
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
-use libipld::Cid;
+use libipld_core::cid::Cid;
 use serde::{
     de::Error as DeError, ser::Error as SerError, Deserialize, Deserializer, Serialize, Serializer,
 };
@@ -308,14 +308,14 @@ impl PublicDirectory {
     ///     public::PublicDirectory,
     ///     common::MemoryBlockStore
     /// };
-    /// use libipld::cid::Cid;
+    /// use libipld_core::cid::Cid;
     /// use std::rc::Rc;
     /// use chrono::Utc;
     ///
     /// #[async_std::main]
     /// async fn main() {
     ///     let dir = &mut Rc::new(PublicDirectory::new(Utc::now()));
-    ///     let store = &mut MemoryBlockStore::default();
+    ///     let store = &MemoryBlockStore::default();
     ///     let cid = Cid::default();
     ///
     ///     dir
@@ -357,7 +357,7 @@ impl PublicDirectory {
     ///     public::PublicDirectory,
     ///     common::MemoryBlockStore
     /// };
-    /// use libipld::cid::Cid;
+    /// use libipld_core::cid::Cid;
     /// use std::rc::Rc;
     /// use chrono::Utc;
     ///
@@ -461,7 +461,7 @@ impl PublicDirectory {
     ///     public::PublicDirectory,
     ///     common::MemoryBlockStore
     /// };
-    /// use libipld::cid::Cid;
+    /// use libipld_core::cid::Cid;
     /// use std::rc::Rc;
     /// use chrono::Utc;
     ///
@@ -523,7 +523,7 @@ impl PublicDirectory {
     ///     public::PublicDirectory,
     ///     common::MemoryBlockStore
     /// };
-    /// use libipld::cid::Cid;
+    /// use libipld_core::cid::Cid;
     /// use std::rc::Rc;
     /// use chrono::Utc;
     ///
@@ -592,7 +592,7 @@ impl PublicDirectory {
     ///     public::PublicDirectory,
     ///     common::MemoryBlockStore
     /// };
-    /// use libipld::cid::Cid;
+    /// use libipld_core::cid::Cid;
     /// use std::rc::Rc;
     /// use chrono::Utc;
     ///
@@ -673,7 +673,7 @@ impl PublicDirectory {
     ///
     /// #[async_std::main]
     /// async fn main() {
-    ///     let store = &mut MemoryBlockStore::default();
+    ///     let store = &MemoryBlockStore::default();
     ///     let dir = PublicDirectory::new(Utc::now());
     ///
     ///     let cid = dir.store(store).await.unwrap();
@@ -796,7 +796,7 @@ impl<'de> Deserialize<'de> for PublicDirectory {
 mod tests {
     use super::*;
     use chrono::Utc;
-    use libipld::Ipld;
+    use libipld_core::ipld::Ipld;
     use wnfs_common::MemoryBlockStore;
 
     #[async_std::test]
@@ -1158,7 +1158,7 @@ mod tests {
     #[async_std::test]
     async fn previous_links_get_set() {
         let time = Utc::now();
-        let store = &mut MemoryBlockStore::default();
+        let store = &MemoryBlockStore::default();
         let root_dir = &mut Rc::new(PublicDirectory::new(time));
         let previous_cid = root_dir.store(store).await.unwrap();
 
@@ -1182,7 +1182,7 @@ mod tests {
     #[async_std::test]
     async fn prepare_next_revision_shortcuts_if_possible() {
         let time = Utc::now();
-        let store = &mut MemoryBlockStore::default();
+        let store = &MemoryBlockStore::default();
         let root_dir = &mut Rc::new(PublicDirectory::new(time));
 
         let previous_cid = &root_dir.store(store).await.unwrap();

--- a/wnfs/src/public/file.rs
+++ b/wnfs/src/public/file.rs
@@ -5,7 +5,7 @@ use crate::{error::FsError, traits::Id, WNFS_VERSION};
 use anyhow::{bail, Result};
 use async_once_cell::OnceCell;
 use chrono::{DateTime, Utc};
-use libipld::Cid;
+use libipld_core::cid::Cid;
 use serde::{de::Error as DeError, Deserialize, Deserializer, Serialize, Serializer};
 use std::{collections::BTreeSet, rc::Rc};
 use wnfs_common::{BlockStore, Metadata, RemembersCid};
@@ -17,7 +17,7 @@ use wnfs_common::{BlockStore, Metadata, RemembersCid};
 /// ```
 /// use wnfs::public::PublicFile;
 /// use chrono::Utc;
-/// use libipld::Cid;
+/// use libipld_core::cid::Cid;
 ///
 /// let file = PublicFile::new(Utc::now(), Cid::default());
 ///
@@ -43,7 +43,7 @@ impl PublicFile {
     /// ```
     /// use wnfs::public::PublicFile;
     /// use chrono::Utc;
-    /// use libipld::Cid;
+    /// use libipld_core::cid::Cid;
     ///
     /// let file = PublicFile::new(Utc::now(), Cid::default());
     ///
@@ -111,7 +111,7 @@ impl PublicFile {
     ///     common::MemoryBlockStore
     /// };
     /// use chrono::Utc;
-    /// use libipld::Cid;
+    /// use libipld_core::cid::Cid;
     ///
     /// #[async_std::main]
     /// async fn main() {
@@ -213,16 +213,15 @@ impl RemembersCid for PublicFile {
 mod tests {
     use super::*;
     use chrono::Utc;
-    use libipld::IpldCodec;
-    use wnfs_common::MemoryBlockStore;
+    use wnfs_common::{MemoryBlockStore, CODEC_RAW};
 
     #[async_std::test]
     async fn previous_links_get_set() {
         let time = Utc::now();
-        let store = &mut MemoryBlockStore::default();
+        let store = &MemoryBlockStore::default();
 
         let content_cid = store
-            .put_block(b"Hello World".to_vec(), IpldCodec::Raw)
+            .put_block(b"Hello World".to_vec(), CODEC_RAW)
             .await
             .unwrap();
 
@@ -239,9 +238,9 @@ mod tests {
     #[async_std::test]
     async fn prepare_next_revision_shortcuts_if_possible() {
         let time = Utc::now();
-        let store = &mut MemoryBlockStore::default();
+        let store = &MemoryBlockStore::default();
         let content_cid = store
-            .put_block(b"Hello World".to_vec(), IpldCodec::Raw)
+            .put_block(b"Hello World".to_vec(), CODEC_RAW)
             .await
             .unwrap();
 

--- a/wnfs/src/public/link.rs
+++ b/wnfs/src/public/link.rs
@@ -2,7 +2,7 @@
 
 use super::{PublicDirectory, PublicFile, PublicNode};
 use anyhow::Result;
-use libipld::Cid;
+use libipld_core::cid::Cid;
 use std::rc::Rc;
 use wnfs_common::{BlockStore, Link};
 

--- a/wnfs/src/public/node/node.rs
+++ b/wnfs/src/public/node/node.rs
@@ -10,7 +10,7 @@ use anyhow::{bail, Result};
 use async_once_cell::OnceCell;
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
-use libipld::Cid;
+use libipld_core::cid::Cid;
 use serde::{de::Error as DeError, Deserialize, Deserializer, Serialize, Serializer};
 use std::{collections::BTreeSet, rc::Rc};
 use wnfs_common::{AsyncSerialize, BlockStore, RemembersCid};
@@ -86,7 +86,7 @@ impl PublicNode {
     /// ```
     /// use wnfs::public::{PublicDirectory, PublicNode};
     /// use chrono::Utc;
-    /// use libipld::Cid;
+    /// use libipld_core::cid::Cid;
     /// use std::{rc::Rc, collections::BTreeSet};
     ///
     /// let dir = Rc::new(PublicDirectory::new(Utc::now()));
@@ -180,7 +180,7 @@ impl PublicNode {
     /// use wnfs::public::{PublicFile, PublicNode};
     /// use chrono::Utc;
     /// use std::rc::Rc;
-    /// use libipld::Cid;
+    /// use libipld_core::cid::Cid;
     ///
     /// let file = Rc::new(PublicFile::new(Utc::now(), Cid::default()));
     /// let node = PublicNode::File(Rc::clone(&file));
@@ -220,7 +220,7 @@ impl PublicNode {
     /// use wnfs::public::{PublicFile, PublicNode};
     /// use chrono::Utc;
     /// use std::rc::Rc;
-    /// use libipld::Cid;
+    /// use libipld_core::cid::Cid;
     ///
     /// let file = Rc::new(PublicFile::new(Utc::now(), Cid::default()));
     /// let node = PublicNode::File(file);
@@ -331,12 +331,12 @@ impl RemembersCid for PublicNode {
 mod tests {
     use crate::public::{PublicDirectory, PublicFile, PublicNode};
     use chrono::Utc;
-    use libipld::Cid;
+    use libipld_core::cid::Cid;
     use wnfs_common::MemoryBlockStore;
 
     #[async_std::test]
     async fn serialized_public_node_can_be_deserialized() {
-        let store = &mut MemoryBlockStore::default();
+        let store = &MemoryBlockStore::default();
         let dir_node: PublicNode = PublicDirectory::new(Utc::now()).into();
         let file_node: PublicNode = PublicFile::new(Utc::now(), Cid::default()).into();
 

--- a/wnfs/src/public/node/serializable.rs
+++ b/wnfs/src/public/node/serializable.rs
@@ -1,4 +1,4 @@
-use libipld::Cid;
+use libipld_core::cid::Cid;
 use semver::Version;
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;

--- a/wnfs/src/root_tree.rs
+++ b/wnfs/src/root_tree.rs
@@ -10,7 +10,7 @@ use crate::{
 };
 use anyhow::{bail, Result};
 use chrono::{DateTime, Utc};
-use libipld::{Cid, IpldCodec};
+use libipld_core::cid::Cid;
 #[cfg(test)]
 use rand::rngs::ThreadRng;
 use rand_core::RngCore;
@@ -19,7 +19,7 @@ use serde::{Deserialize, Serialize};
 use std::{collections::HashMap, rc::Rc};
 #[cfg(test)]
 use wnfs_common::MemoryBlockStore;
-use wnfs_common::{BlockStore, Metadata};
+use wnfs_common::{BlockStore, Metadata, CODEC_RAW};
 
 //--------------------------------------------------------------------------------------------------
 // Types
@@ -150,13 +150,13 @@ where
 
         match first.as_str() {
             "public" => {
-                let cid = self.store.put_block(content, IpldCodec::Raw).await?;
+                let cid = self.store.put_block(content, CODEC_RAW).await?;
                 self.public_root
                     .write(path_segments, cid, time, self.store)
                     .await
             }
             "exchange" => {
-                let cid = self.store.put_block(content, IpldCodec::Raw).await?;
+                let cid = self.store.put_block(content, CODEC_RAW).await?;
                 self.exchange_root
                     .write(path_segments, cid, time, self.store)
                     .await


### PR DESCRIPTION
This pull request addresses the following [suggestions and feedback](#251) made at ipfs thing. Todo item 3 has been implemented in PR #257. 

We want to limit wnfs dependency on `libipld`. Changing the codec type from `IpldCodec` to `u64` lets us replace `libipld` with `libipld_core` in `wnfs` and `wnfs-wasm` crates. In a way this also removes the limitation of `libipld::IpldCodec` enum. 

We think `bytes::Bytes` is a much more efficient way of getting bytes to and from a BlockStore (for BlockStores implementation that care about that sort of thing). Previously we used `Cow<Vec<u8>>` and we have considered `Read/Write` but `bytes::Bytes` is just more flexible. This change basically makes block storage and retrieval more efficient and flexible while maintaining `no_std` compatibility.


<!-- Summary of the PR -->

This PR implements the following **features**

- [x] Replace IPLDCodec with u64.
- [x] Remove `wnfs` dependency on libipld.
- [x] Prefer `bytes::Bytes` to `Vec<u8>` in BlockStore interface. 

<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

## Test plan (required)
-  Testing
    
    ```bash
    scripts/rs-wnfs test
    ```

## Closing issues

<!-- Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such). -->

Fixes #251
