### PR TITLE
fix: Improve performance of `get_revision_name()`

### DIFF
--- a/wnfs/src/private/directory.rs
+++ b/wnfs/src/private/directory.rs
@@ -1270,7 +1270,7 @@ impl PrivateDirectory {
             .await?;
 
         forest
-            .put_encrypted(&name_with_revision, [header_cid, content_cid], store)
+            .put_encrypted(name_with_revision, [header_cid, content_cid], store)
             .await?;
 
         Ok(self

--- a/wnfs/src/private/file.rs
+++ b/wnfs/src/private/file.rs
@@ -703,7 +703,7 @@ impl PrivateFile {
             .await?;
 
         forest
-            .put_encrypted(&name_with_revision, [header_cid, content_cid], store)
+            .put_encrypted(name_with_revision, [header_cid, content_cid], store)
             .await?;
 
         Ok(self

--- a/wnfs/src/private/node/header.rs
+++ b/wnfs/src/private/node/header.rs
@@ -35,7 +35,7 @@ use wnfs_nameaccumulator::{AccumulatorSetup, Name, NameSegment};
 ///
 /// println!("Header: {:#?}", file.header);
 /// ```
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Eq)]
 pub struct PrivateNodeHeader {
     /// A unique identifier of the node.
     pub(crate) inumber: NameSegment,
@@ -226,5 +226,11 @@ impl PrivateNodeHeader {
             header.name = name;
         }
         Ok(header)
+    }
+}
+
+impl PartialEq for PrivateNodeHeader {
+    fn eq(&self, other: &Self) -> bool {
+        self.inumber == other.inumber && self.ratchet == other.ratchet && self.name == other.name
     }
 }

--- a/wnfs/src/private/node/header.rs
+++ b/wnfs/src/private/node/header.rs
@@ -67,17 +67,24 @@ impl PrivateNodeHeader {
     /// Advances the ratchet.
     pub(crate) fn advance_ratchet(&mut self) {
         self.ratchet.inc();
+        self.revision_name = OnceCell::new();
     }
 
     /// Updates the name to the child of given parent name.
     pub(crate) fn update_name(&mut self, parent_name: &Name) {
-        self.name = parent_name.clone();
-        self.name.add_segments(Some(self.inumber.clone()));
+        self.name = parent_name.with_segments_added(Some(self.inumber.clone()));
+        self.revision_name = OnceCell::new();
+    }
+
+    /// Sets the ratchet and makes sure any caches are cleared.
+    pub(crate) fn update_ratchet(&mut self, ratchet: Ratchet) {
+        self.ratchet = ratchet;
+        self.revision_name = OnceCell::new();
     }
 
     /// Resets the ratchet.
     pub(crate) fn reset_ratchet(&mut self, rng: &mut impl CryptoRngCore) {
-        self.ratchet = Ratchet::from_rng(rng)
+        self.update_ratchet(Ratchet::from_rng(rng));
     }
 
     /// Derives the revision ref of the current header.

--- a/wnfs/src/private/node/node.rs
+++ b/wnfs/src/private/node/node.rs
@@ -435,7 +435,7 @@ impl PrivateNode {
             current_header.ratchet = current.clone();
 
             let has_curr = forest
-                .has(&current_header.get_revision_name(), store)
+                .has(current_header.get_revision_name(), store)
                 .await?;
 
             let ord = if has_curr {

--- a/wnfs/src/private/node/node.rs
+++ b/wnfs/src/private/node/node.rs
@@ -432,7 +432,7 @@ impl PrivateNode {
 
         loop {
             let current = search.current();
-            current_header.ratchet = current.clone();
+            current_header.update_ratchet(current.clone());
 
             let has_curr = forest
                 .has(current_header.get_revision_name(), store)
@@ -449,7 +449,7 @@ impl PrivateNode {
             }
         }
 
-        current_header.ratchet = search.current().clone();
+        current_header.update_ratchet(search.current().clone());
 
         let name_hash =
             blake3::Hasher::hash(&current_header.get_revision_name().as_accumulator(setup));

--- a/wnfs/src/private/previous.rs
+++ b/wnfs/src/private/previous.rs
@@ -117,7 +117,7 @@ impl<F: PrivateForest> PrivateNodeHistory<F> {
             return Ok(None);
         };
 
-        self.header.ratchet = previous_ratchet;
+        self.header.update_ratchet(previous_ratchet);
 
         let setup = self.forest.get_accumulator_setup();
         let previous_node = PrivateNode::from_private_ref(


### PR DESCRIPTION
This simply caches the result of `get_revision_name()`, as that's accessed quite a lot and would otherwise cause lots of repeated BigUint operations, which are costly.

It improves performance of general filesystem operations by roughly 20% in my limited testing (I compared runtime of `cargo test --lib -p wnfs -- "private::directory::"`).