### PR TITLE
feat: Implement public directory cp & more efficient copy for `PrivateFile`

### DIFF
--- a/wnfs-wasm/src/fs/public/directory.rs
+++ b/wnfs-wasm/src/fs/public/directory.rs
@@ -211,6 +211,30 @@ impl PublicDirectory {
         }))
     }
 
+    /// Copies a specific node to another location.
+    pub fn cp(
+        &self,
+        path_segments_from: &Array,
+        path_segments_to: &Array,
+        time: &Date,
+        store: BlockStore,
+    ) -> JsResult<Promise> {
+        let mut directory = Rc::clone(&self.0);
+        let store = ForeignBlockStore(store);
+        let time = DateTime::<Utc>::from(time);
+        let path_segments_from = utils::convert_path_segments(path_segments_from)?;
+        let path_segments_to = utils::convert_path_segments(path_segments_to)?;
+
+        Ok(future_to_promise(async move {
+            (&mut directory)
+                .cp(&path_segments_from, &path_segments_to, time, &store)
+                .await
+                .map_err(error("Cannot copy content between directories"))?;
+
+            Ok(utils::create_public_op_result(directory, JsValue::NULL)?)
+        }))
+    }
+
     /// Creates a new directory at the specified path.
     ///
     /// This method acts like `mkdir -p` in Unix because it creates intermediate directories if they do not exist.

--- a/wnfs-wasm/tests/public.spec.ts
+++ b/wnfs-wasm/tests/public.spec.ts
@@ -225,6 +225,52 @@ test.describe("PublicDirectory", () => {
     expect(imagesContent[0].name).toEqual("cats");
   });
 
+  test("cp can copy content between directories", async ({ page }) => {
+    const [imagesContent, picturesContent] = await page.evaluate(async () => {
+      const {
+        wnfs: { PublicDirectory },
+        mock: { MemoryBlockStore, sampleCID },
+      } = await window.setup();
+
+      const time = new Date();
+      const store = new MemoryBlockStore();
+      const root = new PublicDirectory(time);
+
+      var { rootDir } = await root.write(
+        ["pictures", "cats", "luna.jpeg"],
+        sampleCID,
+        time,
+        store
+      );
+
+      var { rootDir } = await rootDir.write(
+        ["pictures", "cats", "tabby.png"],
+        sampleCID,
+        time,
+        store
+      );
+
+      var { rootDir } = await rootDir.mkdir(["images"], time, store);
+
+      var { rootDir } = await rootDir.cp(
+        ["pictures", "cats"],
+        ["images", "cats"],
+        time,
+        store
+      );
+
+      const imagesContent = await rootDir.ls(["images"], store);
+
+      const picturesContent = await rootDir.ls(["pictures"], store);
+
+      return [imagesContent, picturesContent];
+    });
+
+    expect(imagesContent.length).toEqual(1);
+    expect(picturesContent.length).toEqual(1);
+    expect(imagesContent[0].name).toEqual("cats");
+  });
+
   test("A PublicDirectory has the correct metadata", async ({ page }) => {
     const result = await page.evaluate(async () => {
       const {

--- a/wnfs/src/private/directory.rs
+++ b/wnfs/src/private/directory.rs
@@ -602,11 +602,9 @@ impl PrivateDirectory {
     ///        .await?;
     ///     // Clone the forest that was used to write the file
     ///     // Open the file mutably
-    ///     let file = {
-    ///         root_dir
-    ///             .open_file_mut(hello_py, true, Utc::now(), forest, store, rng)
-    ///             .await?
-    ///     };
+    ///     let file = root_dir
+    ///         .open_file_mut(hello_py, true, Utc::now(), forest, store, rng)
+    ///         .await?;
     ///     // Define the content that will replace what is already in the file
     ///     let new_file_content = b"print('hello world 2')";
     ///     // Set the contents of the file, waiting for result and expecting no errors

--- a/wnfs/src/private/directory.rs
+++ b/wnfs/src/private/directory.rs
@@ -1204,7 +1204,7 @@ impl PrivateDirectory {
     ///         .await
     ///         .unwrap();
     ///
-    ///     let result = root_dir
+    ///     root_dir
     ///         .cp(
     ///             &["code".into(), "python".into(), "hello.py".into()],
     ///             &["code".into(), "hello.py".into()],

--- a/wnfs/src/private/node/node.rs
+++ b/wnfs/src/private/node/node.rs
@@ -123,9 +123,7 @@ impl PrivateNode {
         match self {
             Self::File(file_rc) => {
                 let file = Rc::make_mut(file_rc);
-
-                file.prepare_key_rotation(parent_name, forest, store, rng)
-                    .await?;
+                file.prepare_key_rotation(parent_name, rng).await?;
             }
             Self::Dir(dir_rc) => {
                 let dir = Rc::make_mut(dir_rc);


### PR DESCRIPTION
Fixes #316 (although what was missing was actually `cp` for *Public* directory, not private)

Since #306 we can actually do a more efficient copy of external `PrivateFile` content that doesn't require re-encryption, because we can directly refer to the old content (using the `bare_name` property of `ExternalFileContent`).

I've decided to set this as the default copy algorithm. There's no benefit to re-encrypting the actual content bytes. You already get the key rotation on the wrapping `PrivateFile`, and it doesn't implicitly give you access to anything else besides the bytes you're supposed to be able to read.

I think this supersedes #256 at least in terms of what Banyan needs.