### PR TITLE
chore: Fix CI: Run `yarn install` before npm publishing & use non-version dev-dependency

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -121,6 +121,10 @@ jobs:
       - name: Install Binaryen
         run: sudo apt update && sudo apt install binaryen -y
 
+      - name: Install Node Dependencies
+        run: yarn
+        working-directory: wnfs-wasm
+
       # Build and rename package.json name
       - name: Build
         run: ./scripts/rs-wnfs.sh build --wasm

--- a/wnfs-hamt/Cargo.toml
+++ b/wnfs-hamt/Cargo.toml
@@ -42,7 +42,7 @@ async-std = { version = "1.11", features = ["attributes"] }
 proptest = "1.1"
 rand = "0.8"
 test-strategy = "0.3"
-wnfs-common = { path = "../wnfs-common", version = "0.1.23", features = ["test_utils"] }
+wnfs-common = { path = "../wnfs-common", features = ["test_utils"] }
 
 [features]
 test_utils = ["proptest"]


### PR DESCRIPTION
Fixes #321 