### PR TITLE
fix: More reliably cache `NameAccumulator` modexps

### DIFF
--- a/wnfs-nameaccumulator/src/name.rs
+++ b/wnfs-nameaccumulator/src/name.rs
@@ -25,11 +25,10 @@ const L_HASH_DSI: &str = "wnfs/PoKE*/l 128-bit hash derivation";
 /// However, these names are based on RSA accumulators to make it possible
 /// to prove a relationship between two names, e.g a file being contained in
 /// a sub-directory of a directory while leaking as little information as possible.
-#[derive(Clone, Debug, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct Name {
     relative_to: NameAccumulator,
     segments: Vec<NameSegment>,
-    accumulated: OnceCell<(NameAccumulator, ElementsProof)>,
 }
 
 /// Represents a setup needed for RSA accumulator operation.
@@ -52,7 +51,7 @@ pub struct NameAccumulator {
 
 /// A name accumluator segment. A name accumulator commits to a set of these.
 /// They are represented as 256-bit prime numbers.
-#[derive(Clone, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct NameSegment(
     /// Invariant: Must be a 256-bit prime
     BigUint,
@@ -116,7 +115,6 @@ impl Name {
         Self {
             relative_to,
             segments: segments.into_iter().collect(),
-            accumulated: OnceCell::new(),
         }
     }
 
@@ -129,7 +127,6 @@ impl Name {
     /// Remove the last name segment, if possible.
     pub fn up(&mut self) {
         self.segments.pop();
-        self.accumulated = OnceCell::new();
     }
 
     /// Return the parent name, if possible.
@@ -149,7 +146,6 @@ impl Name {
 
     pub fn add_segments(&mut self, segments: impl IntoIterator<Item = NameSegment>) {
         self.segments.extend(segments);
-        self.accumulated = OnceCell::new();
     }
 
     pub fn with_segments_added(&self, segments: impl IntoIterator<Item = NameSegment>) -> Self {
@@ -163,20 +159,18 @@ impl Name {
     /// this name is relative to.
     ///
     /// This proof process is memoized. Running it twice won't duplicate work.
-    pub fn as_proven_accumulator(
+    pub fn into_proven_accumulator(
         &self,
         setup: &AccumulatorSetup,
-    ) -> &(NameAccumulator, ElementsProof) {
-        self.accumulated.get_or_init(|| {
-            let mut name = self.relative_to.clone();
-            let proof = name.add(self.segments.iter(), setup);
-            (name, proof)
-        })
+    ) -> (NameAccumulator, ElementsProof) {
+        let mut name = self.relative_to.clone();
+        let proof = name.add(self.segments.iter(), setup);
+        (name, proof)
     }
 
     /// Return what name accumulator this name commits to.
-    pub fn as_accumulator(&self, setup: &AccumulatorSetup) -> &NameAccumulator {
-        &self.as_proven_accumulator(setup).0
+    pub fn into_accumulator(&self, setup: &AccumulatorSetup) -> NameAccumulator {
+        self.into_proven_accumulator(setup).0
     }
 }
 
@@ -498,27 +492,6 @@ impl Serialize for UnbatchableProofPart {
     }
 }
 
-impl PartialEq for Name {
-    fn eq(&self, other: &Self) -> bool {
-        let left = self
-            .accumulated
-            .get()
-            .map(|x| &x.0)
-            .or(self.segments.is_empty().then_some(&self.relative_to));
-        let right = other
-            .accumulated
-            .get()
-            .map(|x| &x.0)
-            .or(other.segments.is_empty().then_some(&other.relative_to));
-
-        if let (Some(left), Some(right)) = (left, right) {
-            return left == right;
-        }
-
-        self.relative_to == other.relative_to && self.segments == other.segments
-    }
-}
-
 impl PartialEq for NameAccumulator {
     fn eq(&self, other: &Self) -> bool {
         self.state == other.state
@@ -690,17 +663,17 @@ mod tests {
         ]);
         name_image.add_segments([root_dir_segment, pics_dir_segment, image_file_segment]);
 
-        let (accum_note, proof_note) = name_note.as_proven_accumulator(setup);
-        let (accum_image, proof_image) = name_image.as_proven_accumulator(setup);
+        let (accum_note, proof_note) = name_note.into_proven_accumulator(setup);
+        let (accum_image, proof_image) = name_image.into_proven_accumulator(setup);
 
         let mut batched_proof = BatchedProofPart::new();
-        batched_proof.add(proof_note, setup);
-        batched_proof.add(proof_image, setup);
+        batched_proof.add(&proof_note, setup);
+        batched_proof.add(&proof_image, setup);
 
-        let name_base = Name::empty(setup).as_accumulator(setup).clone();
+        let name_base = Name::empty(setup).into_accumulator(setup);
         let mut verification = BatchedProofVerification::new(setup);
-        verification.add(&name_base, accum_note, &proof_note.part)?;
-        verification.add(&name_base, accum_image, &proof_image.part)?;
+        verification.add(&name_base, &accum_note, &proof_note.part)?;
+        verification.add(&name_base, &accum_image, &proof_image.part)?;
         verification.verify(&batched_proof)?;
 
         Ok(())

--- a/wnfs/Cargo.toml
+++ b/wnfs/Cargo.toml
@@ -32,6 +32,7 @@ libipld-core = { version = "0.16" }
 multihash = "0.19"
 once_cell = "1.16"
 proptest = { version = "1.1", optional = true }
+quick_cache = "0.3.0"
 rand_core = "0.6"
 semver = { version = "1.0", features = ["serde"] }
 serde = { version = "1.0", features = ["rc"] }

--- a/wnfs/examples/write_proofs.rs
+++ b/wnfs/examples/write_proofs.rs
@@ -57,8 +57,7 @@ async fn alice_actions(store: &impl BlockStore) -> Result<(Cid, AccessKey, NameA
 
     let access_key = root_dir.as_node().store(forest, store, rng).await?;
     let cid = forest.store(store).await?;
-    let setup = forest.get_accumulator_setup();
-    let allowed_name = root_dir.header.get_name().as_accumulator(setup).clone();
+    let allowed_name = forest.get_accumulated_name(&root_dir.header.get_name());
 
     Ok((cid, access_key, allowed_name))
 }

--- a/wnfs/src/private/directory.rs
+++ b/wnfs/src/private/directory.rs
@@ -1258,7 +1258,7 @@ impl PrivateDirectory {
             .await?;
 
         forest
-            .put_encrypted(name_with_revision, [header_cid, content_cid], store)
+            .put_encrypted(&name_with_revision, [header_cid, content_cid], store)
             .await?;
 
         Ok(self

--- a/wnfs/src/private/directory.rs
+++ b/wnfs/src/private/directory.rs
@@ -15,7 +15,7 @@ use std::{
     rc::Rc,
 };
 use wnfs_common::{utils::error, BlockStore, Metadata, PathNodes, PathNodesResult, CODEC_RAW};
-use wnfs_nameaccumulator::{AccumulatorSetup, Name, NameSegment};
+use wnfs_nameaccumulator::{Name, NameSegment};
 
 //--------------------------------------------------------------------------------------------------
 // Type Definitions
@@ -391,15 +391,6 @@ impl PrivateDirectory {
         cloned.header.advance_ratchet();
 
         Ok(cloned)
-    }
-
-    /// Returns the private ref, if this directory has been `.store()`ed before.
-    pub(crate) fn derive_private_ref(&self, setup: &AccumulatorSetup) -> Option<PrivateRef> {
-        self.content.persisted_as.get().map(|content_cid| {
-            self.header
-                .derive_revision_ref(setup)
-                .into_private_ref(*content_cid)
-        })
     }
 
     /// This prepares this directory for key rotation, usually for moving or
@@ -1257,8 +1248,7 @@ impl PrivateDirectory {
         store: &impl BlockStore,
         rng: &mut impl CryptoRngCore,
     ) -> Result<PrivateRef> {
-        let setup = &forest.get_accumulator_setup().clone();
-        let header_cid = self.header.store(store, setup).await?;
+        let header_cid = self.header.store(store, forest).await?;
         let temporal_key = self.header.derive_temporal_key();
         let name_with_revision = self.header.get_revision_name();
 
@@ -1273,7 +1263,7 @@ impl PrivateDirectory {
 
         Ok(self
             .header
-            .derive_revision_ref(setup)
+            .derive_revision_ref(forest)
             .into_private_ref(content_cid))
     }
 
@@ -1282,9 +1272,9 @@ impl PrivateDirectory {
         serializable: PrivateDirectoryContentSerializable,
         temporal_key: &TemporalKey,
         cid: Cid,
+        forest: &impl PrivateForest,
         store: &impl BlockStore,
         parent_name: Option<Name>,
-        setup: &AccumulatorSetup,
     ) -> Result<Self> {
         if serializable.version.major != 0 || serializable.version.minor != 2 {
             bail!(FsError::UnexpectedVersion(serializable.version));
@@ -1307,9 +1297,9 @@ impl PrivateDirectory {
         let header = PrivateNodeHeader::load(
             &serializable.header_cid,
             temporal_key,
+            forest,
             store,
             parent_name,
-            setup,
         )
         .await?;
         Ok(Self { header, content })

--- a/wnfs/src/private/file.rs
+++ b/wnfs/src/private/file.rs
@@ -731,7 +731,7 @@ impl PrivateFile {
             .await?;
 
         forest
-            .put_encrypted(name_with_revision, [header_cid, content_cid], store)
+            .put_encrypted(&name_with_revision, [header_cid, content_cid], store)
             .await?;
 
         Ok(self

--- a/wnfs/src/private/link.rs
+++ b/wnfs/src/private/link.rs
@@ -7,7 +7,7 @@ use async_recursion::async_recursion;
 use rand_core::CryptoRngCore;
 use std::rc::Rc;
 use wnfs_common::BlockStore;
-use wnfs_nameaccumulator::{AccumulatorSetup, Name};
+use wnfs_nameaccumulator::Name;
 
 #[derive(Debug)]
 pub(crate) enum PrivateLink {
@@ -133,14 +133,6 @@ impl PrivateLink {
     #[inline]
     pub(crate) fn with_file(file: PrivateFile) -> Self {
         Self::from(PrivateNode::File(Rc::new(file)))
-    }
-
-    #[allow(dead_code)]
-    pub(crate) fn get_ref(&self, setup: &AccumulatorSetup) -> Option<PrivateRef> {
-        match self {
-            Self::Encrypted { private_ref, .. } => Some(private_ref.clone()),
-            Self::Decrypted { node } => node.derive_private_ref(setup),
-        }
     }
 }
 

--- a/wnfs/src/private/node/header.rs
+++ b/wnfs/src/private/node/header.rs
@@ -226,6 +226,8 @@ impl PrivateNodeHeader {
 
 impl PartialEq for PrivateNodeHeader {
     fn eq(&self, other: &Self) -> bool {
-        self.inumber == other.inumber && self.ratchet == other.ratchet && self.name == other.name
+        // We skip equality-checking the name, since it depends on where the node header was mounted.
+        // The inumber should suffice as identifier, the ratchet covers the revision part.
+        self.inumber == other.inumber && self.ratchet == other.ratchet
     }
 }

--- a/wnfs/src/private/node/header.rs
+++ b/wnfs/src/private/node/header.rs
@@ -168,7 +168,7 @@ impl PrivateNodeHeader {
     /// Encrypts this private node header in an block, then stores that in the given
     /// BlockStore and returns its CID.
     ///
-    /// This *does not* store the block itself in the forest, only the the given block store.
+    /// This *does not* store the block itself in the forest, only in the given block store.
     pub async fn store(&self, store: &impl BlockStore, forest: &impl PrivateForest) -> Result<Cid> {
         let temporal_key = self.derive_temporal_key();
         let cbor_bytes = serde_ipld_dagcbor::to_vec(&self.to_serializable(forest))?;

--- a/wnfs/src/private/node/node.rs
+++ b/wnfs/src/private/node/node.rs
@@ -18,7 +18,7 @@ use skip_ratchet::{JumpSize, RatchetSeeker};
 use std::{cmp::Ordering, collections::BTreeSet, fmt::Debug, rc::Rc};
 use wnfs_common::BlockStore;
 use wnfs_hamt::Hasher;
-use wnfs_nameaccumulator::{AccumulatorSetup, Name};
+use wnfs_nameaccumulator::Name;
 
 //--------------------------------------------------------------------------------------------------
 // Type Definitions
@@ -413,7 +413,6 @@ impl PrivateNode {
         store: &impl BlockStore,
     ) -> Result<Vec<PrivateNode>> {
         let header = self.get_header();
-        let setup = forest.get_accumulator_setup();
         let mountpoint = header.name.parent().unwrap_or_else(|| forest.empty_name());
 
         let current_name = &header.get_revision_name();
@@ -450,7 +449,7 @@ impl PrivateNode {
         current_header.update_ratchet(search.current().clone());
 
         let name_hash =
-            blake3::Hasher::hash(&current_header.get_revision_name().as_accumulator(setup));
+            blake3::Hasher::hash(&forest.get_accumulated_name(current_header.get_revision_name()));
 
         Ok(forest
             .get_multivalue_by_hash(
@@ -482,17 +481,15 @@ impl PrivateNode {
             _ => bail!(FsError::NotFound),
         };
 
-        let setup = forest.get_accumulator_setup();
-
-        Self::from_cid(cid, &private_ref.temporal_key, store, parent_name, setup).await
+        Self::from_cid(cid, &private_ref.temporal_key, forest, store, parent_name).await
     }
 
     pub(crate) async fn from_cid(
         cid: Cid,
         temporal_key: &TemporalKey,
+        forest: &impl PrivateForest,
         store: &impl BlockStore,
         parent_name: Option<Name>,
-        setup: &AccumulatorSetup,
     ) -> Result<PrivateNode> {
         let encrypted_bytes = store.get_block(&cid).await?;
         let snapshot_key = temporal_key.derive_snapshot_key();
@@ -504,9 +501,9 @@ impl PrivateNode {
                     file,
                     temporal_key,
                     cid,
+                    forest,
                     store,
                     parent_name,
-                    setup,
                 )
                 .await?;
                 PrivateNode::File(Rc::new(file))
@@ -516,22 +513,14 @@ impl PrivateNode {
                     dir,
                     temporal_key,
                     cid,
+                    forest,
                     store,
                     parent_name,
-                    setup,
                 )
                 .await?;
                 PrivateNode::Dir(Rc::new(dir))
             }
         })
-    }
-
-    /// Returns the private ref, if this node has been `.store()`ed before.
-    pub(crate) fn derive_private_ref(&self, setup: &AccumulatorSetup) -> Option<PrivateRef> {
-        match self {
-            Self::File(file) => file.derive_private_ref(setup),
-            Self::Dir(dir) => dir.derive_private_ref(setup),
-        }
     }
 
     pub(crate) fn get_persisted_as(&self) -> &OnceCell<Cid> {

--- a/wnfs/src/private/node/node.rs
+++ b/wnfs/src/private/node/node.rs
@@ -432,7 +432,7 @@ impl PrivateNode {
             current_header.update_ratchet(current.clone());
 
             let has_curr = forest
-                .has(current_header.get_revision_name(), store)
+                .has(&current_header.get_revision_name(), store)
                 .await?;
 
             let ord = if has_curr {
@@ -449,7 +449,7 @@ impl PrivateNode {
         current_header.update_ratchet(search.current().clone());
 
         let name_hash =
-            blake3::Hasher::hash(&forest.get_accumulated_name(current_header.get_revision_name()));
+            blake3::Hasher::hash(&forest.get_accumulated_name(&current_header.get_revision_name()));
 
         Ok(forest
             .get_multivalue_by_hash(

--- a/wnfs/src/private/node/node.rs
+++ b/wnfs/src/private/node/node.rs
@@ -678,13 +678,15 @@ mod tests {
         let file_private_ref = file_node.store(forest, store, rng).await.unwrap();
         let dir_private_ref = dir_node.store(forest, store, rng).await.unwrap();
 
-        let deserialized_file_node = PrivateNode::load(&file_private_ref, forest, store, None)
-            .await
-            .unwrap();
+        let deserialized_file_node =
+            PrivateNode::load(&file_private_ref, forest, store, Some(forest.empty_name()))
+                .await
+                .unwrap();
 
-        let deserialized_dir_node = PrivateNode::load(&dir_private_ref, forest, store, None)
-            .await
-            .unwrap();
+        let deserialized_dir_node =
+            PrivateNode::load(&dir_private_ref, forest, store, Some(forest.empty_name()))
+                .await
+                .unwrap();
 
         assert_eq!(file_node, deserialized_file_node);
         assert_eq!(dir_node, deserialized_dir_node);

--- a/wnfs/src/private/previous.rs
+++ b/wnfs/src/private/previous.rs
@@ -119,11 +119,10 @@ impl<F: PrivateForest> PrivateNodeHistory<F> {
 
         self.header.update_ratchet(previous_ratchet);
 
-        let setup = self.forest.get_accumulator_setup();
         let previous_node = PrivateNode::from_private_ref(
             &self
                 .header
-                .derive_revision_ref(setup)
+                .derive_revision_ref(&self.forest)
                 .into_private_ref(previous_cid),
             &self.forest,
             store,

--- a/wnfs/src/private/share.rs
+++ b/wnfs/src/private/share.rs
@@ -251,11 +251,10 @@ pub mod recipient {
         sharer_forest: &impl PrivateForest,
         store: &impl BlockStore,
     ) -> Result<PrivateNode> {
-        let setup = sharer_forest.get_accumulator_setup();
         // Get cid to encrypted payload from sharer's forest using share_label
         let access_key_cid = sharer_forest
             .get_encrypted_by_hash(
-                &blake3::Hasher::hash(&share_label.as_accumulator(setup)),
+                &blake3::Hasher::hash(&sharer_forest.get_accumulated_name(share_label)),
                 store,
             )
             .await?


### PR DESCRIPTION
`BigUint::modexp` operations take up to 14ms in Wasm on my machine, and it's the core operation for `NameAccumulator`s.

This introduces a LRU cache inside `HamtForest` that caches `NameAccumulator` operations.

This is much more reliable than sprinkling `OnceCell`s every here and there, since
1. The "eviction" of these `OnceCell` caches depends on the lifetime of the object they're contained in, and it's harder to make these structs longer-lived in some cases.
2. Sometimes the structs that these `OnceCell`s are contained inside are mutable via `&mut self` operations. We need to remember to always empty these `OnceCell`s when that happens. This is bad for two reasons: (1) we might forget doing so sometimes, keeping stale, incorrectly cached data around and (2) even though the cache doesn't match the object anymore, it may still be a useful cache!

