### PR TITLE
chore: Release 0.1.24

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,6 +1,5 @@
 {
   "wnfs": "0.1.23",
-  "wnfs-bench": "0.1.23",
   "wnfs-common": "0.1.23",
   "wnfs-hamt": "0.1.23",
   "wnfs-nameaccumulator": "0.1.23",

--- a/wnfs/src/private/directory.rs
+++ b/wnfs/src/private/directory.rs
@@ -331,6 +331,7 @@ impl PrivateDirectory {
         Ok(SearchResult::Found(working_dir))
     }
 
+    #[allow(clippy::suspicious)]
     pub(crate) async fn get_or_create_leaf_dir_mut<'a>(
         self: &'a mut Rc<Self>,
         path_segments: &[String],
@@ -618,6 +619,7 @@ impl PrivateDirectory {
     ///     Ok(())
     /// }
     /// ```
+    #[allow(clippy::suspicious)]
     pub async fn open_file_mut<'a>(
         self: &'a mut Rc<Self>,
         path_segments: &[String],
@@ -1362,6 +1364,7 @@ impl PrivateDirectoryContent {
     ///
     /// The header cid is required as it's not stored in the PrivateDirectoryContent itself, but
     /// stored in the serialized format.
+    #[allow(clippy::suspicious)]
     pub(crate) async fn store(
         &self,
         header_cid: Cid,

--- a/wnfs/src/private/file.rs
+++ b/wnfs/src/private/file.rs
@@ -805,6 +805,7 @@ impl PrivateFileContent {
         )?)
     }
 
+    #[allow(clippy::suspicious)]
     pub(crate) async fn store(
         &self,
         header_cid: Cid,


### PR DESCRIPTION
Also ignoring the `needless_pass_by_ref_mut` lint.
That lint has a bug that causes false positives. It'll be fixed when this is released: https://github.com/rust-lang/rust-clippy/pull/11314
However, it's a nightly lint, so unfortunately I can't ignore it via a `#[allow(clippy::needless_pass_by_ref_mut)]`, since that makes *stable* clippy fail with an unknown lint error.
So I made it ignore all lints from the `suspicious` group on the affected functions.
