### PR TITLE
fix: bump package.json version number to 0.1.24

### DIFF
--- a/wnfs-wasm/package.json
+++ b/wnfs-wasm/package.json
@@ -4,7 +4,7 @@
     "The Fission Authors"
   ],
   "description": "WebNative Filesystem API (WebAssembly)",
-  "version": "0.1.23",
+  "version": "0.1.24",
   "license": "Apache-2.0",
   "homepage": "https://fission.codes",
   "repository": {


### PR DESCRIPTION
The release action was trying to re-publish 0.1.23, this PR bumps it up to 0.1.24