### PR TITLE
Update data format version to 1.0.0 and adjust domain separation strings according to the latest spec

### DIFF
--- a/wnfs-nameaccumulator/src/name.rs
+++ b/wnfs-nameaccumulator/src/name.rs
@@ -13,7 +13,8 @@ use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use std::{hash::Hash, str::FromStr};
 use zeroize::Zeroize;
 
-const L_HASH_DSI: &str = "wnfs/PoKE*/l 128-bit hash derivation";
+/// The domain separation string for deriving the l hash in the PoKE* protocol.
+const L_HASH_DSI: &str = "wnfs/1.0/PoKE*/l 128-bit hash derivation";
 
 //--------------------------------------------------------------------------------------------------
 // Type Definitions

--- a/wnfs/src/lib.rs
+++ b/wnfs/src/lib.rs
@@ -32,7 +32,8 @@ pub mod nameaccumulator {
 // Constants
 //--------------------------------------------------------------------------------------------------
 
-const VERSION: semver::Version = semver::Version::new(0, 2, 0);
+/// The version of the WNFS data format that this library outputs
+pub const WNFS_VERSION: semver::Version = semver::Version::new(1, 0, 0);
 
 //--------------------------------------------------------------------------------------------------
 // Types
@@ -46,7 +47,24 @@ pub(crate) enum SearchResult<T> {
 }
 
 //--------------------------------------------------------------------------------------------------
-// Constants
+// Functions
 //--------------------------------------------------------------------------------------------------
 
-pub const WNFS_VERSION: semver::Version = semver::Version::new(0, 2, 0);
+/// Whether given WNFS data format version can be read by this library
+pub fn is_readable_wnfs_version(version: &semver::Version) -> bool {
+    get_wnfs_version_req().matches(version)
+}
+
+/// The WNFS data format version requirement for this version of the library
+pub fn get_wnfs_version_req() -> semver::VersionReq {
+    use semver::*;
+    VersionReq {
+        comparators: vec![Comparator {
+            op: Op::Exact,
+            major: WNFS_VERSION.major,
+            minor: Some(WNFS_VERSION.minor),
+            patch: None,
+            pre: Prerelease::EMPTY,
+        }],
+    }
+}

--- a/wnfs/src/private/directory.rs
+++ b/wnfs/src/private/directory.rs
@@ -3,7 +3,7 @@ use super::{
     PrivateDirectoryContentSerializable, PrivateFile, PrivateNode, PrivateNodeContentSerializable,
     PrivateNodeHeader, PrivateRef, TemporalKey,
 };
-use crate::{error::FsError, traits::Id, SearchResult, WNFS_VERSION};
+use crate::{error::FsError, is_readable_wnfs_version, traits::Id, SearchResult, WNFS_VERSION};
 use anyhow::{bail, ensure, Result};
 use async_once_cell::OnceCell;
 use chrono::{DateTime, Utc};
@@ -1278,7 +1278,7 @@ impl PrivateDirectory {
         store: &impl BlockStore,
         parent_name: Option<Name>,
     ) -> Result<Self> {
-        if serializable.version.major != 0 || serializable.version.minor != 2 {
+        if !is_readable_wnfs_version(&serializable.version) {
             bail!(FsError::UnexpectedVersion(serializable.version));
         }
 

--- a/wnfs/src/private/file.rs
+++ b/wnfs/src/private/file.rs
@@ -3,7 +3,7 @@ use super::{
     PrivateNode, PrivateNodeContentSerializable, PrivateNodeHeader, PrivateRef, SnapshotKey,
     TemporalKey, AUTHENTICATION_TAG_SIZE, BLOCK_SEGMENT_DSI, HIDING_SEGMENT_DSI, NONCE_SIZE,
 };
-use crate::{error::FsError, traits::Id, WNFS_VERSION};
+use crate::{error::FsError, is_readable_wnfs_version, traits::Id, WNFS_VERSION};
 use anyhow::{bail, Result};
 use async_once_cell::OnceCell;
 use async_stream::try_stream;
@@ -745,7 +745,7 @@ impl PrivateFile {
         store: &impl BlockStore,
         parent_name: Option<Name>,
     ) -> Result<Self> {
-        if serializable.version.major != 0 || serializable.version.minor != 2 {
+        if !is_readable_wnfs_version(&serializable.version) {
             bail!(FsError::UnexpectedVersion(serializable.version));
         }
 

--- a/wnfs/src/private/keys/snapshots/wnfs__private__keys__access__snapshot_tests__access_key-2.snap
+++ b/wnfs/src/private/keys/snapshots/wnfs__private__keys__access__snapshot_tests__access_key-2.snap
@@ -15,10 +15,10 @@ expression: snap_key
       },
       "snapshotKey": {
         "/": {
-          "bytes": "owWtrui+W7imdTj+i77J6G/5RT1Rlu9ACfMsYCdULCI"
+          "bytes": "7SoxAmhQW3XHxn5UpettI89xokpcEjFXapTSkFRQleU"
         }
       }
     }
   },
-  "bytes": "oXN3bmZzL3NoYXJlL3NuYXBzaG90o2VsYWJlbFggf7J7lBYC0B0RVCIRE0/HGqyuVON+fQB7u3tV7/BiooRqY29udGVudENpZNgqRQABAAAAa3NuYXBzaG90S2V5WCCjBa2u6L5buKZ1OP6Lvsnob/lFPVGW70AJ8yxgJ1QsIg=="
+  "bytes": "oXN3bmZzL3NoYXJlL3NuYXBzaG90o2VsYWJlbFggf7J7lBYC0B0RVCIRE0/HGqyuVON+fQB7u3tV7/BiooRqY29udGVudENpZNgqRQABAAAAa3NuYXBzaG90S2V5WCDtKjECaFBbdcfGflSl620jz3GiSlwSMVdqlNKQVFCV5Q=="
 }

--- a/wnfs/src/private/node/keys.rs
+++ b/wnfs/src/private/node/keys.rs
@@ -29,24 +29,26 @@ pub const KEY_BYTE_SIZE: usize = 32;
 /// The revision segment derivation domain separation info
 /// used for salting the hashing function when turning
 /// node names into revisioned node names.
-pub(crate) const REVISION_SEGMENT_DSI: &str = "wnfs/revision segment deriv from ratchet";
+pub(crate) const REVISION_SEGMENT_DSI: &str = "wnfs/1.0/revision segment derivation from ratchet";
 /// The hiding segment derivation domain separation info
 /// used for salting the hashing function when generating
 /// the hiding segment from the external file content key,
 /// which is added to a file's name to generate the external content base name.
-pub(crate) const HIDING_SEGMENT_DSI: &str = "wnfs/hiding segment deriv from content key";
+/// This domain separation string is not part of the standard, as the standard leaves
+/// the way the base name is derived open to implementations.
+pub(crate) const HIDING_SEGMENT_DSI: &str = "wnfs/1.0/hiding segment derivation from content key";
 /// The block segment derivation domain separation info
 /// used for salting the hashing function when generating
 /// the segments for each file's external content blocks.
-pub(crate) const BLOCK_SEGMENT_DSI: &str = "wnfs/segment deriv for file block";
+pub(crate) const BLOCK_SEGMENT_DSI: &str = "wnfs/1.0/segment derivation for file block";
 /// The temporal key derivation domain seperation info
 /// used for salting the hashing function when deriving
 /// symmetric keys from ratchets.
-pub(crate) const TEMPORAL_KEY_DSI: &str = "wnfs/temporal deriv from ratchet";
+pub(crate) const TEMPORAL_KEY_DSI: &str = "wnfs/1.0/temporal derivation from ratchet";
 /// The snapshot key derivation domain separation info
 /// used for salting the hashing function when deriving
 /// the snapshot key from the temporal key.
-pub(crate) const SNAPSHOT_KEY_DSI: &str = "wnfs/snapshot key deriv from temporal";
+pub(crate) const SNAPSHOT_KEY_DSI: &str = "wnfs/1.0/snapshot key derivation from temporal";
 
 //--------------------------------------------------------------------------------------------------
 // Type Definitions

--- a/wnfs/src/private/snapshots/wnfs__private__directory__snapshot_tests__private_fs.snap
+++ b/wnfs/src/private/snapshots/wnfs__private__directory__snapshot_tests__private_fs.snap
@@ -3,161 +3,6 @@ source: wnfs/src/private/directory.rs
 expression: values
 ---
 {
-  "bafkr4ia6ddv7yfregz6kbs2xxqledpwbtevv42gpgvpmxg6b5utlkrjwha": {
-    "value": {
-      "inumber": {
-        "/": {
-          "bytes": "3Z7G3JebhuU5yeJZkofUBTlfs2Zs7sV+m/PkFnUmaqM"
-        }
-      },
-      "name": {
-        "/": {
-          "bytes": "ayUufv6djgi/dODTvVwJ2IaXn7af/mK0nGskm3IT1bK0tQ2QBlocw1SBb36DPlSx6q66jJ1OoQhSuaSGRiGJ9JF4CFECtBAbzpP0+IsgjeePZbBpi75FNiOLdVP5QjcXLLj1FQ9LfWJs47ULBQlG3mDXR039e8KZM1Jp+K9UI5I0UUNNN/vZr0ogtuEIulPHShkBZNZ33g3WOBZwPo/aMAVyWcqHZAsOFbYSdJmprp61Yh1GuzH+EQsLn69Cgj+nczsxoFttojrbrk0oj7ZEbQfNjR9+yKRv5knLtKtOQrwmYMaXWkABGZfJWzyjwdJYnnuScTwgG6xnhEaO4kJQSA"
-        }
-      },
-      "ratchet": {
-        "large": {
-          "/": {
-            "bytes": "YaC+JBrbi/0ijSebZNkA9xlgjdq9f7ycFPE5/78HmO8"
-          }
-        },
-        "medium": {
-          "/": {
-            "bytes": "v8M5ThznEBqsrvylEFG1AmyxTgjdYLS/20+SFA0HHTk"
-          }
-        },
-        "mediumCounter": 28,
-        "salt": {
-          "/": {
-            "bytes": "NO8dg+rac2jR64nn/36lclXxGlyXlvONt0TTdf7Wv10"
-          }
-        },
-        "small": {
-          "/": {
-            "bytes": "Sp+YoS3lup4NgJbxkdgnptpbs8o78HqX6vqqoteFrLM"
-          }
-        },
-        "smallCounter": 9
-      }
-    },
-    "bytes": "uQeEHHFl25gpJfZEufGDzIyPyO3yHx3jAc4S/cP/nBJOQt8CSFWupZ+Rxrataes83YX3pHcmP7OSpFAq1Cra4lKDaIdmgm6ay45fwCrz6NGzLXsIl93S7IWAeud/YXcdGzgO0F+6CqQhA41LDSG2gxMHAJs7vTTvO2jNjgO+/YBT1DyESM8MxUEBIVsnRQffW5HwKnv0d55kDUF8GB9XlwxAY01pJgSkOrk7CV9NtM3qpDxbAqLZqXMk4t5vQv3q+6iXCkd4FCU1Wv1MRQp01ouHSe/aMwrFQgLEEF4tKA5cB34EiinBHHH8lGTUrfEAr9VDpltFZTyfRmG51bhboE2u6NwQDinmTOs3V8JUwExAw9s7+DuAoMUtZkjs1v5GviMckH75VEl7CXNwV/gwKqFXlPM/Wt9fSWAlvIk70o/2QSb8RAMhIVnbE7Uz6q4+6oTPbOPAoQUM3ejk7eEAGA9boWZSwMU3TpUwmNx18XNOG1p7bQ+fDz4tOcaK4o3cHWF6/HEWTHHVXP0DodB1AQx1KXVyWCOnNRphgHNmVqtvIjDGxVLxEmf5hCaesZ9uBODNbiGd/yNit0WdbE4Rr/CN1vXW7rPvd45/wWf7U1yW0p4cB6oQryu2j0acSKbJwJyiq3V54O9C6dLdVkjHcSMhGfQhirmhTPuAArzNqBNc3fx71WASdg=="
-  },
-  "bafkr4ia7pqc2hlj6hfhekje5ahetokwa4wf4vu6t4ds2oo4zj4xp5kc6yq": {
-    "value": {
-      "inumber": {
-        "/": {
-          "bytes": "4Rw8Wzk9Be77iAS6n5C9UOLatGrg4UmMm1ST3GT3oqs"
-        }
-      },
-      "name": {
-        "/": {
-          "bytes": "SkM4IhExInZkPcASX4xPUscgI/S+hwXKidMzNBvNR/9MzxbPLEhUKHHYcEHu+mUMu2Mve+SISnvIAgQ2XW0gYZMf02o4CYeXMCPD5wH0HXwXaTZz/wZUkR2uATkk4828x5b3HKIRJ9o9CgxGnCR45yHT+g+QdF8FiX4DrGmdSOLLP0xRUGvhQ70TDINPtM1PMUGwYTtiUCpo1M2rNaVY0+wda2wB3DTyFCJlj6D/WbvqZtCzJNQhJ6QagO+XIljujKg4puyRfLD8I40/7yXFlNoD+fbAClBttA6UKnJkQf5buc5Ghek/Xn1ctq4BuDuGy0G6Tul75GTbs4G1fyWhMg"
-        }
-      },
-      "ratchet": {
-        "large": {
-          "/": {
-            "bytes": "WHu5AC1kgPMHil7KNZNllEduLodbVzRKVclTlkwjrmA"
-          }
-        },
-        "medium": {
-          "/": {
-            "bytes": "gdq1GlHQkbPXDVcaRV9xeRiO2k8pYY5yEfDE5wxaRYk"
-          }
-        },
-        "mediumCounter": 74,
-        "salt": {
-          "/": {
-            "bytes": "x7rdS4zEr0dhMT/2YTABBjNp3pMuc21XGrULhUr2UYQ"
-          }
-        },
-        "small": {
-          "/": {
-            "bytes": "/MU0z9MqX/+KFJ+g1PTMSXAKuVoIpwd/lUbSk9FZUW8"
-          }
-        },
-        "smallCounter": 164
-      }
-    },
-    "bytes": "egK0Vpbxb0MQo/R6yQWWA8iv8yxgOZm2jxBo5s25UPksD3kdBXKJL3wooeL0WkbnJzrN8sV7AT006kzKTidKLEn434F7ClrQQFkBqx9e0ME4B/XHbPjgwZzpis54BWhV0J2qWQFr7+1cZB0OOkd2WEF3ZGcNCHVD1Z+vfRplRACk23pP7EJ8AD4e21+R9tQobbWKlr2uyf1OK+iAdXx9+ftgBEDJJzER2SRWJ33An9fGIGOT8pjQ48RKJzHgugbluvxLvN/zZTL4Bg+zoQs79Rx9+KlP53hpC4bt7kPO8AMTZMganmuVTTMIZnhwA1PHXQzVKUGDgzakhZ+/QR01guwTG85Fh2Hje8y+ImEPxlKkGigKAGnqMP64v45fkPb+dqgZmvCeZ4+ZiOdIz0F5y6yVYdC8mQc6Y5xbzZTZG5Nv9HKe1hSLTJ/p8QqzmXMspgBg1+9cB65egsOykfY8u9TvtdF5rx0hGG8CXG0zyXB94Ca+Kcm4BfhhY8rFjwumZxaEjyWqLQZJuj/k8kABT0e0kEQxEP/Cb6MVuXWRxPLONjb8EanXeKugjLe5OYc9tDdWx1XPqTW4deVMWU0TxTmSxvOVhG7shXEP1OWw65mhr0cqyEazbiFLAVfbFE3a3OBp+/GRKwAwvbnc9/Ul9l+0DK/rIyUXI1Y6toaUTzsqryXr313y8Q=="
-  },
-  "bafkr4ialzawfqojsdqungfvkxsxa2iibt7sdkksqg7pji6lfumxx4g274e": {
-    "value": {
-      "inumber": {
-        "/": {
-          "bytes": "7ZvvLa9s5/MxqtesArctKhbSHrGHtv4ndDhloMGL5aM"
-        }
-      },
-      "name": {
-        "/": {
-          "bytes": "aCl7M9B9ISc0FKfkXlC+/fQrBieSdFa7UHfg9pxWUysSEqTFDNmSnAtJrTLHKvcrXdHNABZnh+8xmzLMsMWDfhbpgUcy8JbGZHUE5tdEPJSjmfzymH5hcA/5ZLK4GveiCpcwnzgF4rvBF+8gjtmlAcfgZODJVtQXpakP7JEv4/0oaD4RfFSCYbr7dI3ZwMbTn/0ksZ4GLWWGtPSbzca9i6r6Rf+94k1s8Du7HPzflDtHvhhkYPqRG4od8xElyNKD9kA7PchcDyEO903zaRgnOdlx8+jxVeTAnDa2fYb9uBvrmQVxp3aKG8onzWPqcvyOxFVUyA36YYoflrmgEWQ2DA"
-        }
-      },
-      "ratchet": {
-        "large": {
-          "/": {
-            "bytes": "b95XEkEp/IWq3CHcuY/FLd9TSA14bbv0QE9Mrq7sQ1o"
-          }
-        },
-        "medium": {
-          "/": {
-            "bytes": "z7xgOiJfD8LlFflXWeM0gvUBHx+LXf76SWglSQd1PPE"
-          }
-        },
-        "mediumCounter": 128,
-        "salt": {
-          "/": {
-            "bytes": "N0VVwHRctdFamy9wwLDwDau8vOm4vw38NzLZ91fvvJw"
-          }
-        },
-        "small": {
-          "/": {
-            "bytes": "7DSyYV83IQ+FL+/xhT8sHLrYn9A+vvfkwuc/atd4MOs"
-          }
-        },
-        "smallCounter": 215
-      }
-    },
-    "bytes": "sUslhbC1FU9XYt0BwpDANQ7eNWgUChbbmpV6GSrILKFmeWKvDGGnAyK+QM3RZqVaIv+nEzeq0LnWp0Ckvcvi9hhP0uKcw+SRQxst3bGFQWV8p155n3eO8FW7+aiBwdrJlTdH87dlyeiiIXQBBy5rvWRwRDQrkqq474Vwj6HIt2mnGovGjzpRWoIbQQnV0aioSLVcLdEQj2XUpBM834KoC1cdWXDcLxbdQFZ0NM/75Dcb2nlWL7eUEUbAu++dAdOK+biAOdchpP6CdaYLz1krxOcY3o/0wIyOd0Tuq0tHENJZGZUayVfPpc0BqxHNRBFWCwF9Hti/hOdYPk3jN7ZZVkkay4BZgZyHO3TiHZ1ZXPoOGtghKnBp4Im7PnG6ryWhcp5rozWxvPzpX2USlH+TwrNSSoH57sez+5Y8OqKgO2tvGY67BWcZWGZP5PcfXCBD2fn/LFDKztB9JXgIIYztIaW0Sew/DVkYdYvP5OsfA5JQhXUtbe2p9SRXgUWRH8VqAJy3hZ7V3wGWO3JftMyhl8Dmu/Tp1Z0JZtzoV+37aZsHIi4pJ1BcwAbZLKhfIxNBa2yLmBjXL8S1InPTVWw61lWjtAR4EQ55Fg4SfUa/Z4TYtWvIRkuEwAfboSiiAhkBUMOzznrqa0/YM5yn2xDyQmyuT+xlRgBOnmQ/lrbh0w0cbGRINB573g=="
-  },
-  "bafkr4ib4eoey5sv2bh4fvqu3t5usrdfqtffyi7ib5fakmb5en23mcuul6m": {
-    "value": {
-      "wnfs/priv/dir": {
-        "entries": {
-          "jazz": {
-            "contentCid": {
-              "/": "bafkr4ighicgigw2bafkdye4pbz5lbhqbkv6qrulzvqlbfy5jkcms764avm"
-            },
-            "label": {
-              "/": {
-                "bytes": "vJLPpwa0mhmCH4brcvkwkuifDEDqgTLTPpWhqVG5Pow"
-              }
-            },
-            "snapshotKey": {
-              "/": {
-                "bytes": "U9+m4P2Cf0ob8sKpkPPxL8AQ66i3nPQg+Pg7xqldJhc"
-              }
-            },
-            "temporalKey": {
-              "/": {
-                "bytes": "gpJ00pcM4rhRq+DZ3yo7uHs3XDCU5lyoShHu41oI5sNaIEuPV23Vsg"
-              }
-            }
-          }
-        },
-        "headerCid": {
-          "/": "bafkr4ia7pqc2hlj6hfhekje5ahetokwa4wf4vu6t4ds2oo4zj4xp5kc6yq"
-        },
-        "metadata": {
-          "created": 0,
-          "modified": 0
-        },
-        "previous": [],
-        "version": "0.2.0"
-      }
-    },
-    "bytes": "rKZokOHhLOcKvVUCeWXl+3v2h6SE2zLlalGbuzKUqID/L1MGRh/W20m7Sd9cMB9smmM2F+m9NmRyBpU36R37uACeh+/hCInGgZc8Q8uitjJxN6rGBUYClu9N9gqq6bKoq1Q7ftOtPxZQ//STahJjvxUsI6k/wlCsBW1ASdn0PeFgpyOm/5G0EmYACvLPbNFmK2p9hoylErzS7nL/qZ3Bo4BYYtgvChq1Q4wKcmCsHe4nasxXwf56b8kWMrlBjk1RZWVo0TJD++iEG/m9UXsIOe16PTdmNzwuqF/tnFOFbDXtM1rO6o9NU5RI5OCzGXCBTkxNECGFVkzfepls4baiIJXScwodLfWq218DDdeaofVnI/D25hReZbhF+aZX5ffO5YoScTVfZpcAy5a30v4O1CcUZM4ac5qr84e5kKhrC4wk1De54amyEnTpQKwM5Cp3cPIjXzSn3XyQxT0rojf+05wSsdt8x1JCVC1B0IQq3A=="
-  },
   "bafkr4ibpbyy7pbkq3kppxasqy7gh6nnfg35on3n76vamzzku2gberpsype": {
     "value": {
       "/": {
@@ -166,7 +11,7 @@ expression: values
     },
     "bytes": "vG6ZYJMyeptrhuJGi8skFx1dpDnCGMy40/ExTPFIbgoktrjNz/xvzjbksKgkBoampf3u"
   },
-  "bafkr4icgxtjjq3zqn77cugdjk6f2tj6piunqjap3d5lifs2vvrtao2jor4": {
+  "bafkr4id27ok2an5uiboe2ssvitwsgrzfavh4ez7wx6q2cw2c4joxxql6je": {
     "value": {
       "inumber": {
         "/": {
@@ -203,321 +48,9 @@ expression: values
         "smallCounter": 233
       }
     },
-    "bytes": "bofld/8bLCDLjtMq37oo69jDlSt/NmAwBddIXxF6s1fBbPagMuFdrHWqmQT9+RpPF1g+oxfRXP8E7/IwdDd3/qtJle9fhOH4CQZmS9CqMQOT3zecdmsN30ogAZrZzLy0ro1tjVZKrIPWOhST1ZDAcyMh7/zgzzvWbc68vLNCRrMqAgs58w1Wv0ojmfGdZ7YFVCzfqDE2PBlaqSLbjJDf88feChMH6jWsgGsfynalJQqxvOiyH22sCm8gwpY8mpgkfOeDTLxget/rsF60lcJAgmXwNjS0ifLqaHbSEHz44PWuCpZRgquF02pr9Wkp+R1fgQnrSUBl619HKzCe61/yI+YUzTO7Eh5hAvUThKpggTHcD9jCOfyYK2q6fGmZdbOLy2syoqNk2wTDhvM5ek6XIvm0SMFQBVoIWcKf76uHuZwjnR06cb7uKB9h+69lw4dq84dlj1/6IlMXh3r+CS6iYiow+08UR8Y2l+Z4SPoNs1YiwAMoeeOHQh02d40Ajk5zjeFQyIwBSSS4sAMtAoNoJU67cttoAMJCZ1tfDku4E+pGPSMHfrUYeCc9NJ9ilqkbEiIZFYw0ZdSGCF+uADbRJRu2hoG2kapwAFCP5oxXcdF2Mdex1pdqqaERZot96RoJpZDy4ScnZinVl8KAXpWFLT5VyiP+yrFE9IBOziEpTmMQZ1ELZt0gJQ=="
+    "bytes": "6rSlRYc/JDqMDHabm6I+1yQ0NKkmtCk41qKzfyg2wuS71KZDAbyuYpq+6SGIxGulZofSncSKN+JcrjrXs0T3r5RynGTv6TJozRZXCMdynmAMxUzep1ox9dPy6PBSDCsPN0LqnVbF4cw0fAcH6adUoH5Frlz9AteTcPWJQ73iMtQAnKbDJrLODW0gcekEnuB+S+zSVArP9WguxbddUFoLnVfxFzg4j8dbkgeJB4Ix/AGwJjqZ5ir27PJcRi0hzuuSHAznydOACqUK/w7723pKf34rFyt/lsnNE6ULe9uJbvSU80Qb75Nl+LuLZrmEgcXJfew9mCLgMOIKtjbuOFLMZEgLB/P4vOWk2PIX4T3htgtxE4QWlWkUc/xZfZ+3qvQkxFAPKRoTBzvkmK3RXB+4sVv4E2ViwhBRgaa4SUl7OCp8s+1uS4aAHauB6L4Aqu/ER0ONOHjPj3WdNUjhxWJyRpRQAheOcu8rIfyNeDA/AAvQNj3X+AfeUOM2jZjUDBuXE4ylXHhumJ1Dt6fAO8L62NKzaU8ljOPtb5V/FJPwKBHkmL09ruSREMFVpX3IMP1D2ijoh/kaF/lPH0H7nltbNCHv+V02DK9SMZJYtAs834a1AFlK1uOgANs/kOXk2ft6DH0XAuLl5NEtCGp+RlUtOsToZNC4MB6OX1CkDOASWjxAfMm2jC+zqQ=="
   },
-  "bafkr4icyf5r2o2lwbfampnwbgvtp76kxisefgxnc3qxozwndtdyb5vnfxi": {
-    "value": {
-      "wnfs/priv/dir": {
-        "entries": {
-          "movies": {
-            "contentCid": {
-              "/": "bafkr4ifa5i2eojj336ptkj6bkpmfu5ahkocgntjh5tprpqwavif6imfs54"
-            },
-            "label": {
-              "/": {
-                "bytes": "6oRphljDvmnjdMgOAKNy4Oam8JdPX1ZQN75IFObfi48"
-              }
-            },
-            "snapshotKey": {
-              "/": {
-                "bytes": "djpfO1GgGa0bN94WUWHlyi7F8Oj+M5GARS0UXmdFRPI"
-              }
-            },
-            "temporalKey": {
-              "/": {
-                "bytes": "DT7ytb/v+bJ1yGzcOjiT89w5PvveQzmhBJBMF4sVXQKEo0AZh6sI1w"
-              }
-            }
-          }
-        },
-        "headerCid": {
-          "/": "bafkr4ia6ddv7yfregz6kbs2xxqledpwbtevv42gpgvpmxg6b5utlkrjwha"
-        },
-        "metadata": {
-          "created": 0,
-          "modified": 0
-        },
-        "previous": [],
-        "version": "0.2.0"
-      }
-    },
-    "bytes": "f7Z6Q+0RfkBPBWsJz+Gs3268UR0ooT5pkUuubYwDg5t6ryCI8iOr7A2mHTfY+UgTMEcHqcVfu+viaxPooEuX/+91XO31tAc30d2QBrMAL8awRX/J6+QGRMjmHpmgzmB1mDlt78Ln3qRUsj1HaGRTUAZqg5aK8hwcqDJEPjbDzlD/AdILzo7jyF1C6deu6SAHSLqJWa6zH9FDnAoKMSKttOGwDqA3fOHCFlVB9Unl9AQ8yfsrfZ7WOYsToprTCJyLh98dCz+nGdOn/dRleNYBp77A9c5GJtq0rfkfHc1CzFej2jOZG1HeLlZREolg6a/+ts2k9uoZHP6l9MYIVsJaHfjEvoUDoZtXLFnJp4VPZ+jHWwk8Vxv8N1WAdb/JWgki35RI8G0TeUiwZMc8ljqpDvBOWVb/w9H0KPbryXJ4CAEdCt+SEJ5eFrtx5LpGrswcLq9i0Zs97b+S56GAYmoWoTUjDT7QBepHW5Bm6iXUIjQy"
-  },
-  "bafkr4id54hntfdhurztwuheicsvk4yumsdikg7eo632bj7ibsbt5yj7zla": {
-    "value": {
-      "wnfs/priv/file": {
-        "content": {
-          "external": {
-            "baseName": {
-              "/": {
-                "bytes": "PXXRpCTOGnww7rXEAdSoj9dd0jF3XxtItnAOxLN0+e4ldHbNCvY+aslq2XWDUeAEsmh3+UQHLkLlWPhhFRvXmi71t+oWbi+8gYnsS/JwGwD71MBa5pNtGoPM1j6LpN1yqY8X5Nb6sV7ZHIA5q5C8B692tvY0gh1uzsl+W0zMJW3CZs/TrYbNS2hFUYlUNtIyHsnFPvusemb2k+OwWKrt7SL9tZ9X2+1JzAq2f21bK3nrSSfhyJoKfs0K4+RDvWAcxcuaipFp4Z3aUDI6oSX8P/9K/T577WUjO0udi4DjjH48STOrMPPMs1U9LBW0NkFWXyDFOaFh2pr+mAX8o5IWOw"
-              }
-            },
-            "blockContentSize": 262104,
-            "blockCount": 1,
-            "key": {
-              "/": {
-                "bytes": "wYGfU86hcikcBpbCe+6Kuv2P53356Ae9rOBxGeGjeJ8"
-              }
-            }
-          }
-        },
-        "headerCid": {
-          "/": "bafkr4icgxtjjq3zqn77cugdjk6f2tj6piunqjap3d5lifs2vvrtao2jor4"
-        },
-        "metadata": {
-          "created": 0,
-          "modified": 0
-        },
-        "previous": [],
-        "version": "0.2.0"
-      }
-    },
-    "bytes": "4xPLthg8lZC4Q2TKeFIrTtOqmrcLRaPOz1e1hxe28M+CpFYetz+i7CdMPYzrLtH1X/w9FHowlR1pWo2pzeT33uF+rUsIYttidhZ/D8S+wo3L9aVQkdapP8hXZPHlat5GBMA2AcL6z9bsH4vKyjF5z/MDtji7gwLQQ/G+FZgZyRkHvR1In3ImJV38RfqEzP9XG9vHr5qSTQmwqrKqOBblgaV8d6rcRCA4bNTsvVbh/kcifmzhCafqBm5bBY9YyWqWKhYEDkyWIR36wEWweMc8f0hId++CmdLlI+77nAGO5II+rf9O65XQs4iEUcIW12D3KOKAT0URhH8PHsYhKLfrRTXol1QVuv/YY7kcwyv1W7QYuNmyDWBjVQZwGoK4kNNRNEaaFvRhpu8rhIDt+gLkNM9GI3wujVRZrP3A2gDqjjdSKs1CIcKNqV5TnKzp3s34IIhBo2zX7hs3tBBqYP8s3Q6LEm3f+N755At4/dz6jW36xw1UzcTf23292N40uqSOpOY/h3VAv8fln0h9ArWSTkq1SHBrJL7wggRjNjSvs/u5uhbC9nEZeFK4nRlAPzJawY/tcssPAwwioIsLH0JMbMLsX1Ae3HImAU5es1Wj1cK5XNRQgZ2g48/I8u8gmLTTJsKfmZdBXvFVcwylPs3ukgHf+HnRMW04D1/xjo8kLOi5yAU7h1jghQ=="
-  },
-  "bafkr4ids4frwdo3i7vfotshrgrid6tfbbx4bkwpprpt6i5shod7nsauxaq": {
-    "value": {
-      "/": {
-        "bytes": "SGVsbG8gV29ybGQ"
-      }
-    },
-    "bytes": "SIFrP7QTHcbJxYRf//G+3gbIYuM7r1MNps0gn2k9Y9XuX8mgaZwXsFM3+OCIhXO/48cK"
-  },
-  "bafkr4iejjjkfbpeflivh436mut6254p7gujytubff65e2kpgqgenvqizh4": {
-    "value": {
-      "/": {
-        "bytes": "SGVsbG8gV29ybGQ"
-      }
-    },
-    "bytes": "rXpvVcxD9beDA/T/qtOLeX8I7Ie6GXArKOgMjHtOv43tOPmkx1bjBc4KCwXFB2gbq6sK"
-  },
-  "bafkr4ieoqvjjlgphk3swbfmekbhabajdya3qi7bd6wypzf7edqpagwyilm": {
-    "value": {
-      "inumber": {
-        "/": {
-          "bytes": "ypaJGIrS8i9y82KczwXG0wtvpesf98lrTfEkPJFh9JM"
-        }
-      },
-      "name": {
-        "/": {
-          "bytes": "thu93ziRXeiShpo34RV3DucMrwZcIjPrXbUKTmD7lBPrqkwUjvO1bM2FPyNq0Hejp+c7xXpaUVyuIFtdJ6uoJu12ucIpkMXEtyxAIDcJWxnMK5BQyGL1k+T5ED+S5F8CYnSnLsFivkfwif7z7jS87zbDaOqM7o1wO60fAYJDDV0br70mi3jz/U0gwyL7ENo0tTdOyx/7kkmMuxEhdXfAXrnKeUWJjqlOFym+koeKkBSYWaqqlwcW+fEUhvuN8BOOkV2rw0Cv6yneZAHMhCXjeVhB4bEq+TeUzjDKHGI52cITqgi0EIoly4ry4FP16fRKxPp3MA+SHNmXm5cvl48H7A"
-        }
-      },
-      "ratchet": {
-        "large": {
-          "/": {
-            "bytes": "qORVSKgvnZ0QKrnDS+icXs0/CehJuHXOiAM0c24yGZo"
-          }
-        },
-        "medium": {
-          "/": {
-            "bytes": "HkeMDQSmvMWFtXcJgg2+ybJmMKeQqCPRBOgCP/w8c54"
-          }
-        },
-        "mediumCounter": 204,
-        "salt": {
-          "/": {
-            "bytes": "Eyss3p6SPJzhIHH68fqEu3kNQQC6JHe+YHlpB9NH0wM"
-          }
-        },
-        "small": {
-          "/": {
-            "bytes": "re72wkaCmnH6qXpCXL2O7cAJiii/JusVg4z5Y8cgdQA"
-          }
-        },
-        "smallCounter": 96
-      }
-    },
-    "bytes": "VS/rbDU7iv9Rbxc41EZh95U4C5yNXWGn1bR35LrbZs6KZdbiSBW1xaNXcHzCRowgSFcZ7kOFz0s3nBS1N1uaa01CN9TSRkJmEbLeGLP9iNHoBd0QuV50/Wiky8aqlBFSlYivsbC1poKFFa3itnePghU5/78lHHQzi9hKOkuQTTRbGIbBqSlrGp47NidtrOQQGSLT11xV2VZceocI/pTQV47/Ie9i2Gu2+0eyHu+BU/3zU3qpf06y7OaY/NQGhIt5dexlqif+xKULS/rLzwpr0nLS0d1z0HqU8/MLLmW+AympiJeEAat3SpSBt8heSPAZtqjfeinBihqZDXDOWJjSlFxZxZN1rq473VqeDv04fSWOz+VNwFsysC4lv4MOzp679NUlKGM7bqzYIo9clun06Ut+H4s2lYHLw1iMdvljeyvHs9OGuGN/d/FKqr1PV3tOwQDoPal/TftU27p3M22eKfW9d9kVu1Zd0MjwKQ8BNG2quURD0F6JdT3Dn4v4p75CPvy0sP/W00mgCh4mAKkwTF5blXYEGH0fWurBj4lwAWr4wMziN7RKEMjiZkdkiykBajBES7Xyzs1rdbXJt9C0ADeeeOwni0B9SSo/rW8hEYNdXBp6727AjpRG+kU7pWYW09aT+Kzzr3O2Wm9/wvPN25HP5ld7VRwP473I6YQBeVsozA1dtghPrw=="
-  },
-  "bafkr4ifa5i2eojj336ptkj6bkpmfu5ahkocgntjh5tprpqwavif6imfs54": {
-    "value": {
-      "wnfs/priv/dir": {
-        "entries": {
-          "anime": {
-            "contentCid": {
-              "/": "bafkr4ihg2zwzklxkjbs3t2c3geyc7i3luq5wgfvszfrrvt32gadpepmhvq"
-            },
-            "label": {
-              "/": {
-                "bytes": "mN/FtKXhE7YhT5lPs9TJtHQBPFml7SsP7/ovU/uDDuA"
-              }
-            },
-            "snapshotKey": {
-              "/": {
-                "bytes": "y+4nC6ZcTMwNnhoD1DSverO4ei3sE0PYqsSYk2BUdks"
-              }
-            },
-            "temporalKey": {
-              "/": {
-                "bytes": "DX3YA67AcVij1nE+rSshGFlSsIEl4vXIuImzQJCOLo3OgeJh2Qx9KA"
-              }
-            }
-          }
-        },
-        "headerCid": {
-          "/": "bafkr4ialzawfqojsdqungfvkxsxa2iibt7sdkksqg7pji6lfumxx4g274e"
-        },
-        "metadata": {
-          "created": 0,
-          "modified": 0
-        },
-        "previous": [],
-        "version": "0.2.0"
-      }
-    },
-    "bytes": "jCZd/ulsiIetp68MkeBovSD3o1Dn3CFjonsAMgM8zqmo5anJwKAno6sFAFEvjm1BlEpr9HHTZTVRMwv3G7Uh0FJI5MNJj2DJDVZ9++nJj4R4nCr6r04KNQDCMwsC6NwEeWTNKIcaQhEIFpFCIXvbsua4GF1S05RhxvT6DjyaxaajY52+64dhotid1Js6xoBB8LlF9v6DVNtXb80qpjw1GVriUR/AbXYK2auhBBXAvcLxUJPYmOQfjl65ME7ZRxY/ktzwMK387QQVaKO//A2LusaKRq1AS32qiuzvm12gkmhGybp9eKvM/UbKODJ6BJKtszTJpZ/SF1dZnG+sN38axMumliw8xX/Cl5hqh3F0er7uF/0EpNIOgljHEMJb/V0yZ1k4JyKLHKXlX65y2+aJbSW2YIq0YoACRuLXbAnK0H1epSAdmgCceXwQorHxkfZ0EyogFzdpgSq4DmWD78GI1/NQ3qQxIvZjCAyvd2IXCFo="
-  },
-  "bafkr4ifmed3prclylogohletbebwwgrz74fzotipqogkym2wwkbq445vcm": {
-    "value": {
-      "wnfs/priv/dir": {
-        "entries": {
-          "music": {
-            "contentCid": {
-              "/": "bafkr4ib4eoey5sv2bh4fvqu3t5usrdfqtffyi7ib5fakmb5en23mcuul6m"
-            },
-            "label": {
-              "/": {
-                "bytes": "lq6rVae2agWdmmNEEx1w64dLx/aMc3ll/8psNhWIst4"
-              }
-            },
-            "snapshotKey": {
-              "/": {
-                "bytes": "MNYOjFOJ3t8tCO8ur++EW6sfbN2pfuNLaj1pi5keJ8k"
-              }
-            },
-            "temporalKey": {
-              "/": {
-                "bytes": "ds1TTBBY9O1+aMg2SGje/WEHJ78NAyelryCF5ZuayP5PBWAT9JxOEA"
-              }
-            }
-          },
-          "text.txt": {
-            "contentCid": {
-              "/": "bafkr4id54hntfdhurztwuheicsvk4yumsdikg7eo632bj7ibsbt5yj7zla"
-            },
-            "label": {
-              "/": {
-                "bytes": "SWaK4UO2W5Xv08HqgK8YySkZQdLHGUZQu8oY2lPo1iQ"
-              }
-            },
-            "snapshotKey": {
-              "/": {
-                "bytes": "BNJkDOvegv182MPt2srGn+9uwdscu2w8xC8XekORO2w"
-              }
-            },
-            "temporalKey": {
-              "/": {
-                "bytes": "F9FQciYmT1MyLMvFIwH9x2Xc/WkeXFXUVO8cGUHdPJd8xxM+owByBg"
-              }
-            }
-          },
-          "videos": {
-            "contentCid": {
-              "/": "bafkr4icyf5r2o2lwbfampnwbgvtp76kxisefgxnc3qxozwndtdyb5vnfxi"
-            },
-            "label": {
-              "/": {
-                "bytes": "BvX+lV8s7/hxH7U7HzcOwGkUqtygbqBMnE8bCE4yl1M"
-              }
-            },
-            "snapshotKey": {
-              "/": {
-                "bytes": "2QNnZB5z6hUhHnSqFGIGLogynEFC8TfBZEA6F4yF75s"
-              }
-            },
-            "temporalKey": {
-              "/": {
-                "bytes": "bv5vwHtD2v1/k5hq9KAjSq0YaidaRwr2yqqXsoqrTmOGd4jljxrR1A"
-              }
-            }
-          }
-        },
-        "headerCid": {
-          "/": "bafkr4igo6gzbk6zax6jhouev6e7lzfg57xjgvuguqpvsqyir2wpqmelyuq"
-        },
-        "metadata": {
-          "created": 0,
-          "modified": 0
-        },
-        "previous": [],
-        "version": "0.2.0"
-      }
-    },
-    "bytes": "35mqAHTW0wZrgWimDb/hhmgqfPCkjxsx01Bb57B7Vv57hhsk7XZLv4YcqUWOouzOuuApFl7EcNFEd41oFbb27QXXSMjkYyN6Cuf+Zvkc8hULw4xQ/5K0r6fdrirkoxEjS1hSd9MaCpko5v21EWqPeRnqWWsj4jLsZgK8vGbNsNhM1R2Isx1izHeU3AwNgF6WXNMCGjnX6pj3LgO+B34IMxFoAhCX5z/K1kM+e5Sb2Jh7QIQhIdwOQyGV16YIi1Yggyh6aMzkH93c8WA83ovrKXMeI2YPqq5pJ/gL1JsRvBBzoSbcVSRURJRDBRNZnOnGoAUtfTimSXyoDjPteWxcusTUEmVE7B8GbrWvCrDl1L5Sm+aoaUO1ukXtgK5hkufZAjl0Nx1/1b+io3jsabHa3hQ9uibw3MqvUfoWsNP4J9xhLs3YpzoMN90oqKonq91BNGkCZyeXil8dx0PZzenX4O7EtXvu0G1/MsxP2s8PUw2mL3ZcKhvWFwsYF32AcnHLHB/4BiRc+24AJl1QYlh77oTIuSKmHEobKoZO4tO/TLI6zRf9YWMfzOlBE45WmVlZjtSYSsMFuxMryMTbIdIj3x1afHo68lib3NU873V2gjLemzkxXVmFiMcVhLzJ4aVI0zJsDrV0S0gQXzWDcli3zPIl/3g9dEZu25BJ8WVK3CcmsW1dWrO9XIboxLoQOFh0Bk999abF4MH/YOulc2EGYMWB/InyytX+adDOodV5TINzf9+toMvr9xiRluMU2UJyaKbKk+19a+UNYRtR4BmWpkxLJ/yHr8VnZarLeXfpOQtT0n2ovzc+lQPRZEEt0z7FCkDXdW0C0tOTUr5mPnSz17HQ2OdH5jcyF6wqBhX4c6b2GqVesCGd6QzNJufVWqTZgrKapOV4Lm4Y6j/Fu9WEWw/axg+hVL9EPMw6u/gLofPKMf6qOCsC7RvA/V8JS5FftdgmL0CQBh2eVzZYRyW6OQ0LZEsWfW2iSo9HQ5DYx3eLS+8ZoT/EitAJDY6ZsnlX2pE="
-  },
-  "bafkr4ighicgigw2bafkdye4pbz5lbhqbkv6qrulzvqlbfy5jkcms764avm": {
-    "value": {
-      "wnfs/priv/file": {
-        "content": {
-          "external": {
-            "baseName": {
-              "/": {
-                "bytes": "UMpPN8n0htLdf131VV5dymCuSWURA7DvuCVX/LRmfX6Rj3iJfT/pSvHkCFQ+0ZqUnuE7iJOcWW9j4NkdgCpKZcRyuKPsRFO0V2yh/XSQD3+KrC/YUaFyczKMG4PK6to6d4BtmvjpKdJ2qZNFuzdTdyLtFeRQjXrt1Sr1D5BKOx1UmJIP1yCJUwQ8m6TVKur+iHak9IliYGvtRNSz1CuFnnl5W6cUJYFq1MkGNWAWEpa7D2zeF4/cu3cte2rkFB7vreIysEOVPRpINeMZ7MUk4yAt2LaLA6Y5k89rBHCbPJE5XVbQSMh1u5aa6EQiYQDkKZ1N6g/Or8lW0kiI1J2h0A"
-              }
-            },
-            "blockContentSize": 262104,
-            "blockCount": 1,
-            "key": {
-              "/": {
-                "bytes": "HY11mdYMnUK6/+Ovq9+rZuNFJ6YZhAin0KZFqMaIRwA"
-              }
-            }
-          }
-        },
-        "headerCid": {
-          "/": "bafkr4igk5fnk54a5azve6pcxkoj6lfn23klyrxqweilmzh6qj3r7le45ta"
-        },
-        "metadata": {
-          "created": 0,
-          "modified": 0
-        },
-        "previous": [],
-        "version": "0.2.0"
-      }
-    },
-    "bytes": "JBRWcLMTiXgVO/n7HAGwjlTJZ++zjqbczQxxyg+Bj5qQMSD7PeAMM1K16Pf19cai7j65JvD/62qxvGJE5VtEJOw4sand1c95sVg2CD2BOKn2U/Fl63uxvwU/9HbOXnRR35tSuUPtAJ8rGSR/LGGAkrkq/UuOFGOM3l1Lpab4VXGSjtZBDJDPxgdPDLLHkU7Sn0IjD0G+MDkfApzrqOQTVdKyoFoE5dAAh44NSVeEk9qvmn4qADEFshA4qn+dDk+Z+KZBGrIwr/0tjk59dMVV2EZ0V9dczcDiW1MM31TZHp2D+73Yz8iGzpTxnb5eLgew+bp4yHHymClFr+KJ7+aG/5oG7Zj0+YyZB1OYgDdmZVNzuQfyD4Y295ggUw8WZ2f4K0snM1dV6nrr61pp/9EB+4rzlq023EX9IIxvLe4DFDnTAE1Lf2A5BTsueufAQTipf8WrfJRT4j4xQIEo8PsPZn4XOTn4rIMgsr/7151ZiEXEiBW1Tys2UOun9nMyedJkEovinPcRntee7dNfBMuNlocCR5re+VpU/WOfYUh7qrsAhymyu3va+lXA+Us6H7liqnTLh/277em+KqSQn4aVxl8Z6vPtLe5NEGRRF6HKUOFVbGDdMrNl3NY5NNvVrA1BbtfCyTDLUms7IjAbrlOblEM8z3exezm1f1yH8zxWzvtx+EHXCZIg4g=="
-  },
-  "bafkr4igk5fnk54a5azve6pcxkoj6lfn23klyrxqweilmzh6qj3r7le45ta": {
-    "value": {
-      "inumber": {
-        "/": {
-          "bytes": "7LI5vb6fJKDlptKRQqtS/K7s1D5fX1pQnlh5e8fKb5E"
-        }
-      },
-      "name": {
-        "/": {
-          "bytes": "bd0HYCevh6Mraxhx0Q5qUgIA0U+ule20QG9IYQWZAyIT+k4pOaHFxnwRWjMmcak9ssy/lpEeJFsneOas2qnmPyMo5YNIUG6lh64h5VJxi0bOQh6mozelVCIC7VFYCdwWr81pFj3BGGv6nIEIDvIx1ERMQ/S2rgK2l/gY+kfWIFbQaciwWdFpWy0XxHzuY++JkkS4wVaY7hqftDuPLj0bPq7klvNe4iblR6vHfvt59nUJ/TuhAJvQRyEouPD7EljS+mw3FxFPTDsmbspKOAVEg/M1W6LKFuH1dMnJaILW7pHM9v6LBRoOtstJq/2Mcv41rfYA4LCTZO1eIgQwbtVvVQ"
-        }
-      },
-      "ratchet": {
-        "large": {
-          "/": {
-            "bytes": "+pC06oPe44aEfbeBDfnbmQtdUKXyODqTQdGOW7OU66Q"
-          }
-        },
-        "medium": {
-          "/": {
-            "bytes": "5aJQtOkloCDd1yk0p13d+aNRqB9v1C6uXnaLwzmvZXU"
-          }
-        },
-        "mediumCounter": 165,
-        "salt": {
-          "/": {
-            "bytes": "eyr4FS0kny3XDqCtPGFx5W/SH5XWrB0Q+Hklxfjexak"
-          }
-        },
-        "small": {
-          "/": {
-            "bytes": "ZnyX4M59Vpc3UK3OSeeMIoDydkjYC15BQ/zW5Km1di4"
-          }
-        },
-        "smallCounter": 123
-      }
-    },
-    "bytes": "HP14P3X79frAW3Udgo47zP/le7U/d6RYZCMwrlwGO+tdXaC6+hjO6v/LB717LE0qivboubZ9KbK4H4MyjHfKFu0WnCOfeeOXnKb5lRoLdy7s9HwziPdZ1k7lVs2jFG78jdeoCP/ItQDYEoQ3Mry0tLemBVbwQqc0FujesA+BHVsKF8ZKrCD6naKYZ9RTQQHxREWu9Sa3PzcP2lIcS0OAEGmGfIoKIrAF+UBqL+VG7bQSAO6jogjlbNJ5DTBYeJhykXek5pvpxMsD5eF/RS3aTKV55Uh9o3VGRz2TKWxe1Epn48GzU4qa9ia7Je6JOrEXRz0lrhFvjw2PeM2ZZ2OXwW4vH+gqvaQVukIfLoEGGA4tb8ZukY5Q6ywizC+oQ6cM/1Bg8eqkaqwEFeXrg8kbK5N94HIYOkRvfCDMeLeL22+kfV69n/3qFLX8aAcuUc+pPtlu0ijUqKMv27AxJ80x8fKjpW3oMpFt46qdpKqXeZbvK7C4IRtkP4NvsfW+4tp428j4fxVim1LkBpEWcFMseeCzhfSj1gevjFj3gmGLaymF/5JhbRLOel2hXg7sTXX9CwX21KsCAekR3Heyo5pIzlVJPmZNP/kjuP/vsv1RR0msAh2Vtzd36HaYo4KPeeRpB1M91TB6tdXcwwZnJ/ZAPy9Sa14WtWw0IlEvX1mFK17zF5JXvmPNlA=="
-  },
-  "bafkr4igo6gzbk6zax6jhouev6e7lzfg57xjgvuguqpvsqyir2wpqmelyuq": {
+  "bafkr4id4dtihsnfxer2fetfspcxgakiq23xk7cxmumpvzwn2kyoxfwuh2i": {
     "value": {
       "inumber": {
         "/": {
@@ -554,16 +87,444 @@ expression: values
         "smallCounter": 85
       }
     },
-    "bytes": "U7HxOYRu5Z3znTkT9MNFlIgltFOTHDUr6VDWsvXeKnvd4ToszD0agzxB1vQXVVgP5MCFxMipXiFT6/TNGCXT2eUac2mdlnh58ju3XQj2d+W/8W2Gzh3/w44pLnDyYH3uEAIo6rBxhakbrMUnEqKv6LRov+Ln0pPkQMnYdQprB/FQA7guXfpY2hNmwQAb+FFzv4K+tmyDt+g2ka6XtEytphG5sw48FrZ4vAioBvQDLpuFjzRRR8XXkyAMwz5h8eOgg7M2J2VznwxhRaVSReFsu6W0LLnqEH1NUp7GAo11xcesc81l1CaKSu6Qpj+SSOWNybGpiUoxeVOswcMhYzUTJ396jXB+IDpz7jMTJZ6aohGNhuXKjihvZR3GWeFhQ5XLdqppPxzOx6Mi0EW5d+KCM6T8HVAOehd+dBe87RW02uYbrW+2YAP2puVQeOAjVF6WAggiEgc/k5w8tmbnUG00E5EVAIhz/zigpDzo/M8aitlcg1egvC1StwB0j1AX69Bvgkl0LEPUMVJPDLG6MEudtOB3rIDqmzi46Qc3wvZNyFP642YBO6j5Pu+/bhqTjeC0yfdCMz54XWjUNgUioUIo8gRgCHwynIXQtqOW8/tbREX4ITTRQiA1AUmb+yOWOwkglsMKdXuYowboqyiOMkLyeE/KDUIEPu9w2xkl2PbBsDViC5krEs5LfQ=="
+    "bytes": "ii7le04vg5L+Ba8NzLeitiRjoiELZHxNwsAMiHJ4u1iPqhNogDLMaMXYnJvnEyipIJWyJjB2y57EAdQNpDa6Kg/eeHgia3B3jjH7qnaVY89NLSB7yVaONLd1g941kLxeW8O7ljsDbE44U3jB83vR/QSwtBiu5iMBSOzFaf4ehVgNSFXvERjdQBJxNnVFx5qjl15FZyOr/AzxEDdbu+fEDlNRMEg9BG2ztzzsl6a6bU01KjowBhf0RNarA1eIfDxa4b2WmqnX0dqHDJqLceIyoJclMqcLJ/IzxBoq4ZBuqIc75P8bnm8pyPAecacbU+w3rPTMJ69OJIJQYNRwI/q/OPeUE3Yj9cnA+QiYlbbjjyJgODDK0cf5Q+LGlew/FvWdK85SwsASbmsJRxIc8zz1cDWTeUSyQEQoqhuyzUyHdWYiRlP9kKZ828kUl3ppCprdpBI5XyMQcl4vIkKaMKlbBAHzgAHmqColmpJBRoRt6CE7aIB0Dri8jSQMpuNmdkpX/a25VEwU9PT8xmGDLcyw918CmPc04ulN6wIzK3omsnM1wM09GF3YD2STmdlmSiXup4fnizfD45AQi8KwiopgMdQhdZaRzSDTO5lq7B8qs3m+zBXnBJw13wZdFp5g5ePiAR58CENxPBlf8MqZZeszcyi8M6c0S4uY4cJOG0fB9wMe0/5g7dpIfw=="
   },
-  "bafkr4ihg2zwzklxkjbs3t2c3geyc7i3luq5wgfvszfrrvt32gadpepmhvq": {
+  "bafkr4ids4frwdo3i7vfotshrgrid6tfbbx4bkwpprpt6i5shod7nsauxaq": {
+    "value": {
+      "/": {
+        "bytes": "SGVsbG8gV29ybGQ"
+      }
+    },
+    "bytes": "SIFrP7QTHcbJxYRf//G+3gbIYuM7r1MNps0gn2k9Y9XuX8mgaZwXsFM3+OCIhXO/48cK"
+  },
+  "bafkr4ie4v5pcplbse5oplfwh2ddy5vphqizlhzuc27nvputzgypwjkic2a": {
+    "value": {
+      "wnfs/priv/dir": {
+        "entries": {
+          "music": {
+            "contentCid": {
+              "/": "bafkr4ieds46knvozeny3uexqfhr6rg2orvvlhu5bvdsbdon3dy72fcolme"
+            },
+            "label": {
+              "/": {
+                "bytes": "GBMA4EKNu+NkaiABT0r+nXE5trYw9Y16BfKxG4/G/3U"
+              }
+            },
+            "snapshotKey": {
+              "/": {
+                "bytes": "GctU041tbnQXxQghFycZ3NCi9KXp9FEvCpsX1fHN/hI"
+              }
+            },
+            "temporalKey": {
+              "/": {
+                "bytes": "mflFW4FzetFh3s+OhhotdmMys+lFVMcJ9W5OnMyNsHcXbcDdS9w7Qw"
+              }
+            }
+          },
+          "text.txt": {
+            "contentCid": {
+              "/": "bafkr4igoes2nc5ibp3kcq5qerw7lvdwx47v4eiycn37kkqr3qngepjbn2u"
+            },
+            "label": {
+              "/": {
+                "bytes": "Pr/Kvof4PIwow7w3/F4NgNc23oJKynd+PIeWrWiwBMw"
+              }
+            },
+            "snapshotKey": {
+              "/": {
+                "bytes": "yxUxDoN7Gl3NXf4T8vpSb/1uTLHf1/lP4zUtMN7N4pA"
+              }
+            },
+            "temporalKey": {
+              "/": {
+                "bytes": "Tl0NzzZCkOQMJz7KBpoyzKj6emCS+IzbGi29QMSGn7lIhkCk0Xt5Jw"
+              }
+            }
+          },
+          "videos": {
+            "contentCid": {
+              "/": "bafkr4igkqdavo5ukmdawyydj4jsfmllux6azgj2yb72xars4ljmmwokg6u"
+            },
+            "label": {
+              "/": {
+                "bytes": "MdJqK4GLwV3ODnzA5uF+o1Wgo2IadpsdxNOevRGvaEo"
+              }
+            },
+            "snapshotKey": {
+              "/": {
+                "bytes": "bMGva1260vF7e0lkT+FqES0slM0vgN7TryBjZpdZ9Po"
+              }
+            },
+            "temporalKey": {
+              "/": {
+                "bytes": "K6nfQ1mo3dARe1fSfJVc/xlI/ULA2zipXQmZn9e9Mu3fDcPAlPtIBQ"
+              }
+            }
+          }
+        },
+        "headerCid": {
+          "/": "bafkr4id4dtihsnfxer2fetfspcxgakiq23xk7cxmumpvzwn2kyoxfwuh2i"
+        },
+        "metadata": {
+          "created": 0,
+          "modified": 0
+        },
+        "previous": [],
+        "version": "1.0.0"
+      }
+    },
+    "bytes": "35mqAHTW0wZrgWimDb/hhmgqfPCkjxsxlcrOuh/V5GzKIPRMEMfDrI/YHk3kqMCfuGfWoIAHP0snosE2RsbJMbo7+wT2w/tiCOTNmoakRn41dEbr3aNSosphNk41rYH90RoggzQfmScaiWpyogT/z4uCqLOM1OSpuiUm3vf3MBMEvRsWa4dSohraIWdJYx4dS6c38oDjlT9QAuBI958Pi8XdiPAseH1duSuA/WVEAN6/igeiUJCBjS9SdUZ2TygsKnyCMRXu4NGj66WmjUGPO3G9SBgguJWDXqyKVsz++nEbyp4syscM56T6w+6h3OsMiiirVfPubySJ6WqtqHVdUdID3TAgDjcek5LJTi/dCjUlxHnLJNJDdHdMfr/gSPrnmU9b4cuxMGouT+8BlKK8yR9hMARwVazzt1av57uqUkGElpa5e71gPPViVdCe+t1c3POIGOzl/BmUh+qh/bSSWB0o30dFV2uhR+vWqPYTYwb22ZI+PfNJ4H6YRI/O22+e2wdMsNa6WGzR7V01lZ8n/vL5gprkEfdjlotC8EmPbjGHCc3hRrj/8cC53dpQZyklTd4mX7lRVoD6+cWJJFt9QNhEQuncORBSvjQJzVftHsYJgA39jrhadMG/psKR2QWBnv4iGySlCqVxcP8hjsGkcZ5QNM2fO/nIJ1qY5lb+dXFvlAUF8NTuEBRFl/p3eec8F0fbahtHRDdVxFRbKU3/6RfavVND45E1EvjqiFj7bgyAC2GbmVOSTd3+5PPmrTTaiBA+w+fsDao4v+EuXoCEW3+1Am40Dd3XHTAs7M88YmyVWrxb8OcNyY58gBy8dziBMaJ7aqlzbIa131tLdU8dzeAVaHEq1jeojiAZru+tQdbhMnVC001+mIrg0GAdjOftMkchLzUU1ODASegS+uTdzIcXXO54OrGQt3ks09Da5r2H+NqBV67HhM6bezks5O8xe+NEE+MQnvvvSGrLfv38DP7mUqUehBpLgFRZLzUHBjAd4RxzxucKalXVIJMrfhEVPK0="
+  },
+  "bafkr4ieds46knvozeny3uexqfhr6rg2orvvlhu5bvdsbdon3dy72fcolme": {
+    "value": {
+      "wnfs/priv/dir": {
+        "entries": {
+          "jazz": {
+            "contentCid": {
+              "/": "bafkr4iet6tkcbjesymahvv7p65qkrh3hd5yfftaidfresulzmes32btkqi"
+            },
+            "label": {
+              "/": {
+                "bytes": "CU27qct4Yn3oVYDQIL6XoGDw1yxRcjbGpXeICSW4X2w"
+              }
+            },
+            "snapshotKey": {
+              "/": {
+                "bytes": "sRFISMmAn36+mP7DKw3l+UlgWk6PtR/TRA2bpMf7i20"
+              }
+            },
+            "temporalKey": {
+              "/": {
+                "bytes": "8XKv3Kzu9OlMdVLH55opsyvo0ZBIPQtWVwDcp90Miki+48PpXoeFqQ"
+              }
+            }
+          }
+        },
+        "headerCid": {
+          "/": "bafkr4igjmm53wzadt5zcedrl4j2xiwzmd5shi4iczwqfk2tuoj5xu6paym"
+        },
+        "metadata": {
+          "created": 0,
+          "modified": 0
+        },
+        "previous": [],
+        "version": "1.0.0"
+      }
+    },
+    "bytes": "rKZokOHhLOcKvVUCeWXl+3v2h6SE2zLlexLHf69uLKqmmAHi7AM9RMC3dPlphOc2TrvT1jFOaGT/qfn8K7wcWPhWusEY7wTfzTIQ9UacCDhO2ohnhkK5GhPfgnf5EUnNMuapFu7UlAI8lgjf1Ypy0b8KWeVwjHz0NVpQ3tZbBVWlct06phT8fw1T2ROBHiEKbZev8Qme6zsr1tQDHYXv+i4/SEI92uRPf37MAP5uc8Ev7aXomDmDMgzh+wemHHQO+pMYX78qbZWL20otuR1JwmZCyD/eFALK4HYAE6Kuh6L5KmRH8S+NC2UnpfGlHjLfxUE9ySMyhmLjsJZ+4sm/klLj3+koJp70kqvM9cCYoD5egYaq1EZW+4hOsAZLciIVeIz0N5Cd1zATc7Q+KT0SibecZQE5x+q7Z2EXBt6XTa+rpwbT6KzXMj4o2gEvky9M+JMwTZ42JmXhJf0y2kwasztDSfDk/wHa+OCrX/JIzw=="
+  },
+  "bafkr4iejjjkfbpeflivh436mut6254p7gujytubff65e2kpgqgenvqizh4": {
+    "value": {
+      "/": {
+        "bytes": "SGVsbG8gV29ybGQ"
+      }
+    },
+    "bytes": "rXpvVcxD9beDA/T/qtOLeX8I7Ie6GXArKOgMjHtOv43tOPmkx1bjBc4KCwXFB2gbq6sK"
+  },
+  "bafkr4iet6tkcbjesymahvv7p65qkrh3hd5yfftaidfresulzmes32btkqi": {
     "value": {
       "wnfs/priv/file": {
         "content": {
           "external": {
             "baseName": {
               "/": {
-                "bytes": "VH8vmE2n+G9DphbXR11PBXvM2/9TJMg4V4wQ8XCiYfCz5M98JBMDSJ3gIEKXDsYNYHamvFu5DfDjodUONxjjip+x16LJcv1DPZQ2CGM+ficux5EF+6GGbnc+wVnEouWvxqbh6xyS5/TqczeXzeNVYRlMiEV0FbIlSADo8tj16iPG7A9KavEUgzWUDrlPeT6L9WG2yl01EQ4qS2Pd/Dkcnu8mdnCaghXtDxVXfoIAZgd0kViii6LXSGhPsKZ4ewWhIZJegA9N8Po2iQVd0ke54o87qhwRVfRtjww43jMSCebs/r72qCttB7N+C0mq/sUOQ4eqBhmNyiAi5RyKTLlnsQ"
+                "bytes": "XlJObiItJl7E8FVvluJCf2IRdsy4H3Zpn4HqgeMY1GL1AAUqADp6HkOHhYMhqHM7QqKHuy37sswLMewKyA/0cSpNtKFmfztmDImOkpmFZsFYWGtbIdYbRe4C5W/laX7ot7HVS2UQU7/J6r/zqQY8BuoUUZqQ521NdnkjC7bR4wm9Dt6w9axaO3apr7xs9BjdMstUjhxHkzBRl97T2XZL1PQc02Zgs9ThJKs4S2hkosMfco9gc3rcXfegScwo2wU3v0iDIG/kpWxNuC6DJaRnpURNU1PcWDEKwgYWY5YCrgcibINGRbR2aOB7UtpvzXcC/3dH0YhOklW/naLL+SyYHg"
+              }
+            },
+            "blockContentSize": 262104,
+            "blockCount": 1,
+            "key": {
+              "/": {
+                "bytes": "HY11mdYMnUK6/+Ovq9+rZuNFJ6YZhAin0KZFqMaIRwA"
+              }
+            }
+          }
+        },
+        "headerCid": {
+          "/": "bafkr4ifutwdq3umnvxedkcatmt2jkmuelhha5r4p2weemjt7husmk3cbg4"
+        },
+        "metadata": {
+          "created": 0,
+          "modified": 0
+        },
+        "previous": [],
+        "version": "1.0.0"
+      }
+    },
+    "bytes": "JBRWcLMTiXgVO/n7HAGwjlTJZ++zjqbcuWTEo5z1UpGxTer+m7MTTwLEL+4CEpL2B05rSUXqwmwHMg4E6L9E00pGRj6CrOVejhz5lqq3OEPG6GDFCJthi9xhHBfmOvhLB6mW/r8yXYBVeQqMBygoVaPZh1qX4jlfzPfBJJygcWQhi1BZ5bSCZaWD9m3KkmWGarrw3+X2CLQegIG3s9rdipPNiyPBwCRKucMokWlUDUUr1R62FJ7hvOZdReb7flrxV7G7ucufrxTq5Ty3P5sdLLxcyk4JJxgUtTs0WRgbHSJRCSUp2hSEgsDaTfaz6zNlDV+VZ5kP+F0MCBJH6wW74ixykswHFbHy4nnFNV2XHTkUlsP2l6HLjhiIaTlQUj3I8n261aJOdZS+X6gK8sBWp3Xud81Z/+ytkj5yKO+b976Ff+7raLrENFwzmuaMTF9O2PfWDl1xjgFSg42s/cU/pTOaK/o+SruhBhJV0qJzbWpPMz3RdiXOYjiutIIopOzBy1OD92o+mZX3TrmhP1SEwltTIewbjfbL/XkzNNUfxAAIakutLYqPue8jTiQbjo2Qc1LmlT74H855UAZ8GjMcizGMpTGRFNJ9kK1iIBJrIAG9OwSqc72t7+vHHKIw3QFLPGUgMgHby4BqwS8znfc+FTOltJjwBk1vFXJqoHzD7/pMRPgGIRkoQA=="
+  },
+  "bafkr4ifutwdq3umnvxedkcatmt2jkmuelhha5r4p2weemjt7husmk3cbg4": {
+    "value": {
+      "inumber": {
+        "/": {
+          "bytes": "7LI5vb6fJKDlptKRQqtS/K7s1D5fX1pQnlh5e8fKb5E"
+        }
+      },
+      "name": {
+        "/": {
+          "bytes": "bd0HYCevh6Mraxhx0Q5qUgIA0U+ule20QG9IYQWZAyIT+k4pOaHFxnwRWjMmcak9ssy/lpEeJFsneOas2qnmPyMo5YNIUG6lh64h5VJxi0bOQh6mozelVCIC7VFYCdwWr81pFj3BGGv6nIEIDvIx1ERMQ/S2rgK2l/gY+kfWIFbQaciwWdFpWy0XxHzuY++JkkS4wVaY7hqftDuPLj0bPq7klvNe4iblR6vHfvt59nUJ/TuhAJvQRyEouPD7EljS+mw3FxFPTDsmbspKOAVEg/M1W6LKFuH1dMnJaILW7pHM9v6LBRoOtstJq/2Mcv41rfYA4LCTZO1eIgQwbtVvVQ"
+        }
+      },
+      "ratchet": {
+        "large": {
+          "/": {
+            "bytes": "+pC06oPe44aEfbeBDfnbmQtdUKXyODqTQdGOW7OU66Q"
+          }
+        },
+        "medium": {
+          "/": {
+            "bytes": "5aJQtOkloCDd1yk0p13d+aNRqB9v1C6uXnaLwzmvZXU"
+          }
+        },
+        "mediumCounter": 165,
+        "salt": {
+          "/": {
+            "bytes": "eyr4FS0kny3XDqCtPGFx5W/SH5XWrB0Q+Hklxfjexak"
+          }
+        },
+        "small": {
+          "/": {
+            "bytes": "ZnyX4M59Vpc3UK3OSeeMIoDydkjYC15BQ/zW5Km1di4"
+          }
+        },
+        "smallCounter": 123
+      }
+    },
+    "bytes": "QNXJEzJ3F5yR5CCyPAlA6proSrphpkXTMek20X83C6oJCAo4wrtaWE+eMIQ/g9o867Xxg9HL9L6AB+UAch4d71ZagCj9b+vJN+UrrfNkgEHaS6pyrNPIUVyqslwMJE8PRhhnOwsMqZeGhF4wsWN25vXw7pFZLqceG82d3wWkvxAHzZv7msGXMZE2GLT9To83lsL25M7TXVJD/q624/xgbAu7Tj7v6JkBeo1fF8fSy4Vk3BZcE7Bw2ZrjpR6H8Ix2R13PULH7c48QY0LadymZQicrglUQvZs/Y3PGwGazhM3yVOVrai0GOTDD6X1cuJRvCBNk/f2Bnc+2QuudKcz2M+S7hDyzXUP934wqDeIWzG35lhdtTzqML7/W4/VPPDVFzZHN/8E+dR5IVNlYoNsToWy/8n4YfcWPuHJqhpIxmVNla6/96WZ96fqXZ5qlVNSOEHTbBYY+NmgwtdsnpaXDpNJflkLDAi+96H58WyPuQuJ4Oovvb3/ynZYnEGUb3QJxdYI96o6JtSLM7+LGjQ1tbOMGRbSoV07BnbGwO2vlP316t9y5/VMuFg7oyg3cTk/6D0uJCGRG+IaCBWU/uEvnt6pdqKdHCJg7WzAGFi81o0iSqQpq+YbDDaaFmPaDiQiIFvOYm83L6SzLTQZaoQTc+I3wg41WLJuNsk2I62zVw1UaOOvzmpEX3g=="
+  },
+  "bafkr4ig7tinqye3xoya3xvhk7loti67g7fy6jzmlstkjhvk55jmelzml3q": {
+    "value": {
+      "wnfs/priv/dir": {
+        "entries": {
+          "anime": {
+            "contentCid": {
+              "/": "bafkr4ihdaiqkdywzh6uk3m5ey73m27utfmwkx5fbhnjqahw6ws6xc4nzwq"
+            },
+            "label": {
+              "/": {
+                "bytes": "G53zVA78ZDufB35+WhsHz4trY1C05sCR57zTkGgVlNU"
+              }
+            },
+            "snapshotKey": {
+              "/": {
+                "bytes": "pGBh5TssmnLpKqtAmK1WhG8HxffP2Wwpe56yafosg5s"
+              }
+            },
+            "temporalKey": {
+              "/": {
+                "bytes": "RmT4PA8pNQz93PXzHmVdeWChh2Ys4r4xnlhpvBHX8sZK4sT9RL8q0g"
+              }
+            }
+          }
+        },
+        "headerCid": {
+          "/": "bafkr4ihyqn24ajhlatyprnuvlwzm2rc6mifvspd5ky7kzzkb5x5vz2km2u"
+        },
+        "metadata": {
+          "created": 0,
+          "modified": 0
+        },
+        "previous": [],
+        "version": "1.0.0"
+      }
+    },
+    "bytes": "jCZd/ulsiIetp68MkeBovSD3o1Dn3CFjnm71LYSiVrDLGGU/a5knP3UmVWtPXyOkBouD1EhIlxlEE9LpWkT3EejGQZxcdz3XpcZ1tE3yRgOBIjV/xWvByWSCRztI15AU/B9HtJkASLdy/mawfVQkW8Dgbijmvb4/8sQj9VRatAWbPmiw84z2rN/OMp+BhIgvXxc0XzaX6HnBee4DwtMY9B1HpWYMoCkYFqmxeqUPMGe3YYt35FDrNnLaliISVdaUqU9YG5j+QQ+ypFJvWgzGPMi5KUuk+/E7xUHUgVegGlmp7iNBPDs/9AJwmLauFhZqq/KHt3IEFJShz8CB9lC3HX4bd4QerhXOe+a47DIq5bSKoOoLJUtRum9cXr1QtaZnKj80iAHlJUM6erR9qFElVv0v9HGobDfuW98wGfqQ2CTxv3EJImkGItaAYnCMBEPQg5IBK/Oj0TxdJahZO9KIqWgKbavtJSwIiJmm8Erkvjo="
+  },
+  "bafkr4igc3l4da4vqhyjmr27pys4iw743v3cii5ovwitxmdqmqnincr7ujy": {
+    "value": {
+      "inumber": {
+        "/": {
+          "bytes": "3Z7G3JebhuU5yeJZkofUBTlfs2Zs7sV+m/PkFnUmaqM"
+        }
+      },
+      "name": {
+        "/": {
+          "bytes": "ayUufv6djgi/dODTvVwJ2IaXn7af/mK0nGskm3IT1bK0tQ2QBlocw1SBb36DPlSx6q66jJ1OoQhSuaSGRiGJ9JF4CFECtBAbzpP0+IsgjeePZbBpi75FNiOLdVP5QjcXLLj1FQ9LfWJs47ULBQlG3mDXR039e8KZM1Jp+K9UI5I0UUNNN/vZr0ogtuEIulPHShkBZNZ33g3WOBZwPo/aMAVyWcqHZAsOFbYSdJmprp61Yh1GuzH+EQsLn69Cgj+nczsxoFttojrbrk0oj7ZEbQfNjR9+yKRv5knLtKtOQrwmYMaXWkABGZfJWzyjwdJYnnuScTwgG6xnhEaO4kJQSA"
+        }
+      },
+      "ratchet": {
+        "large": {
+          "/": {
+            "bytes": "YaC+JBrbi/0ijSebZNkA9xlgjdq9f7ycFPE5/78HmO8"
+          }
+        },
+        "medium": {
+          "/": {
+            "bytes": "v8M5ThznEBqsrvylEFG1AmyxTgjdYLS/20+SFA0HHTk"
+          }
+        },
+        "mediumCounter": 28,
+        "salt": {
+          "/": {
+            "bytes": "NO8dg+rac2jR64nn/36lclXxGlyXlvONt0TTdf7Wv10"
+          }
+        },
+        "small": {
+          "/": {
+            "bytes": "Sp+YoS3lup4NgJbxkdgnptpbs8o78HqX6vqqoteFrLM"
+          }
+        },
+        "smallCounter": 9
+      }
+    },
+    "bytes": "V2+csz7KVJCwphgG2/Qd1z+kanWLJvF7ke8qsFIHqwD8/elLwgTGzDtp2ZQXwXLOjfQMoU+iZrQRA4X5SrRzmFEXIhEE+cSOqR34tROjh82eCYJN3q7JIEyQU7GdbB9FwDtwb2HnZEOVTmq60nEjl8zWuYwQXlBbnDUK/jVjtkVo5F8AEHpqJx+bbRNWxpK1E/sIzldycp4mvD1Kk5sTIz28xB3zNFj0DmNGzmLn7il/7+GPlJ6DA9DS94kKSNQPjjQWqcb82B3R3vAVih/D6erXE97v3LGQOlSJvJq47PrJsrsezsXIyw10ncJzZePFg/UxgKzYr0RCvQmuRszG+G9ijF2yIr8+/mplRmfiGaViJ4IpSJtZjFnnKkFzhoxsniRJZpdxywfWWw1Y4cPcImcEbdBUt7XhmVeoZv09Ydi7Jy2FAUwiHhIFx2vwwP2EMHn/It3FmgwT6hOq/AQLJlnQu1cIafZqB2TFZa65ucjLHiXg/vX8X2vjQ9mFPokaGnbFIoJrkwV9cjn0v/8rkDG3mxnQ63FDgyhjXm2pHQkX/JhQ/EYnv5GG05jWznuPkQDwbIW+KhVuwNOovxm2UsbkNkyaIT7C2c+GaSR+5wgQbWkV45ERnhT8ZEK4QrBbbKsFSJH4RU4kCBngPn9q6DtFmJFqUy8wzL7qK++eGqUmI0t+e35EIw=="
+  },
+  "bafkr4ige3uogilhvhm4ofo47g77o23h66wsmahzvp4wg4skdxorlej3caq": {
+    "value": {
+      "inumber": {
+        "/": {
+          "bytes": "ypaJGIrS8i9y82KczwXG0wtvpesf98lrTfEkPJFh9JM"
+        }
+      },
+      "name": {
+        "/": {
+          "bytes": "thu93ziRXeiShpo34RV3DucMrwZcIjPrXbUKTmD7lBPrqkwUjvO1bM2FPyNq0Hejp+c7xXpaUVyuIFtdJ6uoJu12ucIpkMXEtyxAIDcJWxnMK5BQyGL1k+T5ED+S5F8CYnSnLsFivkfwif7z7jS87zbDaOqM7o1wO60fAYJDDV0br70mi3jz/U0gwyL7ENo0tTdOyx/7kkmMuxEhdXfAXrnKeUWJjqlOFym+koeKkBSYWaqqlwcW+fEUhvuN8BOOkV2rw0Cv6yneZAHMhCXjeVhB4bEq+TeUzjDKHGI52cITqgi0EIoly4ry4FP16fRKxPp3MA+SHNmXm5cvl48H7A"
+        }
+      },
+      "ratchet": {
+        "large": {
+          "/": {
+            "bytes": "qORVSKgvnZ0QKrnDS+icXs0/CehJuHXOiAM0c24yGZo"
+          }
+        },
+        "medium": {
+          "/": {
+            "bytes": "HkeMDQSmvMWFtXcJgg2+ybJmMKeQqCPRBOgCP/w8c54"
+          }
+        },
+        "mediumCounter": 204,
+        "salt": {
+          "/": {
+            "bytes": "Eyss3p6SPJzhIHH68fqEu3kNQQC6JHe+YHlpB9NH0wM"
+          }
+        },
+        "small": {
+          "/": {
+            "bytes": "re72wkaCmnH6qXpCXL2O7cAJiii/JusVg4z5Y8cgdQA"
+          }
+        },
+        "smallCounter": 96
+      }
+    },
+    "bytes": "t29SYUDcNQLlRwQb5mpQHsuINtI2uso3IphjqHMmtMlImHg+FF3RIxsnSd7kxApqZL9CfoCN3MAg5TJOxDu+JJZFi7IEJzU7uqD3V+sPUJLCg4Lojwli0H7VTElpb5W8tiF6fuH+V58qNVdmaNlnEwfQOagOpgD1Xkax4NArgmox9nS1HmkNtcj8C5L1QcErfHgKcskMOCllDjAlogpDOyvUU6OgqajzTgJt/hhF6bkTSb3AF43Dp274aK0HurwXK6pCqotaBuXwwIA6SUwAKWj38v7e1HO3Py089LGSvz4/Ys9pdjmFyhv2seSICJ1j2JTMOZFgHX9EWMhWtfiUHkq2tWayS/hMfEEPdVp+HndVfYAEMoROLBo/n0pAV3lxeIjFKZB9j6/FoRH0P3NAlO7HIrjIRNKHYnkGcENsahyXXNkaDuUCAI+Ty4c0vTsbH0tGUGJ3GKXiRnCdVN1AVnlxR6bgLMPmK0QOpmua8j9bvQSUXytzOjKQ5iMtOrmO9QHuL4KgtyarpX1fVsF1gA0J9Vb8z+/yM0FPpDrWaQPQ6ZHAzV5oJiWMUCHyATIFy4xHeudR6Ycppau2Jvg48vPGZjrdkHR/7oAe0EK7HF/FSe1r96Cuba4rDzJKZQSbWvNZrxJIMlqsw9b4H50e9qit/5Ez0uPnGCa1QDwlxZuWKrR1/Cv3eQ=="
+  },
+  "bafkr4igjmm53wzadt5zcedrl4j2xiwzmd5shi4iczwqfk2tuoj5xu6paym": {
+    "value": {
+      "inumber": {
+        "/": {
+          "bytes": "4Rw8Wzk9Be77iAS6n5C9UOLatGrg4UmMm1ST3GT3oqs"
+        }
+      },
+      "name": {
+        "/": {
+          "bytes": "SkM4IhExInZkPcASX4xPUscgI/S+hwXKidMzNBvNR/9MzxbPLEhUKHHYcEHu+mUMu2Mve+SISnvIAgQ2XW0gYZMf02o4CYeXMCPD5wH0HXwXaTZz/wZUkR2uATkk4828x5b3HKIRJ9o9CgxGnCR45yHT+g+QdF8FiX4DrGmdSOLLP0xRUGvhQ70TDINPtM1PMUGwYTtiUCpo1M2rNaVY0+wda2wB3DTyFCJlj6D/WbvqZtCzJNQhJ6QagO+XIljujKg4puyRfLD8I40/7yXFlNoD+fbAClBttA6UKnJkQf5buc5Ghek/Xn1ctq4BuDuGy0G6Tul75GTbs4G1fyWhMg"
+        }
+      },
+      "ratchet": {
+        "large": {
+          "/": {
+            "bytes": "WHu5AC1kgPMHil7KNZNllEduLodbVzRKVclTlkwjrmA"
+          }
+        },
+        "medium": {
+          "/": {
+            "bytes": "gdq1GlHQkbPXDVcaRV9xeRiO2k8pYY5yEfDE5wxaRYk"
+          }
+        },
+        "mediumCounter": 74,
+        "salt": {
+          "/": {
+            "bytes": "x7rdS4zEr0dhMT/2YTABBjNp3pMuc21XGrULhUr2UYQ"
+          }
+        },
+        "small": {
+          "/": {
+            "bytes": "/MU0z9MqX/+KFJ+g1PTMSXAKuVoIpwd/lUbSk9FZUW8"
+          }
+        },
+        "smallCounter": 164
+      }
+    },
+    "bytes": "gaPUJ9X60+2qhw939JL0sDDU2QlTgnq7iz0YXZl8xNNBhIDfg3fJ0vdNY0GQJbw9yUQ597kSLWlDGnGyMSWWKEgR1TZhewEpe1PF+g5BDkKBQTEv6G/IbJhZN3FiL/Zp0PMX5yxhpN97ChnrmkvsE6x9ofdKJclOW2nm/y9oiOW2xHD+lJVMmjWQFQoSWQFGRBTrRTtDreKXV4OjfSgbSYKmiD5OQLWMudfFHBUtLrw6M8gVFKK0CvkYJ1+16KpQPgb+K+K2buTXo8LrrUB50BQxlVD0iCxuMkqfCtKDjtub4iyxZ7OAGTGDmdXpfqUxc2/C3zU2QaZIKn1EaT6K0IcdNh51ZARobERH8kJTZiLcO0Mw6w0HabfNjzqcUt5oZDgZL9gGkWCa87WD+nzKGaLINJwUHdgDR4ngW8UTh2I0tgDCvZf1Nt730JVPOyjYjbv4XLCgm36ngBeXPYIQ7+VHXgSsVKQpaspcz/219doBKImL1FYbeddOQiYhCMm2i3GwPGzyBPccTblKAsOdFrnd/Ps86wib6Sg3zOyXCcAKDX6yjfEZJNZN/USTphxm5PQUXcuqLIxEEEd5vJ31E4z2Klln+ooMDh4mnCI5H9Kx5+CjQN8NXBCeZfmo2zDQz4uGU0YCOZBw8zGMytGMdy1jvUQ8i2LTkbId8X5bxw/vZJRUR+5lkA=="
+  },
+  "bafkr4igkqdavo5ukmdawyydj4jsfmllux6azgj2yb72xars4ljmmwokg6u": {
+    "value": {
+      "wnfs/priv/dir": {
+        "entries": {
+          "movies": {
+            "contentCid": {
+              "/": "bafkr4ig7tinqye3xoya3xvhk7loti67g7fy6jzmlstkjhvk55jmelzml3q"
+            },
+            "label": {
+              "/": {
+                "bytes": "qWd894Z7QT4ujw0IWo7cLjO1pe+TqtPtJNR5fFBGRN8"
+              }
+            },
+            "snapshotKey": {
+              "/": {
+                "bytes": "qSPhgHBAaCREG4O9l195AmUsyYVE32tu5G5CVHJD+KY"
+              }
+            },
+            "temporalKey": {
+              "/": {
+                "bytes": "hjA4fGrsKrUx6IaNMaQ96dLYfesG/6GySY54RUk7bt5JC2SaMzq4QQ"
+              }
+            }
+          }
+        },
+        "headerCid": {
+          "/": "bafkr4igc3l4da4vqhyjmr27pys4iw743v3cii5ovwitxmdqmqnincr7ujy"
+        },
+        "metadata": {
+          "created": 0,
+          "modified": 0
+        },
+        "previous": [],
+        "version": "1.0.0"
+      }
+    },
+    "bytes": "f7Z6Q+0RfkBPBWsJz+Gs3268UR0ooT5pmFFp4RID/f0rCWwlyfBp3zdQtrPfSiqQVSFJyIS2nnhHJXjhEDCUs4fr457aq5k89B8WtAqKmYH6erDF1wsUjhOIQqlRFVXAWYnr+m/plLQeGLm1Zihqlh9JDWH0RgQkFqR0bOePGIcWgi6QDF4JgJdNUI3XCCsb9mYGe+4IcLxRCPcuug/ZOHDxwi+3J8ynbL7nan0PJ1dBl1aAUo/n1gfwSMoKgA/a3JNvIwF0PW5aIjIcaGMMqp8F2MEzgcR8VWa22Y55XoJ6exBo0AYCxxcZK56ga3Jjr3Kk0//5DudSVh8ylAdgMx+6XZz6/qkj1QLC0bDp09fBOhfAfulU1X9JKFqaN2i0A7BdE5o7Kw4BnD+1s9TPclIhbL8IkHIrc5La+y40LG6uWQLOIoqIT0t+ndUYWnWF6GBWrHfnaOk/y9pekCu7CTjLS16jm2+WZjnszEaf1YyY"
+  },
+  "bafkr4igoes2nc5ibp3kcq5qerw7lvdwx47v4eiycn37kkqr3qngepjbn2u": {
+    "value": {
+      "wnfs/priv/file": {
+        "content": {
+          "external": {
+            "baseName": {
+              "/": {
+                "bytes": "OWJDv/FN6RSs6Wv1rsBVXJjI+DvZD4aLnXdM+9Cohv1wHVUWPK3cETrbjiB48N0i517YUKpyf2GEKUWSeENRYVj4Q3AejzeDIKuJF7d+YdSuqs+ShLUv6yXaPAFBpmj/k9hH9qe4pI3AfuvTiCwqxTiz0PseK0SV8gtoBRRQq8lHFBZkmHjcwydKnav8grvt8qcu4xKS78Ug2K/KS6khGupGAhiDO2xnMIhz2coM+rOfn1qyXwcdxeRtdanVn5HYnFZsx72fx/mALYWcE++XgOml+25nKnUlLGuVeaBKODcied3y6uOsy3UvfLxWqo9e1l93sSmuINFGCTwHUV+v2w"
+              }
+            },
+            "blockContentSize": 262104,
+            "blockCount": 1,
+            "key": {
+              "/": {
+                "bytes": "wYGfU86hcikcBpbCe+6Kuv2P53356Ae9rOBxGeGjeJ8"
+              }
+            }
+          }
+        },
+        "headerCid": {
+          "/": "bafkr4id27ok2an5uiboe2ssvitwsgrzfavh4ez7wx6q2cw2c4joxxql6je"
+        },
+        "metadata": {
+          "created": 0,
+          "modified": 0
+        },
+        "previous": [],
+        "version": "1.0.0"
+      }
+    },
+    "bytes": "4xPLthg8lZC4Q2TKeFIrTtOqmrcLRaPOIKuhWMVTjj4GejvOAAsq+xRT3u2SqIyVKhYo0Vayl3T/zOfjIzFtBHhvPtR/06Ao7Q4a7zd5C306x0hFAenkbCaw2su9OJiiN/2p/tJw9GNkktdynFXJ8RAKqua3WfqlCU2P0BfURglsrH4PYjz4T07MQ8F8bA9pGIm9q5NrJvdI3bB9VJ7e4D15GLfO3+Ax8kwrtE8eEV0oE6WmG2rsZTbMu1lDIu/b9MU5TpwhFpMmzbfDkBIpjnHkgwKsa6PcOhFovTVtqq698fipU5fJypLJfiAf0dZpYXT54Cj2UnFlB5rEeHpZuXvSA5lv/tc89ytqofnJFLT9/FbwikBTqpw+LgrucwgilKMvD7drYD2S002fBGntNJ9GKcDkz/FMr2B5Z9NtAfcYznrE5BYX96r0T1XcO8t//ENiuCMg0HmT92/fb+WkWtcaBRnEmSFNNBIBHWdC35/hHywkl37oekirTdqFkA0+JYTbFFvOkLMn+icgN3EMxW9oAg1DQfMHmRgeRA6xQgGV32a0demnRUYCwXfXngY/rTzRG00XR6ZVI1hSkRG1ZRrsZdapnkhfKuXDH8TIwxoEqL9ehisY0xUS5zk9XJwVj3VjUaq74RXBpYIEb/uAxlZWRSmCGXWWuV7KPDGiugMaptp/1RN57g=="
+  },
+  "bafkr4ihdaiqkdywzh6uk3m5ey73m27utfmwkx5fbhnjqahw6ws6xc4nzwq": {
+    "value": {
+      "wnfs/priv/file": {
+        "content": {
+          "external": {
+            "baseName": {
+              "/": {
+                "bytes": "OQzghzyCvKlcMeSn3LlJ17S0ADe8C/5XVfObj16Yt5/yXhzaF6k58g0wt+Z8T4787Fo9120nb0VmWncjIiE0TtWrTeAb6T9euBlgZ9ZaMjX27RsBZNEustqinwLsC2y54bFqDdhkcp9qbNSKYz1gyGVdz+8aCCFWW+D3s+p0ZRbIXx30tlyqzd4Lrs3Fbi5oHwMBkTf2+w4m7w3ekLPOxLVK34E01d5YYHeWvRXHfIJ2Ry8dkdFs1atalTrtQG4YPNjiC/HIDUiAxfLaKM4iFViEqimYziuJUvjs7qQfhAqdKpnZHXR07cQLzI8dDggP1LcAGkW5TTh5tLMvrEOXqg"
               }
             },
             "blockContentSize": 262104,
@@ -576,19 +537,58 @@ expression: values
           }
         },
         "headerCid": {
-          "/": "bafkr4ieoqvjjlgphk3swbfmekbhabajdya3qi7bd6wypzf7edqpagwyilm"
+          "/": "bafkr4ige3uogilhvhm4ofo47g77o23h66wsmahzvp4wg4skdxorlej3caq"
         },
         "metadata": {
           "created": 0,
           "modified": 0
         },
         "previous": [],
-        "version": "0.2.0"
+        "version": "1.0.0"
       }
     },
-    "bytes": "74os63KRbRUtxxjkQivsoC4DeRKbpUDBfEXZhqHAi95T3PcjN4AzQbc9pyFEwcBQFeg6MwLbZXpQpQVYxMb/EdvnB4/Xqyu0jXk2ZSk/oxXg5WI+xuXcoJtmX94jaK8ikZJNQGAcszo/MlqHOb5wIEvHpV2qYe/6isB/uNcenO1ugtgvDS9upi9SIxbfnacSRiPhpo4TWeJhY1JcCeeVEYBns2xStYkPZlHuZAtrLQpAgmv0e8p1kwLiQaj04x1R10q8FQIvSvgX2xYI8tlrtBV4PP5Tfil76Y5WsxhmkpGtignv0vuInDwcG7tO/vZxjaBcmhVw0Pa5ZtLfB56YcjRfwo8WQ/yKWJGr25EfT65pza4J9sji/Vp/JxSipz9vrsZtMZXbSEDQlEDPqKX+NYENB86oK7xaXUP5wL3TVdSyIS9e42zO2XZCWeT0QNbcN6qKVj8oVat1sEwhKkxv0Pd2G1S4kiKHcKp7MUR2aoK6Aku58rOGpygiabNbwd3+FSqCzSQvKncIZSMrVm9l4G6T7jnizCzU3TKaxlKdRSjioCOxcqvzr+Fdr5KNzSFdJ4jBBR05hEh6sHwvPymdpVohyim6VJh8YAkIJLrokdgiu3THUlE+5WMU4DIO6TMdY3bzwS0dLOzOO6UD/LRwu3OTCJwGUCpApfjUFuD2ijV7b3cag3F7ig=="
+    "bytes": "74os63KRbRUtxxjkQivsoC4DeRKbpUDB7q7YSWThpYvCEALNycd9x0hQMAX+g8IEi11kxh8vhl5cZcyfDqSR7CGAOyMMKqtZZC1DWzwNiLbMV9am+0NOwl3JnfFkYfrmWB1juapQBBIF7rK2Rfc4S+pF4n1QC8DqFAyrXUAUq77Kkl3HRvEdAi3vp1T+mQm5hozkN6sEokwNyFKj0glmCRjFfsWxi9YkwVFJHz1ozb4Pep729/ruDR+WZ3/nm9FnlwlUeIomk1Gg3XM3hW4jVgSQhS6Rh78R+Emff13CSvY4b/xYq4XLn8TOtm9zgiBrPd4ukDbFp+Ew8Bsl8I+krMjJ0yEEMwoMuCcPdTEAvjGrb2FO8h/QJVXgaJBsHOUKaL1+kFqebJhhuXW6VSzWczMO9EkoMCcc+MSokv6T9u1usvk/h/nRi5RNz92iNfpK2T8IMnPxpn5bu2Qxm8Xq37qUg9aPZ6EIskDBQ7U+teZkDHwMbX01RI5WxGBQsGLwk3MMjCnTHeL3wPTx8K/y6745jWordbigoUghWMukFzz0oTg/tlfOXUQ2j02IKEzgG7QsIe0PkTZ9d2QZr6MrbYGvezAuAuu/rsCTsgegpRfhnUut+H4AoM1N8MX20/giXitJneULIaam5j8rE4iv4JmjNSryFlY9MG0jyTcEx6mIiL4o5bunGA=="
   },
-  "bafyr4ifk462eeb44ym4dpbpd3v72osq677wu6cna2ls6doqekqilo2xa7i": {
+  "bafkr4ihyqn24ajhlatyprnuvlwzm2rc6mifvspd5ky7kzzkb5x5vz2km2u": {
+    "value": {
+      "inumber": {
+        "/": {
+          "bytes": "7ZvvLa9s5/MxqtesArctKhbSHrGHtv4ndDhloMGL5aM"
+        }
+      },
+      "name": {
+        "/": {
+          "bytes": "aCl7M9B9ISc0FKfkXlC+/fQrBieSdFa7UHfg9pxWUysSEqTFDNmSnAtJrTLHKvcrXdHNABZnh+8xmzLMsMWDfhbpgUcy8JbGZHUE5tdEPJSjmfzymH5hcA/5ZLK4GveiCpcwnzgF4rvBF+8gjtmlAcfgZODJVtQXpakP7JEv4/0oaD4RfFSCYbr7dI3ZwMbTn/0ksZ4GLWWGtPSbzca9i6r6Rf+94k1s8Du7HPzflDtHvhhkYPqRG4od8xElyNKD9kA7PchcDyEO903zaRgnOdlx8+jxVeTAnDa2fYb9uBvrmQVxp3aKG8onzWPqcvyOxFVUyA36YYoflrmgEWQ2DA"
+        }
+      },
+      "ratchet": {
+        "large": {
+          "/": {
+            "bytes": "b95XEkEp/IWq3CHcuY/FLd9TSA14bbv0QE9Mrq7sQ1o"
+          }
+        },
+        "medium": {
+          "/": {
+            "bytes": "z7xgOiJfD8LlFflXWeM0gvUBHx+LXf76SWglSQd1PPE"
+          }
+        },
+        "mediumCounter": 128,
+        "salt": {
+          "/": {
+            "bytes": "N0VVwHRctdFamy9wwLDwDau8vOm4vw38NzLZ91fvvJw"
+          }
+        },
+        "small": {
+          "/": {
+            "bytes": "7DSyYV83IQ+FL+/xhT8sHLrYn9A+vvfkwuc/atd4MOs"
+          }
+        },
+        "smallCounter": 215
+      }
+    },
+    "bytes": "yB/GOP3COI5493qCebpqK8IBORKcnE0QJ1D8KmnYKNsonP6/JEF83d4enhASDjeZQkYNKsXOjnYnnGb7bDjo6AJFTjRvnAQhXyg3cg+rSyZ40S6VoD5MbO7OgdIb/J1uYXnyb2iOwAxC/zU+kH6mEhEFuWOdrKdtYrXMdTVOqrM8QGU++Cf5PZT50S2bLgQ9mzwfxn0DgiqsslxVWqSoyqbLxpjBS7Czs/EXycqN5bH0Jeh5rPuKoovLN77VNqM1e6jexNyGjkTU4QaPIvSoC2aPdV294rlWA5DowI/RKojFupwchApwcIboH0qxXZVL40OzC/b5Dg49OmF5L17otl8NL07SiHCXeTxPsPJs8CVav6odVgpuhWEA6TMSKJEKfoHPjx56HDMVKfujRZhceJP0Y4v73Sn3g2BQVtahDVQZUMo2rxhrDsYTGHqaJaQzFC10DYfsEpJ0Wp3tfWB4F+cqHA2ACZKtIHXgK1Yc6FKbX21Y87CBzYSvBDkh97EaIJoyu7cL5bLUdwrmskyQF0Nok8hHEErGEpTCwJ8Nz6wCRHtu234jOkD7xrhgxYQQlS0bioIlWs4ZFRo3Dltes8EzEE7EJP4CSy8Qd5y/dYjei7r7W4FYw0r98VwSdqRPrLQaFWm7zjJJBn22bSUv9+yOeVO3KMiTWj5kVuDPsml71G986iDLWA=="
+  },
+  "bafyr4if7e6v454vdr6u7lchzyvnf2dl67va4iov6izm4ws4wzzkwrkxmke": {
     "value": {
       "accumulator": {
         "generator": {
@@ -605,7 +605,7 @@ expression: values
       "root": [
         {
           "/": {
-            "bytes": "EUs"
+            "bytes": "Cyw"
           }
         },
         [
@@ -613,15 +613,15 @@ expression: values
             [
               {
                 "/": {
-                  "bytes": "gDjlmdDJn2PpGAIUX1C0HqGtThD9ckB/kvGuMbVgjeme1EOo8C4ignP2cs+JQlahtUFUWL1Aiwyd5HvJCTJQJ/vGHA98dJ6UvUCDrajZSkBumkJdeGa4DJphzgLceLASX6ZAPE8EgWct5kCudRJNgTqAZ56RvFXz7Uvy/bqXa4M7X9kTBoBenb/UN8qEQhF0dd/jAkZPlHGis9o9WHssr2fat8zqinXfoNYk0J6dDO4Tya3gIAEdvNFOR/azEKAN46a9L11IO/Aj1rV/rWqVfA8NhzkrWahDekGGBcZ1WRBylzgxNBIsdbQk6u5WK4KtQyKrz8c+fRTPkTseGeoBcA"
+                  "bytes": "lymDN7MkGgG3u8iok4B7WlAfHL9C8A6hQwzHRv6gPtvhVs85AFvmM+JtfKbpMiVfpzcWk0JzpkfHPu7DT+lB+a+1gQf29eISR5WdAjjCzRtpON6Y9saLYzcnlutq2VnOp1271GmDgXhc+TSLyQh1PonZtwE9hpnusmK9IYKlaERB9kMPVSjEz1oxFDD3iUibNh/Rc8e/8YoKo5oA2gY9eVNJbt88fenpTz8N1zX+yN3lg+NkbdNmZfyICrX7fmX3z5xQ73AJJtkgBwItQOo/yU5oXFGioMp8Zz8NEGPXGr0GqyN/nY7iDbTcqhkpPnwSQSn7SE0F+Zrx+xxpaun7Rw"
                 }
               },
               [
                 {
-                  "/": "bafkr4ia6ddv7yfregz6kbs2xxqledpwbtevv42gpgvpmxg6b5utlkrjwha"
+                  "/": "bafkr4iet6tkcbjesymahvv7p65qkrh3hd5yfftaidfresulzmes32btkqi"
                 },
                 {
-                  "/": "bafkr4icyf5r2o2lwbfampnwbgvtp76kxisefgxnc3qxozwndtdyb5vnfxi"
+                  "/": "bafkr4ifutwdq3umnvxedkcatmt2jkmuelhha5r4p2weemjt7husmk3cbg4"
                 }
               ]
             ]
@@ -630,7 +630,83 @@ expression: values
             [
               {
                 "/": {
-                  "bytes": "JtY1TRSvmrnLJUHm8UASxEkJ5+QeqjL1oQK/ysw14Np7WCeBjfzIPpfdwA6M9SWKrryv69UnbZzFF8fuue4x0JS4X0Nm0oFpIunBOmJFNj66V4w4dR+UZTzukJOeOC6RtXO2GG1XLIL5vm8RboLm0BUYV1dW0zSkYC4rame7y+Dy7R8FiJDakn6UZE1utOpEQSbyY3jM9/aihNe4spgA5uvW6gk0vZEvRn9I/e5MmVF8PKjJcJyapi37G2huXEScEDR/CBthHti7yHlYOQGVmyn1gsE15lSVsx1Sxc4TeAFyuhXEEp4bJYoGhOnclxowouIaefeekm6ZUcjJmsFB2w"
+                  "bytes": "w14N/BqAkyHzR6pXkHQmVmcyMgU8BWqTAXdI9ykot08G9C3jLTRgtwUsPMZeaJViArFE5uxSDbxPwirN3WJuwpSU8jx24gfRMOKhqP+8hfsAmRbnX9V8MOUy7WG7XoHOZX4LqitSUTyb4Hp/zpfzPGYTrGXeJmpuHPK15bffkIH45Gf80uVuNk7M/UXoLDI3p0ngcNsT9f9ZW0QtO3GbNcmeNjnZBc1xbCG/QvjyMtYlPl4UCNVIrYqHaWBt8w9aunMleVju2CScpLReoD0MRfaj8t98qmOzxt7CqjZrd1oL7h6MBoGOO/6loD1HWd/aX1kgVzVVbrtKV06d7KRjcQ"
+                }
+              },
+              [
+                {
+                  "/": "bafkr4ieds46knvozeny3uexqfhr6rg2orvvlhu5bvdsbdon3dy72fcolme"
+                },
+                {
+                  "/": "bafkr4igjmm53wzadt5zcedrl4j2xiwzmd5shi4iczwqfk2tuoj5xu6paym"
+                }
+              ]
+            ],
+            [
+              {
+                "/": {
+                  "bytes": "UvkoRXdjAid/x/kkWYsYBYxNZ6RhDJvUUU1CTo4HgYfMrFOOBADJqO9ahO4WDmImBjZ/03mNlACLhe1LkLPU6dI1QMmUjBHjmItLqOZf6HtmX9aZL/BTGwlCBtuVE1+QcsgnKzZm6cSB8wv3XECn4mz9nZvSS4sFCwzPFHobZg9UZ0Ry1ZNHRl2cOBz9MwW4A+Y3dSkvWmjCOZlbNuKofUcYm3QWuVDTXALj83myPjgAVaomFV9KKxITefjuNdlN72iTGx6H9Ts+wFOakUHw9/KA4owMovi1Klz2bg5R7/d1BWo5lW6GSjL8IsUC4BrQskpgi3VkVNQvwDfmGBJqOA"
+                }
+              },
+              [
+                {
+                  "/": "bafkr4ige3uogilhvhm4ofo47g77o23h66wsmahzvp4wg4skdxorlej3caq"
+                },
+                {
+                  "/": "bafkr4ihdaiqkdywzh6uk3m5ey73m27utfmwkx5fbhnjqahw6ws6xc4nzwq"
+                }
+              ]
+            ]
+          ],
+          [
+            [
+              {
+                "/": {
+                  "bytes": "SosaSPL/YisdSxgR5F/wrHlNaxyA3/JLcYo0pe+YE8CkKA9Ig944iE7KLSP/J4F33rsaKHyFZUK2QfgYzAF1rUf04ks3vj8QZ3VXiB1hViIRBucSHsOunGi3fQHViH+7yHDzzWbAsUYa+qjLpUwkQVK+YrIxJxi/8CmJM28Wd/hdUq37CHxDX9lVIGzd1QKjgkTay6D4T5szk3TpwX0MwunwdJL9FT4vYfwXhWNpEUPPCfFkG/8KlvZPBBSL3Hn1YjaW5zc4ox1Tp5EDokxQAsvUaJpbkNkQUceYSPIeIOX0FTqc+u9xbseXyfqPIGgjtQFSYFrruFveckdE4Z7izQ"
+                }
+              },
+              [
+                {
+                  "/": "bafkr4igc3l4da4vqhyjmr27pys4iw743v3cii5ovwitxmdqmqnincr7ujy"
+                },
+                {
+                  "/": "bafkr4igkqdavo5ukmdawyydj4jsfmllux6azgj2yb72xars4ljmmwokg6u"
+                }
+              ]
+            ],
+            [
+              {
+                "/": {
+                  "bytes": "ba6bHfa4ErLwY1ivuZ5i4MyMrO1ElocflmRJMiuaBn8sOQIQi864mbluXipI2I+qbYtaqX989L4c1Kv/CXOvBY7plgBzLn9BKY+A7mT0pXX4R375LZxl+I7jusIF91mYHzjkOX+BfsIGu8BoPx5vM8y0U+fwTo4JpAZ4nU6Mj44xd1b23hym6qnnbnwYHQfCxZ+cVYqX1c0IPelWb9b+YQnCVsU3BU6G3BfD8C9ZWqW960ysjsJM+isz5Hr19UKWuV+8LPLwiXgQRnGGx7yiC5B3xRSVrjrgCHShWoNIY3E6zYb41LX/zjOtQiCm2TILH7T6xdEG9s7PehTLHs9KHQ"
+                }
+              },
+              [
+                {
+                  "/": "bafkr4id27ok2an5uiboe2ssvitwsgrzfavh4ez7wx6q2cw2c4joxxql6je"
+                },
+                {
+                  "/": "bafkr4igoes2nc5ibp3kcq5qerw7lvdwx47v4eiycn37kkqr3qngepjbn2u"
+                }
+              ]
+            ]
+          ],
+          [
+            [
+              {
+                "/": {
+                  "bytes": "wrIWSys1EK/cJwoyd7gS3bgRRJmyQt7QAQyspEuED1fHCJh7Clvaa4Kxw1rVgrySArThjLP3lCPRUlwhPC+54i74ZCygCbfYj29Z4blODYlq28s77dVXDKSZpF+zCMA2apLh4ZNlNTonxySu4jrmVv1Q6nYvmQ/W+eMkXnELvNAReu37PhvEriZwi4s7XJMSKZQqAiQ0jba7mBZVR7FbpV21No+qIFFB0IQG0UM1lp5bLAvwCnBCTls2LOvvvk7gaBrLTgVgnt5r0uOYQnb7SCiS0kmI6JLwV8Cngm01ICg/ct/ACnRW8Bcc5Cvf4B5C4ZKUFSKnJW65J0dHug0nIw"
+                }
+              },
+              [
+                {
+                  "/": "bafkr4ibpbyy7pbkq3kppxasqy7gh6nnfg35on3n76vamzzku2gberpsype"
+                }
+              ]
+            ],
+            [
+              {
+                "/": {
+                  "bytes": "G9SXAdfVIrSscPqMWXXU4WbgWYPMfRFjEz9PL93gDN/Ewju2SZIeA/Sy+6T3M3LPVyvzRBKMRBVuhp+NAco5yJURFDI/88sbwA7bfcxzYHv08De61Ni7F4jnrEfm8fu+IwHsXyg5c2Ld3iu8fKl+kiMC+WIoOGOBrr3Je1G5l/i3CTFV+H4VwRCfmQxLo1DcSWbXm+aE1FoZkWn4P5lkGDYGmJXQmOTEVYLHs5K7tLHNKPo/ZKw7XJvJLi5Knt2gb0wNZR7Qv4IrTWz95laf3IVgM3/iDHBjS8jfxfddj7d58iu1i9HNiDVFtAPV63c98J13oIpLUkg1H7jdpMhjOg"
                 }
               },
               [
@@ -642,27 +718,15 @@ expression: values
             [
               {
                 "/": {
-                  "bytes": "J1TGCJPt9iGvb4sQpHDtrDhmjhRVLt6ve2yQhdTyCMo+zTZ9e4kJ4o0udbbVjXBe7bG6i2ocmUztTIbqUAPzb1O7fWzsIqdQkJN2E1XHR8K+DQhZCnD/2dKSH/2OP6aCIVUFOHFDQWqgCJ6I/B1O3XfDhWyzi7Q1lAIhLduno3VEBXJMkiVqT1IeQwU/wc8nMQwgrE0WY2LjOUzHcB6UDvYUXp6TEA1WyA4MImgsZJ7/8pOWUvownXnEA9b/r86kNITQV6N/7lVtUysAQolY3UMMVAMg3zTBz6WJ9Cgy/Lo014BSRAzfhLJb8Rr52IBZw361wRybo15KWx4+i4miHA"
+                  "bytes": "ScNoEItIf9TenchTnWtxd7NtyHrtALuwSOyiYfmvzl2eOt9d6f2H28/Dmi9UmlyTIdJZvscfo+yyBkzikF7L7UDGUKhpa3ARPqT37LFadO5WqFg0+cZ642dhVHC99L5KcGDMO55e047gGDsXVyhaBDlmDEc6g3+nwnGyAyrw6nr1qkEd9TiLGFMRu40+On0KHV+pWZYKxXIzFc1rsHsjcSxqQ+3SC3quCb0UftRQskTGh3IifFEp5RVTngWFj+M3jDgw3ll0zUlH2Fj6UpbMcMY++ekVtbD9sZHMbieFCSu2neyuBSgzM54fWwSVtG0dNg4Xybd9Fh+uGt06CE1Q1g"
                 }
               },
               [
                 {
-                  "/": "bafkr4icgxtjjq3zqn77cugdjk6f2tj6piunqjap3d5lifs2vvrtao2jor4"
+                  "/": "bafkr4ig7tinqye3xoya3xvhk7loti67g7fy6jzmlstkjhvk55jmelzml3q"
                 },
                 {
-                  "/": "bafkr4id54hntfdhurztwuheicsvk4yumsdikg7eo632bj7ibsbt5yj7zla"
-                }
-              ]
-            ],
-            [
-              {
-                "/": {
-                  "bytes": "rydxjH+GrAD5skAcES2b4wOvzlIMilDNvruJq+iHdyQ6V7UVUGLdKWPq+hgDA+R4TikF8d0eltjS9E1uztinxptj1rW2FelGcIV1d2gzxSTsQaNWUjxFcTXCS88nebrsIFehIxHeMhqqcoyPAWszVqpR0kfzWNg9NuWOL1chznpl3UhkhIrdjlFf22P+jERS8NCpNfKkZ4vzxGV3/1NuiQ+AY9SaTpbyrv+UHhKUJHOoRQqhDVQE+ZMr4JyvihsqEx/S0I1DVHiz2PvoyJwjnH/CfI6Fcal2AWRpUAVcL25gPAOhUmCGLt9a2GKSB8oFBHRBZYsmoz37NwW6A+e6tA"
-                }
-              },
-              [
-                {
-                  "/": "bafkr4ibpbyy7pbkq3kppxasqy7gh6nnfg35on3n76vamzzku2gberpsype"
+                  "/": "bafkr4ihyqn24ajhlatyprnuvlwzm2rc6mifvspd5ky7kzzkb5x5vz2km2u"
                 }
               ]
             ]
@@ -671,93 +735,29 @@ expression: values
             [
               {
                 "/": {
-                  "bytes": "E5PghwB9WGFqLNJNN1bWNhxRA6Xd8RZf51rBWfqA8Zyci+ul/qVTX7PQH4sNKQBzIloyiv3k4Q/CbqZZYQ1x+dM4Y5+jrV1kpeUc2Mmt1mVRoWEGCRFL5X3HOZUbfF7zoq6KoZALKIjoCOGT2f5erwBdGChMVsO172X+QJnllLB6lRQ492wd+l6c4HcmEn+diAAbqVP1lI9ta/mLuxrKOrDp+HwZxNDvby2vGzdaZvot4cz8HInwF6KTy8Y+JsYJnipC6FBw9cmhLoerJFymrvFqlmfsyfp4a9/xx5E7MGB+78A8vkflH83TW4Xaef6qMNK0w9FHefpyAOYdfth+Ng"
+                  "bytes": "D3XBvmf1N+qQkCb+VUSRLr1cScJlkhGp4sCLfZHhG5XpAngrMmdk+BHCN2lSwcmtPDvoBdPU+1nK0n1cV92WkKQasBS3WA+O0/20OGjCOSL7V6T2BdYPutuYWZcgLqReJO0qJ2BfnEYBXMowHnOYY7Ks5RqJ/pCR3w9sntQ9kw1dxclp9lTqjWm4edw/TtO7iPKnXm/L8jMwXnxiwMY5QSlWkC4xeCCxDjw2PZCbhrOB1+XQ9mRtV7PQnIRvKW+3FXUkg1583s1Bz/kNakRGatf6eOM16AkLJ1IOTRTL+E6CZH5KhtTy7TbArJMNv4LBQ77MdYWbUPdWzDyhxdVFIA"
+                }
+              },
+              [
+                {
+                  "/": "bafkr4id4dtihsnfxer2fetfspcxgakiq23xk7cxmumpvzwn2kyoxfwuh2i"
+                },
+                {
+                  "/": "bafkr4ie4v5pcplbse5oplfwh2ddy5vphqizlhzuc27nvputzgypwjkic2a"
+                }
+              ]
+            ]
+          ],
+          [
+            [
+              {
+                "/": {
+                  "bytes": "dd7aAL3Yj4H+GeraKglooRrwzrFI5NRzjCfmQ971jXW9MxqrlCC4E8yqnBAcncv8RJMaN5nDOE2VFVyelhx2kfLk8XVXWFpDxNlj6isWZcD4z26BoxpXigQnkuOYPqpVdH3Zhfe1Hj1R1/zsJjQnFognt+Y7cP/rCiujE4MIzO5Clpru/2iikFbxwjEc2jaxvfCq3+VE9ScoZKsSWxJOj9GABIalj4r7uTkqfw3qcE3eccEn6k6c6FnVSzzT4/jui1mMEEHomm0EGYwIKamuXeQfRg7asrWJEL23GP6RU6Np72pVZPIUb/1a1IEua9FM8O0x496XJ3oCinUFAf8F8Q"
                 }
               },
               [
                 {
                   "/": "bafkr4ids4frwdo3i7vfotshrgrid6tfbbx4bkwpprpt6i5shod7nsauxaq"
-                }
-              ]
-            ]
-          ],
-          [
-            [
-              {
-                "/": {
-                  "bytes": "mPXyLEsUbwJM3aR9zH4jUOKu+W5hy/l7Nrb5bcFBq8BgN9CvNWFB50AqIH8HbODRZ8XxEFThrK/TMZvX9twA2rK8Jtqq+kyyFWfaW/jrbHzE6lG47yhjCoZo9hLLw8/ApMwfz52OZyctWce7XaMNi42FRZqKNzP4kqcEpnML5dVz5pkzsTm3Y4qsonmjHqNkMFSWfkkcJE3ltBpD9jYCXO11JpoKsIhvjE4zApvfvhD8zZuGBT23hzA1saurR0b7IygSNriMFQdjUc4rY3TJSYCoy7ruQG0EKxR/2wvDImnqePVNuqGbP+HuJI8g8S9WRUopxxa0QFl0nYowJS4Wow"
-                }
-              },
-              [
-                {
-                  "/": "bafkr4ia7pqc2hlj6hfhekje5ahetokwa4wf4vu6t4ds2oo4zj4xp5kc6yq"
-                },
-                {
-                  "/": "bafkr4ib4eoey5sv2bh4fvqu3t5usrdfqtffyi7ib5fakmb5en23mcuul6m"
-                }
-              ]
-            ],
-            [
-              {
-                "/": {
-                  "bytes": "IloD1YSeYIu3/ZRPJ+h9GHTNe/fzHvjQTq4Gq+NqJlnytjqmrXDBHoBlyeCrwLvcndU5OxAu+fyxq4tXWP8h+xFDu49gk4nJQgqqhhFUNObKha/5Cc7q27RgkLie7PIIIfQcxTdqHe4sFHzUDkqUY09vWYK6FerdB+AJOgFqwO4MM5hAZtOScT2MrhYyCkxPWVohwjYSWRZVzR7Kus832wT6izrh58FDE7EnZTt7oQ6pQ3liMtHkqC0l6e1AVn2VSsbQLQAqgOUUueq+VQWk+KJONwerQPjNuBeZQiZmM5owjUAf8zQO8WbkLqBKJ261dTF0BN/TPgwDzlFJ8ZlU7Q"
-                }
-              },
-              [
-                {
-                  "/": "bafkr4ieoqvjjlgphk3swbfmekbhabajdya3qi7bd6wypzf7edqpagwyilm"
-                },
-                {
-                  "/": "bafkr4ihg2zwzklxkjbs3t2c3geyc7i3luq5wgfvszfrrvt32gadpepmhvq"
-                }
-              ]
-            ]
-          ],
-          [
-            [
-              {
-                "/": {
-                  "bytes": "MWULTJVWErgLeG4YTANI3RgMsCHBp+0rbz0xr7ITiS2X+BhK1/6dtMK0DMCwLYtULuJqHBjAun5af5uLiikQV6eRzUrADmMz1gjJ7pbd0cTZsmlxgSdaJjcy9K0inBiNsIZsMQAAUmmGdBjxqEMOPFDjAU29Deh4Dh960/jpWKBw6/aDDOHO1apgozu5XBjV8vG8ZDowT20d5XrnS5Xr1nC2OOaIiNV5n/J56/QIgHKVgVavUD/Kc6lf8AY20LjoouAispT5lUfD8XwfQH9T7FTuFWW97iq27wYYsqIa87V2E7xJOodrjfRmjOTA7QNMUrDW2khGHeTP5xHagZ1x8g"
-                }
-              },
-              [
-                {
-                  "/": "bafkr4ifmed3prclylogohletbebwwgrz74fzotipqogkym2wwkbq445vcm"
-                },
-                {
-                  "/": "bafkr4igo6gzbk6zax6jhouev6e7lzfg57xjgvuguqpvsqyir2wpqmelyuq"
-                }
-              ]
-            ],
-            [
-              {
-                "/": {
-                  "bytes": "QiI7RRawSc6NHgUu1Ssjf5WAtzyw68k1v8/bnARqoua8OB8Cr2vQoACGISXJODLH7/PwanEWq9ao9fr071tKwg4OB2FOWuSfY464P+IVy4nPd1yVAwK1gpQs5ftrpX94frxOfn/D26ATH0R6tLq5wo0sLUshKNPV/FNf6JChLFeS+t++s2rEK0efsKNd0oYYiA8N+7xZNW6I0RcfZc0zUjy9a4ylePdgjM613Hw+EhtEkQT4iGMAj6BFLVLqYBqUggFcvMpi7Fe3FGlo+BJozIdJxufSD9B6v5z14ptucCg/JZylGcCqiDO4FnfYpGFSYJzlq8w9PJQJpfjy9/zHVQ"
-                }
-              },
-              [
-                {
-                  "/": "bafkr4ighicgigw2bafkdye4pbz5lbhqbkv6qrulzvqlbfy5jkcms764avm"
-                },
-                {
-                  "/": "bafkr4igk5fnk54a5azve6pcxkoj6lfn23klyrxqweilmzh6qj3r7le45ta"
-                }
-              ]
-            ]
-          ],
-          [
-            [
-              {
-                "/": {
-                  "bytes": "R1XSDvziH+rWhJONZ9b/ucCugwhv/2EgCXbQMMv1sqkcdDjgF4K32+0PfE3hhjIFRzWz2Tyblax3BM9oV4rj4a244W2XTlFGv/eJACYwRokoUXmNQGfel7jCV/kxmybnLVc+TdnHO9PeBS5hB5mM2TYqgNkV/wxnC9xri9b46aCkbC7HLSIvcvfMRPY5BCQIzO4NgPrF3QJYVWut98hxhZXC66HtuioB3FikdrGnhk0E0JRlhO3pquRNIV0uo7zTq8EX08rUBNEhgua8F5LUAqyshHKdE3mhqswA+vTG8O6UKcqiS/V63pGXyRKBJKBVdYgD3DLdPFMnWVTEk1tzXQ"
-                }
-              },
-              [
-                {
-                  "/": "bafkr4ialzawfqojsdqungfvkxsxa2iibt7sdkksqg7pji6lfumxx4g274e"
-                },
-                {
-                  "/": "bafkr4ifa5i2eojj336ptkj6bkpmfu5ahkocgntjh5tprpqwavif6imfs54"
                 }
               ]
             ]
@@ -767,6 +767,6 @@ expression: values
       "structure": "hamt",
       "version": "0.1.0"
     },
-    "bytes": "pGRyb290gkIRS4aBglkBAIA45ZnQyZ9j6RgCFF9QtB6hrU4Q/XJAf5LxrjG1YI3pntRDqPAuIoJz9nLPiUJWobVBVFi9QIsMneR7yQkyUCf7xhwPfHSelL1Ag62o2UpAbppCXXhmuAyaYc4C3HiwEl+mQDxPBIFnLeZArnUSTYE6gGeekbxV8+1L8v26l2uDO1/ZEwaAXp2/1DfKhEIRdHXf4wJGT5RxorPaPVh7LK9n2rfM6op136DWJNCenQzuE8mt4CABHbzRTkf2sxCgDeOmvS9dSDvwI9a1f61qlXwPDYc5K1moQ3pBhgXGdVkQcpc4MTQSLHW0JOruViuCrUMiq8/HPn0Uz5E7HhnqAXCC2CpYJQABVR4gHhjr/BYkNnygy1e8FkG+wZkrXmjPNV7Lm8HtJrVFNjjYKlglAAFVHiBYL2OnaXYJQMe2wTVm//lXRIhTXaLcLuzZo5jwHtWluoOCWQEAJtY1TRSvmrnLJUHm8UASxEkJ5+QeqjL1oQK/ysw14Np7WCeBjfzIPpfdwA6M9SWKrryv69UnbZzFF8fuue4x0JS4X0Nm0oFpIunBOmJFNj66V4w4dR+UZTzukJOeOC6RtXO2GG1XLIL5vm8RboLm0BUYV1dW0zSkYC4rame7y+Dy7R8FiJDakn6UZE1utOpEQSbyY3jM9/aihNe4spgA5uvW6gk0vZEvRn9I/e5MmVF8PKjJcJyapi37G2huXEScEDR/CBthHti7yHlYOQGVmyn1gsE15lSVsx1Sxc4TeAFyuhXEEp4bJYoGhOnclxowouIaefeekm6ZUcjJmsFB24HYKlglAAFVHiCJSlRQvIVaKn5vzKT9rvH/NROJ0CUvuk0p5oGI2sEZP4JZAQAnVMYIk+32Ia9vixCkcO2sOGaOFFUu3q97bJCF1PIIyj7NNn17iQnijS51ttWNcF7tsbqLahyZTO1MhupQA/NvU7t9bOwip1CQk3YTVcdHwr4NCFkKcP/Z0pIf/Y4/poIhVQU4cUNBaqAInoj8HU7dd8OFbLOLtDWUAiEt26ejdUQFckySJWpPUh5DBT/BzycxDCCsTRZjYuM5TMdwHpQO9hRenpMQDVbIDgwiaCxknv/yk5ZS+jCdecQD1v+vzqQ0hNBXo3/uVW1TKwBCiVjdQwxUAyDfNMHPpYn0KDL8ujTXgFJEDN+EslvxGvnYgFnDfrXBHJujXkpbHj6LiaIcgtgqWCUAAVUeIEa80phvMG/+KhhpV4upp89FGwSB+x9WgstVrGYHaS6P2CpYJQABVR4gfeHbMoz0jmdqHIgUqq5ijJDQo3yO9vQU/QGQZ9wn+ViCWQEArydxjH+GrAD5skAcES2b4wOvzlIMilDNvruJq+iHdyQ6V7UVUGLdKWPq+hgDA+R4TikF8d0eltjS9E1uztinxptj1rW2FelGcIV1d2gzxSTsQaNWUjxFcTXCS88nebrsIFehIxHeMhqqcoyPAWszVqpR0kfzWNg9NuWOL1chznpl3UhkhIrdjlFf22P+jERS8NCpNfKkZ4vzxGV3/1NuiQ+AY9SaTpbyrv+UHhKUJHOoRQqhDVQE+ZMr4JyvihsqEx/S0I1DVHiz2PvoyJwjnH/CfI6Fcal2AWRpUAVcL25gPAOhUmCGLt9a2GKSB8oFBHRBZYsmoz37NwW6A+e6tIHYKlglAAFVHiAvDjH3hVDanvuCUMfMfzWlNvrm7b/1QMzlVNGCSL5YeYGCWQEAE5PghwB9WGFqLNJNN1bWNhxRA6Xd8RZf51rBWfqA8Zyci+ul/qVTX7PQH4sNKQBzIloyiv3k4Q/CbqZZYQ1x+dM4Y5+jrV1kpeUc2Mmt1mVRoWEGCRFL5X3HOZUbfF7zoq6KoZALKIjoCOGT2f5erwBdGChMVsO172X+QJnllLB6lRQ492wd+l6c4HcmEn+diAAbqVP1lI9ta/mLuxrKOrDp+HwZxNDvby2vGzdaZvot4cz8HInwF6KTy8Y+JsYJnipC6FBw9cmhLoerJFymrvFqlmfsyfp4a9/xx5E7MGB+78A8vkflH83TW4Xaef6qMNK0w9FHefpyAOYdfth+NoHYKlglAAFVHiBy4WNhu2j9SunI8TRQP0yhDfgVWe+L5+R2R3D+2QKXBIKCWQEAmPXyLEsUbwJM3aR9zH4jUOKu+W5hy/l7Nrb5bcFBq8BgN9CvNWFB50AqIH8HbODRZ8XxEFThrK/TMZvX9twA2rK8Jtqq+kyyFWfaW/jrbHzE6lG47yhjCoZo9hLLw8/ApMwfz52OZyctWce7XaMNi42FRZqKNzP4kqcEpnML5dVz5pkzsTm3Y4qsonmjHqNkMFSWfkkcJE3ltBpD9jYCXO11JpoKsIhvjE4zApvfvhD8zZuGBT23hzA1saurR0b7IygSNriMFQdjUc4rY3TJSYCoy7ruQG0EKxR/2wvDImnqePVNuqGbP+HuJI8g8S9WRUopxxa0QFl0nYowJS4Wo4LYKlglAAFVHiAffAWjrT45TkUknQHJNyrA5YvK09Pg5ac7mU8u/qhexNgqWCUAAVUeIDwjiY7Kugn4WsKbn2kojLCZS4R9AelApgekbrbBUovzglkBACJaA9WEnmCLt/2UTyfofRh0zXv38x740E6uBqvjaiZZ8rY6pq1wwR6AZcngq8C73J3VOTsQLvn8sauLV1j/IfsRQ7uPYJOJyUIKqoYRVDTmyoWv+QnO6tu0YJC4nuzyCCH0HMU3ah3uLBR81A5KlGNPb1mCuhXq3QfgCToBasDuDDOYQGbTknE9jK4WMgpMT1laIcI2ElkWVc0eyrrPN9sE+os64efBQxOxJ2U7e6EOqUN5YjLR5KgtJentQFZ9lUrG0C0AKoDlFLnqvlUFpPiiTjcHq0D4zbgXmUImZjOaMI1AH/M0DvFm5C6gSidutXUxdATf0z4MA85RSfGZVO2C2CpYJQABVR4gjoVSlZnnVuVglYRQTgCBI8A3BHwj9bD8l+QcHgNbCFvYKlglAAFVHiDm1m2VLupIZbnoWzEwL6NrpDtjFrLJYxrPejAG8j2HrIKCWQEAMWULTJVWErgLeG4YTANI3RgMsCHBp+0rbz0xr7ITiS2X+BhK1/6dtMK0DMCwLYtULuJqHBjAun5af5uLiikQV6eRzUrADmMz1gjJ7pbd0cTZsmlxgSdaJjcy9K0inBiNsIZsMQAAUmmGdBjxqEMOPFDjAU29Deh4Dh960/jpWKBw6/aDDOHO1apgozu5XBjV8vG8ZDowT20d5XrnS5Xr1nC2OOaIiNV5n/J56/QIgHKVgVavUD/Kc6lf8AY20LjoouAispT5lUfD8XwfQH9T7FTuFWW97iq27wYYsqIa87V2E7xJOodrjfRmjOTA7QNMUrDW2khGHeTP5xHagZ1x8oLYKlglAAFVHiCsIPb4iXhbjOOskwkDaxo5/wuXTQ+DjKwzVrKDDnO1E9gqWCUAAVUeIM7xshV7IL+Sd1CV8T68lN390mrQ1IPrKGER1Z8GEXikglkBAEIiO0UWsEnOjR4FLtUrI3+VgLc8sOvJNb/P25wEaqLmvDgfAq9r0KAAhiElyTgyx+/z8GpxFqvWqPX69O9bSsIODgdhTlrkn2OOuD/iFcuJz3dclQMCtYKULOX7a6V/eH68Tn5/w9ugEx9EerS6ucKNLC1LISjT1fxTX+iQoSxXkvrfvrNqxCtHn7CjXdKGGIgPDfu8WTVuiNEXH2XNM1I8vWuMpXj3YIzOtdx8PhIbRJEE+IhjAI+gRS1S6mAalIIBXLzKYuxXtxRpaPgSaMyHScbn0g/Qer+c9eKbbnAoPyWcpRnAqogzuBZ32KRhUmCc5avMPTyUCaX48vf8x1WC2CpYJQABVR4gx0CMg1tBAVQ8E48OerCeAVV9CNF5rBYS46lQmS/7gKvYKlglAAFVHiDK6Vqu8B0Gak88V1OT5ZW62peI3hYiFsyf0E7j9ZOdmIGCWQEAR1XSDvziH+rWhJONZ9b/ucCugwhv/2EgCXbQMMv1sqkcdDjgF4K32+0PfE3hhjIFRzWz2Tyblax3BM9oV4rj4a244W2XTlFGv/eJACYwRokoUXmNQGfel7jCV/kxmybnLVc+TdnHO9PeBS5hB5mM2TYqgNkV/wxnC9xri9b46aCkbC7HLSIvcvfMRPY5BCQIzO4NgPrF3QJYVWut98hxhZXC66HtuioB3FikdrGnhk0E0JRlhO3pquRNIV0uo7zTq8EX08rUBNEhgua8F5LUAqyshHKdE3mhqswA+vTG8O6UKcqiS/V63pGXyRKBJKBVdYgD3DLdPFMnWVTEk1tzXYLYKlglAAFVHiALyCxYOTIcKNMWqryuDSEBn+Q1KlA33pR5ZaMvfhtf4dgqWCUAAVUeIKDqNEclO9+fNSfBU9hadAdThGbNJ+zfF8LAqgvkMLLvZ3ZlcnNpb25lMC4xLjBpc3RydWN0dXJlZGhhbXRrYWNjdW11bGF0b3KiZ21vZHVsdXNZAQDHlwzu3MOwdUSQIBp6phPNc5EQgceQ9fGocm9GNVC7W3/w244eoRiexy+T0WUAEb1yGu6swqzeMqBBB/BkjCgTox9bC3dl/4tEtLb/yTOEtkbrCcfPXoWS1A6jPIADnzW08UoEtR97/Xgb5NFnMWS6jrmRwsTXMLu+NfWSve9SSvfo2u/SbGb8AsR5r4nWTTc/RCcJQ53mbOuVXz6jfVFZ9hNYCfhTNLXLGBOt3IDNBWCfEKxqla1lhyyQlSW9rTK8cpWSZCkg8kxh3Fs8O3kj5WsWpNnTc9hyHySj/A8bMTH1VhUXKGa8zDD5UFTIJOczpetoF/e8FjmdSMY2HMflaWdlbmVyYXRvclkBAKxgnuVhyI4mY4hcWEqJQTCVY0kqdrRktfKHh7lNp9ERUd5OVHG4yI8cwhdNy7J3YuLAlEZ55GuqsyLPbJfel6Zjht2/nbOip9rHap8Ntr3SFmIy+SetzbU9uotPSTIvCVjWIhfGjUS0nVxoPk2U3daTeCmqO5Ok4XWjxDZ0HkAeCM85KbrW6DNmVE7uicYOLXlTuQ9clyJkHydVYDhsFgQtI+MbkUWfUkx97WcPm6MuKAufOF6EaWoBdAfjzO/6/D45s/wW9qlQN7U3m3mOmVHn7RL6Hbfwz4hLLyr2oNkncM7j0NyFU2TpzRdwmUsuRvltVsC2zJd8lw8TuMjJnDw="
+    "bytes": "pGRyb290gkILLIaBglkBAJcpgzezJBoBt7vIqJOAe1pQHxy/QvAOoUMMx0b+oD7b4VbPOQBb5jPibXym6TIlX6c3FpNCc6ZHxz7uw0/pQfmvtYEH9vXiEkeVnQI4ws0baTjemPbGi2M3J5bratlZzqddu9Rpg4F4XPk0i8kIdT6J2bcBPYaZ7rJivSGCpWhEQfZDD1UoxM9aMRQw94lImzYf0XPHv/GKCqOaANoGPXlTSW7fPH3p6U8/Ddc1/sjd5YPjZG3TZmX8iAq1+35l98+cUO9wCSbZIAcCLUDqP8lOaFxRoqDKfGc/DRBj1xq9Bqsjf52O4g203KoZKT58EkEp+0hNBfma8fscaWrp+0eC2CpYJQABVR4gk/TUIKSSwwB61+/3YKifZx9wUswIGWJJUXlhJb0GaoLYKlglAAFVHiC0nYcN0Y2tyDUIE2T0lTKEWc4Ox4/ViEYmfz0kxWxBN4KCWQEAw14N/BqAkyHzR6pXkHQmVmcyMgU8BWqTAXdI9ykot08G9C3jLTRgtwUsPMZeaJViArFE5uxSDbxPwirN3WJuwpSU8jx24gfRMOKhqP+8hfsAmRbnX9V8MOUy7WG7XoHOZX4LqitSUTyb4Hp/zpfzPGYTrGXeJmpuHPK15bffkIH45Gf80uVuNk7M/UXoLDI3p0ngcNsT9f9ZW0QtO3GbNcmeNjnZBc1xbCG/QvjyMtYlPl4UCNVIrYqHaWBt8w9aunMleVju2CScpLReoD0MRfaj8t98qmOzxt7CqjZrd1oL7h6MBoGOO/6loD1HWd/aX1kgVzVVbrtKV06d7KRjcYLYKlglAAFVHiCDlzym1dkjcboS8Cnj6JtOjWqz06Go5BG5ux4/oonLYdgqWCUAAVUeIMljO7tkA59yIg4r4nV0WywfZHRxAs2gVWp0cnt6eeDDglkBAFL5KEV3YwInf8f5JFmLGAWMTWekYQyb1FFNQk6OB4GHzKxTjgQAyajvWoTuFg5iJgY2f9N5jZQAi4XtS5Cz1OnSNUDJlIwR45iLS6jmX+h7Zl/WmS/wUxsJQgbblRNfkHLIJys2ZunEgfML91xAp+Js/Z2b0kuLBQsMzxR6G2YPVGdEctWTR0ZdnDgc/TMFuAPmN3UpL1powjmZWzbiqH1HGJt0FrlQ01wC4/N5sj44AFWqJhVfSisSE3n47jXZTe9okxseh/U7PsBTmpFB8PfygOKMDKL4tSpc9m4OUe/3dQVqOZVuhkoy/CLFAuAa0LJKYIt1ZFTUL8A35hgSajiC2CpYJQABVR4gxN0cZCz1Ozjiu583/u1s/vWkwB81fyxuSUO7orInYgTYKlglAAFVHiDjAiCh4tk/qK2zpMf2zX6TKyyr9KE7UwAe3rS9cXG5tIKCWQEASosaSPL/YisdSxgR5F/wrHlNaxyA3/JLcYo0pe+YE8CkKA9Ig944iE7KLSP/J4F33rsaKHyFZUK2QfgYzAF1rUf04ks3vj8QZ3VXiB1hViIRBucSHsOunGi3fQHViH+7yHDzzWbAsUYa+qjLpUwkQVK+YrIxJxi/8CmJM28Wd/hdUq37CHxDX9lVIGzd1QKjgkTay6D4T5szk3TpwX0MwunwdJL9FT4vYfwXhWNpEUPPCfFkG/8KlvZPBBSL3Hn1YjaW5zc4ox1Tp5EDokxQAsvUaJpbkNkQUceYSPIeIOX0FTqc+u9xbseXyfqPIGgjtQFSYFrruFveckdE4Z7izYLYKlglAAFVHiDC2vgwcrA+Esjr78S4i3+brsSEddWyJ3YODINQ0Uf0TtgqWCUAAVUeIMqAwVd2imDBbGBp4mRWLXS/gZMnWA/1cEZcWljLOUb1glkBAG2umx32uBKy8GNYr7meYuDMjKztRJaHH5ZkSTIrmgZ/LDkCEIvOuJm5bl4qSNiPqm2LWql/fPS+HNSr/wlzrwWO6ZYAcy5/QSmPgO5k9KV1+Ed++S2cZfiO47rCBfdZmB845Dl/gX7CBrvAaD8ebzPMtFPn8E6OCaQGeJ1OjI+OMXdW9t4cpuqp5258GB0HwsWfnFWKl9XNCD3pVm/W/mEJwlbFNwVOhtwXw/AvWVqlvetMrI7CTPorM+R69fVClrlfvCzy8Il4EEZxhse8oguQd8UUla464Ah0oVqDSGNxOs2G+NS1/84zrUIgptkyCx+0+sXRBvbOz3oUyx7PSh2C2CpYJQABVR4gevuVoDe0QFxNSlVE7SNHJQVPwmf2v6GhW0LiXXvBfknYKlglAAFVHiDOJLTRdQF+1Ch2BI2+uo7X5+vCIwJu/qVCO4NMR6Qt1YOCWQEAwrIWSys1EK/cJwoyd7gS3bgRRJmyQt7QAQyspEuED1fHCJh7Clvaa4Kxw1rVgrySArThjLP3lCPRUlwhPC+54i74ZCygCbfYj29Z4blODYlq28s77dVXDKSZpF+zCMA2apLh4ZNlNTonxySu4jrmVv1Q6nYvmQ/W+eMkXnELvNAReu37PhvEriZwi4s7XJMSKZQqAiQ0jba7mBZVR7FbpV21No+qIFFB0IQG0UM1lp5bLAvwCnBCTls2LOvvvk7gaBrLTgVgnt5r0uOYQnb7SCiS0kmI6JLwV8Cngm01ICg/ct/ACnRW8Bcc5Cvf4B5C4ZKUFSKnJW65J0dHug0nI4HYKlglAAFVHiAvDjH3hVDanvuCUMfMfzWlNvrm7b/1QMzlVNGCSL5YeYJZAQAb1JcB19UitKxw+oxZddThZuBZg8x9EWMTP08v3eAM38TCO7ZJkh4D9LL7pPczcs9XK/NEEoxEFW6Gn40ByjnIlREUMj/zyxvADtt9zHNge/TwN7rU2LsXiOesR+bx+74jAexfKDlzYt3eK7x8qX6SIwL5Yig4Y4Guvcl7UbmX+LcJMVX4fhXBEJ+ZDEujUNxJZteb5oTUWhmRafg/mWQYNgaYldCY5MRVgsezkru0sc0o+j9krDtcm8kuLkqe3aBvTA1lHtC/gitNbP3mVp/chWAzf+IMcGNLyN/F912Pt3nyK7WL0c2INUW0A9Xrdz3wnXegiktSSDUfuN2kyGM6gdgqWCUAAVUeIIlKVFC8hVoqfm/MpP2u8f81E4nQJS+6TSnmgYjawRk/glkBAEnDaBCLSH/U3p3IU51rcXezbch67QC7sEjsomH5r85dnjrfXen9h9vPw5ovVJpckyHSWb7HH6PssgZM4pBey+1AxlCoaWtwET6k9+yxWnTuVqhYNPnGeuNnYVRwvfS+SnBgzDueXtOO4Bg7F1coWgQ5ZgxHOoN/p8JxsgMq8Op69apBHfU4ixhTEbuNPjp9Ch1fqVmWCsVyMxXNa7B7I3EsakPt0gt6rgm9FH7UULJExodyInxRKeUVU54FhY/jN4w4MN5ZdM1JR9hY+lKWzHDGPvnpFbWw/bGRzG4nhQkrtp3srgUoMzOeH1sElbRtHTYOF8m3fRYfrhrdOghNUNaC2CpYJQABVR4g35obDBN3dgG71Or63TR75vlx5OWLlNST1V3qWEXli9zYKlglAAFVHiD4g3XAJOsE8Pi2lV2yzUReYgtZPH1WPqzlQe37XOlM1YGCWQEAD3XBvmf1N+qQkCb+VUSRLr1cScJlkhGp4sCLfZHhG5XpAngrMmdk+BHCN2lSwcmtPDvoBdPU+1nK0n1cV92WkKQasBS3WA+O0/20OGjCOSL7V6T2BdYPutuYWZcgLqReJO0qJ2BfnEYBXMowHnOYY7Ks5RqJ/pCR3w9sntQ9kw1dxclp9lTqjWm4edw/TtO7iPKnXm/L8jMwXnxiwMY5QSlWkC4xeCCxDjw2PZCbhrOB1+XQ9mRtV7PQnIRvKW+3FXUkg1583s1Bz/kNakRGatf6eOM16AkLJ1IOTRTL+E6CZH5KhtTy7TbArJMNv4LBQ77MdYWbUPdWzDyhxdVFIILYKlglAAFVHiB8HNB5NLckdFJMsniuYCkQ1u6viuyjH1zZulYdctqH0tgqWCUAAVUeIJyvXiesMidc9ZbH0MeO1eeCMrPmgtfbV9J5Nh9kqQLQgYJZAQB13toAvdiPgf4Z6toqCWihGvDOsUjk1HOMJ+ZD3vWNdb0zGquUILgTzKqcEBydy/xEkxo3mcM4TZUVXJ6WHHaR8uTxdVdYWkPE2WPqKxZlwPjPboGjGleKBCeS45g+qlV0fdmF97UePVHX/OwmNCcWiCe35jtw/+sKK6MTgwjM7kKWmu7/aKKQVvHCMRzaNrG98Krf5UT1JyhkqxJbEk6P0YAEhqWPivu5OSp/DepwTd5xwSfqTpzoWdVLPNPj+O6LWYwQQeiabQQZjAgpqa5d5B9GDtqytYkQvbcY/pFTo2nvalVk8hRv/VrUgS5r0Uzw7THj3pcnegKKdQUB/wXxgdgqWCUAAVUeIHLhY2G7aP1K6cjxNFA/TKEN+BVZ74vn5HZHcP7ZApcEZ3ZlcnNpb25lMC4xLjBpc3RydWN0dXJlZGhhbXRrYWNjdW11bGF0b3KiZ21vZHVsdXNZAQDHlwzu3MOwdUSQIBp6phPNc5EQgceQ9fGocm9GNVC7W3/w244eoRiexy+T0WUAEb1yGu6swqzeMqBBB/BkjCgTox9bC3dl/4tEtLb/yTOEtkbrCcfPXoWS1A6jPIADnzW08UoEtR97/Xgb5NFnMWS6jrmRwsTXMLu+NfWSve9SSvfo2u/SbGb8AsR5r4nWTTc/RCcJQ53mbOuVXz6jfVFZ9hNYCfhTNLXLGBOt3IDNBWCfEKxqla1lhyyQlSW9rTK8cpWSZCkg8kxh3Fs8O3kj5WsWpNnTc9hyHySj/A8bMTH1VhUXKGa8zDD5UFTIJOczpetoF/e8FjmdSMY2HMflaWdlbmVyYXRvclkBAKxgnuVhyI4mY4hcWEqJQTCVY0kqdrRktfKHh7lNp9ERUd5OVHG4yI8cwhdNy7J3YuLAlEZ55GuqsyLPbJfel6Zjht2/nbOip9rHap8Ntr3SFmIy+SetzbU9uotPSTIvCVjWIhfGjUS0nVxoPk2U3daTeCmqO5Ok4XWjxDZ0HkAeCM85KbrW6DNmVE7uicYOLXlTuQ9clyJkHydVYDhsFgQtI+MbkUWfUkx97WcPm6MuKAufOF6EaWoBdAfjzO/6/D45s/wW9qlQN7U3m3mOmVHn7RL6Hbfwz4hLLyr2oNkncM7j0NyFU2TpzRdwmUsuRvltVsC2zJd8lw8TuMjJnDw="
   }
 }

--- a/wnfs/src/public/directory.rs
+++ b/wnfs/src/public/directory.rs
@@ -3,7 +3,9 @@
 use super::{
     PublicDirectorySerializable, PublicFile, PublicLink, PublicNode, PublicNodeSerializable,
 };
-use crate::{error::FsError, traits::Id, utils, SearchResult, WNFS_VERSION};
+use crate::{
+    error::FsError, is_readable_wnfs_version, traits::Id, utils, SearchResult, WNFS_VERSION,
+};
 use anyhow::{bail, ensure, Result};
 use async_once_cell::OnceCell;
 use async_recursion::async_recursion;
@@ -764,7 +766,7 @@ impl PublicDirectory {
 
     /// Creates a new directory from provided serializable.
     pub(crate) fn from_serializable(serializable: PublicDirectorySerializable) -> Result<Self> {
-        if serializable.version.major != 0 || serializable.version.minor != 2 {
+        if !is_readable_wnfs_version(&serializable.version) {
             bail!(FsError::UnexpectedVersion(serializable.version))
         }
 

--- a/wnfs/src/public/file.rs
+++ b/wnfs/src/public/file.rs
@@ -1,7 +1,7 @@
 //! Public fs file node.
 
 use super::{PublicFileSerializable, PublicNodeSerializable};
-use crate::{error::FsError, traits::Id, WNFS_VERSION};
+use crate::{error::FsError, is_readable_wnfs_version, traits::Id, WNFS_VERSION};
 use anyhow::{bail, Result};
 use async_once_cell::OnceCell;
 use chrono::{DateTime, Utc};
@@ -138,7 +138,7 @@ impl PublicFile {
 
     /// Creates a new file from a serializable.
     pub(crate) fn from_serializable(serializable: PublicFileSerializable) -> Result<Self> {
-        if serializable.version.major != 0 || serializable.version.minor != 2 {
+        if !is_readable_wnfs_version(&serializable.version) {
             bail!(FsError::UnexpectedVersion(serializable.version))
         }
 

--- a/wnfs/src/public/node/snapshots/wnfs__public__node__node__snapshot_tests__public_file_and_directory_nodes-2.snap
+++ b/wnfs/src/public/node/snapshots/wnfs__public__node__node__snapshot_tests__public_file_and_directory_nodes-2.snap
@@ -13,8 +13,8 @@ expression: file
       "userland": {
         "/": "baeaaaaa"
       },
-      "version": "0.2.0"
+      "version": "1.0.0"
     }
   },
-  "bytes": "oW13bmZzL3B1Yi9maWxlpGd2ZXJzaW9uZTAuMi4waG1ldGFkYXRhomdjcmVhdGVkAGhtb2RpZmllZABocHJldmlvdXOAaHVzZXJsYW5k2CpFAAEAAAA="
+  "bytes": "oW13bmZzL3B1Yi9maWxlpGd2ZXJzaW9uZTEuMC4waG1ldGFkYXRhomdjcmVhdGVkAGhtb2RpZmllZABocHJldmlvdXOAaHVzZXJsYW5k2CpFAAEAAAA="
 }

--- a/wnfs/src/public/node/snapshots/wnfs__public__node__node__snapshot_tests__public_file_and_directory_nodes.snap
+++ b/wnfs/src/public/node/snapshots/wnfs__public__node__node__snapshot_tests__public_file_and_directory_nodes.snap
@@ -11,8 +11,8 @@ expression: dir
       },
       "previous": [],
       "userland": {},
-      "version": "0.2.0"
+      "version": "1.0.0"
     }
   },
-  "bytes": "oWx3bmZzL3B1Yi9kaXKkZ3ZlcnNpb25lMC4yLjBobWV0YWRhdGGiZ2NyZWF0ZWQAaG1vZGlmaWVkAGhwcmV2aW91c4BodXNlcmxhbmSg"
+  "bytes": "oWx3bmZzL3B1Yi9kaXKkZ3ZlcnNpb25lMS4wLjBobWV0YWRhdGGiZ2NyZWF0ZWQAaG1vZGlmaWVkAGhwcmV2aW91c4BodXNlcmxhbmSg"
 }

--- a/wnfs/src/public/node/snapshots/wnfs__public__node__node__snapshot_tests__public_fs.snap
+++ b/wnfs/src/public/node/snapshots/wnfs__public__node__node__snapshot_tests__public_fs.snap
@@ -3,25 +3,7 @@ source: wnfs/src/public/node/node.rs
 expression: values
 ---
 {
-  "bafyr4iaf7cxur6cz5723jjxmzjlhfszen6xvkn27b5mvtfrnurtmqggnnq": {
-    "value": {
-      "wnfs/pub/dir": {
-        "metadata": {
-          "created": 0,
-          "modified": 0
-        },
-        "previous": [],
-        "userland": {
-          "jazz": {
-            "/": "bafyr4ifdbpj2udunaj7wpyb3by7zivabfva3qtwbnv232ysw5vut7vzx6e"
-          }
-        },
-        "version": "0.2.0"
-      }
-    },
-    "bytes": "oWx3bmZzL3B1Yi9kaXKkZ3ZlcnNpb25lMC4yLjBobWV0YWRhdGGiZ2NyZWF0ZWQAaG1vZGlmaWVkAGhwcmV2aW91c4BodXNlcmxhbmShZGphenrYKlglAAFxHiCjC9OqDo0Cf2fgOw4/lFQBLUG4TsFtdb1iVu1pP9c38Q=="
-  },
-  "bafyr4icgnjcomojc4uglskm6kmzzzfanxywt5inqcfl7i3kyvcpdqedb2a": {
+  "bafyr4ic4bdlnowxtowfynamfdwgetbetifmdgahjun3sdbjfmaq3o7tvpi": {
     "value": {
       "wnfs/pub/dir": {
         "metadata": {
@@ -30,26 +12,26 @@ expression: values
         },
         "previous": [
           {
-            "/": "bafyr4ihn7m344bbloghcqupxlygkskyhmpg5vgqw6ybin4unpcrksuttmy"
+            "/": "bafyr4ih3k2ipwwqryrlmtmwtolma4t772gknmx7pxqu5opjwsrr2nc27qq"
           }
         ],
         "userland": {
           "music": {
-            "/": "bafyr4iaf7cxur6cz5723jjxmzjlhfszen6xvkn27b5mvtfrnurtmqggnnq"
+            "/": "bafyr4ietl6u7ligzk3sxfwqvycd2vhd4ohw3rxn5qv7ajrlzommvzk5la4"
           },
           "text.txt": {
-            "/": "bafyr4ifdbpj2udunaj7wpyb3by7zivabfva3qtwbnv232ysw5vut7vzx6e"
+            "/": "bafyr4ie5jfvlj66jxhhvggxjltfj4ljfhjyirnngts23e33ugezjpc6xaq"
           },
           "videos": {
-            "/": "bafyr4igv4cb3jiade36ged6hqwdfdu2wpnauksli6emabfgofuphtz27rm"
+            "/": "bafyr4ifmlt3hmgb5kdaprkhqqg774bcgyra54sli273iceddse25d7xkbe"
           }
         },
-        "version": "0.2.0"
+        "version": "1.0.0"
       }
     },
-    "bytes": "oWx3bmZzL3B1Yi9kaXKkZ3ZlcnNpb25lMC4yLjBobWV0YWRhdGGiZ2NyZWF0ZWQAaG1vZGlmaWVkAGhwcmV2aW91c4HYKlglAAFxHiDt+zfOBCtxjihR914MqSsHY83amhb2AobyjXiiqVJzZmh1c2VybGFuZKNlbXVzaWPYKlglAAFxHiAF+K9I+Fnv9bSm7MpWcsskb69VN18PWVmWLaRmyBjNbGZ2aWRlb3PYKlglAAFxHiDV4IO0oAMm/GIPx4WGUdNWe0FFSWjxGACUzi0eeedfi2h0ZXh0LnR4dNgqWCUAAXEeIKML06oOjQJ/Z+A7Dj+UVAEtQbhOwW11vWJW7Wk/1zfx"
+    "bytes": "oWx3bmZzL3B1Yi9kaXKkZ3ZlcnNpb25lMS4wLjBobWV0YWRhdGGiZ2NyZWF0ZWQAaG1vZGlmaWVkAGhwcmV2aW91c4HYKlglAAFxHiD7VpD7WhHEVsmy03LYDk//0ZTWX++8Kdc9NpRjpotfhGh1c2VybGFuZKNlbXVzaWPYKlglAAFxHiCTX6n1oNlW5XLaFcCHqpx8ce243b2FfgTFeXMZXKurB2Z2aWRlb3PYKlglAAFxHiCsXPZ2GD1QwPio8IG//gRGxEHeSWjX9oEQY5E10f7qCWh0ZXh0LnR4dNgqWCUAAXEeIJ1JarT7ybnPUxrpXMqeLSU6cIi1ppy1sm90MTKXi9cE"
   },
-  "bafyr4ifdbpj2udunaj7wpyb3by7zivabfva3qtwbnv232ysw5vut7vzx6e": {
+  "bafyr4ie5jfvlj66jxhhvggxjltfj4ljfhjyirnngts23e33ugezjpc6xaq": {
     "value": {
       "wnfs/pub/file": {
         "metadata": {
@@ -60,30 +42,12 @@ expression: values
         "userland": {
           "/": "baeaaaaa"
         },
-        "version": "0.2.0"
+        "version": "1.0.0"
       }
     },
-    "bytes": "oW13bmZzL3B1Yi9maWxlpGd2ZXJzaW9uZTAuMi4waG1ldGFkYXRhomdjcmVhdGVkAGhtb2RpZmllZABocHJldmlvdXOAaHVzZXJsYW5k2CpFAAEAAAA="
+    "bytes": "oW13bmZzL3B1Yi9maWxlpGd2ZXJzaW9uZTEuMC4waG1ldGFkYXRhomdjcmVhdGVkAGhtb2RpZmllZABocHJldmlvdXOAaHVzZXJsYW5k2CpFAAEAAAA="
   },
-  "bafyr4igv4cb3jiade36ged6hqwdfdu2wpnauksli6emabfgofuphtz27rm": {
-    "value": {
-      "wnfs/pub/dir": {
-        "metadata": {
-          "created": 0,
-          "modified": 0
-        },
-        "previous": [],
-        "userland": {
-          "movies": {
-            "/": "bafyr4ih5spegjcwiwushnajtz4mpo54mwnyti5hvstc34jieou23co5mom"
-          }
-        },
-        "version": "0.2.0"
-      }
-    },
-    "bytes": "oWx3bmZzL3B1Yi9kaXKkZ3ZlcnNpb25lMC4yLjBobWV0YWRhdGGiZ2NyZWF0ZWQAaG1vZGlmaWVkAGhwcmV2aW91c4BodXNlcmxhbmShZm1vdmllc9gqWCUAAXEeIP2TyGSKyLUkdoEzzxj3d4yzcTR09ZTFviUEdTWxO6xz"
-  },
-  "bafyr4ih5spegjcwiwushnajtz4mpo54mwnyti5hvstc34jieou23co5mom": {
+  "bafyr4ielvme7szwdjuhhmiy2h27dqi7ayv5akpry33l365dbz2r7kbuxxu": {
     "value": {
       "wnfs/pub/dir": {
         "metadata": {
@@ -93,15 +57,51 @@ expression: values
         "previous": [],
         "userland": {
           "anime": {
-            "/": "bafyr4ifdbpj2udunaj7wpyb3by7zivabfva3qtwbnv232ysw5vut7vzx6e"
+            "/": "bafyr4ie5jfvlj66jxhhvggxjltfj4ljfhjyirnngts23e33ugezjpc6xaq"
           }
         },
-        "version": "0.2.0"
+        "version": "1.0.0"
       }
     },
-    "bytes": "oWx3bmZzL3B1Yi9kaXKkZ3ZlcnNpb25lMC4yLjBobWV0YWRhdGGiZ2NyZWF0ZWQAaG1vZGlmaWVkAGhwcmV2aW91c4BodXNlcmxhbmShZWFuaW1l2CpYJQABcR4gowvTqg6NAn9n4DsOP5RUAS1BuE7BbXW9YlbtaT/XN/E="
+    "bytes": "oWx3bmZzL3B1Yi9kaXKkZ3ZlcnNpb25lMS4wLjBobWV0YWRhdGGiZ2NyZWF0ZWQAaG1vZGlmaWVkAGhwcmV2aW91c4BodXNlcmxhbmShZWFuaW1l2CpYJQABcR4gnUlqtPvJuc9TGulcyp4tJTpwiLWmnLWyb3QxMpeL1wQ="
   },
-  "bafyr4ihn7m344bbloghcqupxlygkskyhmpg5vgqw6ybin4unpcrksuttmy": {
+  "bafyr4ietl6u7ligzk3sxfwqvycd2vhd4ohw3rxn5qv7ajrlzommvzk5la4": {
+    "value": {
+      "wnfs/pub/dir": {
+        "metadata": {
+          "created": 0,
+          "modified": 0
+        },
+        "previous": [],
+        "userland": {
+          "jazz": {
+            "/": "bafyr4ie5jfvlj66jxhhvggxjltfj4ljfhjyirnngts23e33ugezjpc6xaq"
+          }
+        },
+        "version": "1.0.0"
+      }
+    },
+    "bytes": "oWx3bmZzL3B1Yi9kaXKkZ3ZlcnNpb25lMS4wLjBobWV0YWRhdGGiZ2NyZWF0ZWQAaG1vZGlmaWVkAGhwcmV2aW91c4BodXNlcmxhbmShZGphenrYKlglAAFxHiCdSWq0+8m5z1Ma6VzKni0lOnCItaactbJvdDEyl4vXBA=="
+  },
+  "bafyr4ifmlt3hmgb5kdaprkhqqg774bcgyra54sli273iceddse25d7xkbe": {
+    "value": {
+      "wnfs/pub/dir": {
+        "metadata": {
+          "created": 0,
+          "modified": 0
+        },
+        "previous": [],
+        "userland": {
+          "movies": {
+            "/": "bafyr4ielvme7szwdjuhhmiy2h27dqi7ayv5akpry33l365dbz2r7kbuxxu"
+          }
+        },
+        "version": "1.0.0"
+      }
+    },
+    "bytes": "oWx3bmZzL3B1Yi9kaXKkZ3ZlcnNpb25lMS4wLjBobWV0YWRhdGGiZ2NyZWF0ZWQAaG1vZGlmaWVkAGhwcmV2aW91c4BodXNlcmxhbmShZm1vdmllc9gqWCUAAXEeIIurCflmw00OdiMaPr44I+DFegU+ON7Xv3RhzqP1Bpe9"
+  },
+  "bafyr4ih3k2ipwwqryrlmtmwtolma4t772gknmx7pxqu5opjwsrr2nc27qq": {
     "value": {
       "wnfs/pub/dir": {
         "metadata": {
@@ -110,9 +110,9 @@ expression: values
         },
         "previous": [],
         "userland": {},
-        "version": "0.2.0"
+        "version": "1.0.0"
       }
     },
-    "bytes": "oWx3bmZzL3B1Yi9kaXKkZ3ZlcnNpb25lMC4yLjBobWV0YWRhdGGiZ2NyZWF0ZWQAaG1vZGlmaWVkAGhwcmV2aW91c4BodXNlcmxhbmSg"
+    "bytes": "oWx3bmZzL3B1Yi9kaXKkZ3ZlcnNpb25lMS4wLjBobWV0YWRhdGGiZ2NyZWF0ZWQAaG1vZGlmaWVkAGhwcmV2aW91c4BodXNlcmxhbmSg"
   }
 }

--- a/wnfs/src/public/snapshots/wnfs__public__directory__snapshot_tests__directory_with_children.snap
+++ b/wnfs/src/public/snapshots/wnfs__public__directory__snapshot_tests__directory_with_children.snap
@@ -12,17 +12,17 @@ expression: dir
       "previous": [],
       "userland": {
         "music": {
-          "/": "bafyr4iaf7cxur6cz5723jjxmzjlhfszen6xvkn27b5mvtfrnurtmqggnnq"
+          "/": "bafyr4ietl6u7ligzk3sxfwqvycd2vhd4ohw3rxn5qv7ajrlzommvzk5la4"
         },
         "text.txt": {
-          "/": "bafyr4ifdbpj2udunaj7wpyb3by7zivabfva3qtwbnv232ysw5vut7vzx6e"
+          "/": "bafyr4ie5jfvlj66jxhhvggxjltfj4ljfhjyirnngts23e33ugezjpc6xaq"
         },
         "videos": {
-          "/": "bafyr4igv4cb3jiade36ged6hqwdfdu2wpnauksli6emabfgofuphtz27rm"
+          "/": "bafyr4ifmlt3hmgb5kdaprkhqqg774bcgyra54sli273iceddse25d7xkbe"
         }
       },
-      "version": "0.2.0"
+      "version": "1.0.0"
     }
   },
-  "bytes": "oWx3bmZzL3B1Yi9kaXKkZ3ZlcnNpb25lMC4yLjBobWV0YWRhdGGiZ2NyZWF0ZWQAaG1vZGlmaWVkAGhwcmV2aW91c4BodXNlcmxhbmSjZW11c2lj2CpYJQABcR4gBfivSPhZ7/W0puzKVnLLJG+vVTdfD1lZli2kZsgYzWxmdmlkZW9z2CpYJQABcR4g1eCDtKADJvxiD8eFhlHTVntBRUlo8RgAlM4tHnnnX4todGV4dC50eHTYKlglAAFxHiCjC9OqDo0Cf2fgOw4/lFQBLUG4TsFtdb1iVu1pP9c38Q=="
+  "bytes": "oWx3bmZzL3B1Yi9kaXKkZ3ZlcnNpb25lMS4wLjBobWV0YWRhdGGiZ2NyZWF0ZWQAaG1vZGlmaWVkAGhwcmV2aW91c4BodXNlcmxhbmSjZW11c2lj2CpYJQABcR4gk1+p9aDZVuVy2hXAh6qcfHHtuN29hX4ExXlzGVyrqwdmdmlkZW9z2CpYJQABcR4grFz2dhg9UMD4qPCBv/4ERsRB3klo1/aBEGORNdH+6glodGV4dC50eHTYKlglAAFxHiCdSWq0+8m5z1Ma6VzKni0lOnCItaactbJvdDEyl4vXBA=="
 }

--- a/wnfs/src/public/snapshots/wnfs__public__directory__snapshot_tests__directory_with_previous_links.snap
+++ b/wnfs/src/public/snapshots/wnfs__public__directory__snapshot_tests__directory_with_previous_links.snap
@@ -11,22 +11,22 @@ expression: dir
       },
       "previous": [
         {
-          "/": "bafyr4ihn7m344bbloghcqupxlygkskyhmpg5vgqw6ybin4unpcrksuttmy"
+          "/": "bafyr4ih3k2ipwwqryrlmtmwtolma4t772gknmx7pxqu5opjwsrr2nc27qq"
         }
       ],
       "userland": {
         "music": {
-          "/": "bafyr4iaf7cxur6cz5723jjxmzjlhfszen6xvkn27b5mvtfrnurtmqggnnq"
+          "/": "bafyr4ietl6u7ligzk3sxfwqvycd2vhd4ohw3rxn5qv7ajrlzommvzk5la4"
         },
         "text.txt": {
-          "/": "bafyr4ifdbpj2udunaj7wpyb3by7zivabfva3qtwbnv232ysw5vut7vzx6e"
+          "/": "bafyr4ie5jfvlj66jxhhvggxjltfj4ljfhjyirnngts23e33ugezjpc6xaq"
         },
         "videos": {
-          "/": "bafyr4igv4cb3jiade36ged6hqwdfdu2wpnauksli6emabfgofuphtz27rm"
+          "/": "bafyr4ifmlt3hmgb5kdaprkhqqg774bcgyra54sli273iceddse25d7xkbe"
         }
       },
-      "version": "0.2.0"
+      "version": "1.0.0"
     }
   },
-  "bytes": "oWx3bmZzL3B1Yi9kaXKkZ3ZlcnNpb25lMC4yLjBobWV0YWRhdGGiZ2NyZWF0ZWQAaG1vZGlmaWVkAGhwcmV2aW91c4HYKlglAAFxHiDt+zfOBCtxjihR914MqSsHY83amhb2AobyjXiiqVJzZmh1c2VybGFuZKNlbXVzaWPYKlglAAFxHiAF+K9I+Fnv9bSm7MpWcsskb69VN18PWVmWLaRmyBjNbGZ2aWRlb3PYKlglAAFxHiDV4IO0oAMm/GIPx4WGUdNWe0FFSWjxGACUzi0eeedfi2h0ZXh0LnR4dNgqWCUAAXEeIKML06oOjQJ/Z+A7Dj+UVAEtQbhOwW11vWJW7Wk/1zfx"
+  "bytes": "oWx3bmZzL3B1Yi9kaXKkZ3ZlcnNpb25lMS4wLjBobWV0YWRhdGGiZ2NyZWF0ZWQAaG1vZGlmaWVkAGhwcmV2aW91c4HYKlglAAFxHiD7VpD7WhHEVsmy03LYDk//0ZTWX++8Kdc9NpRjpotfhGh1c2VybGFuZKNlbXVzaWPYKlglAAFxHiCTX6n1oNlW5XLaFcCHqpx8ce243b2FfgTFeXMZXKurB2Z2aWRlb3PYKlglAAFxHiCsXPZ2GD1QwPio8IG//gRGxEHeSWjX9oEQY5E10f7qCWh0ZXh0LnR4dNgqWCUAAXEeIJ1JarT7ybnPUxrpXMqeLSU6cIi1ppy1sm90MTKXi9cE"
 }

--- a/wnfs/src/public/snapshots/wnfs__public__directory__snapshot_tests__empty_directory.snap
+++ b/wnfs/src/public/snapshots/wnfs__public__directory__snapshot_tests__empty_directory.snap
@@ -11,8 +11,8 @@ expression: dir
       },
       "previous": [],
       "userland": {},
-      "version": "0.2.0"
+      "version": "1.0.0"
     }
   },
-  "bytes": "oWx3bmZzL3B1Yi9kaXKkZ3ZlcnNpb25lMC4yLjBobWV0YWRhdGGiZ2NyZWF0ZWQAaG1vZGlmaWVkAGhwcmV2aW91c4BodXNlcmxhbmSg"
+  "bytes": "oWx3bmZzL3B1Yi9kaXKkZ3ZlcnNpb25lMS4wLjBobWV0YWRhdGGiZ2NyZWF0ZWQAaG1vZGlmaWVkAGhwcmV2aW91c4BodXNlcmxhbmSg"
 }

--- a/wnfs/src/public/snapshots/wnfs__public__file__snapshot_tests__file_with_previous_links.snap
+++ b/wnfs/src/public/snapshots/wnfs__public__file__snapshot_tests__file_with_previous_links.snap
@@ -11,14 +11,14 @@ expression: file
       },
       "previous": [
         {
-          "/": "bafyr4ifdbpj2udunaj7wpyb3by7zivabfva3qtwbnv232ysw5vut7vzx6e"
+          "/": "bafyr4ie5jfvlj66jxhhvggxjltfj4ljfhjyirnngts23e33ugezjpc6xaq"
         }
       ],
       "userland": {
         "/": "baeaaaaa"
       },
-      "version": "0.2.0"
+      "version": "1.0.0"
     }
   },
-  "bytes": "oW13bmZzL3B1Yi9maWxlpGd2ZXJzaW9uZTAuMi4waG1ldGFkYXRhomdjcmVhdGVkAGhtb2RpZmllZABocHJldmlvdXOB2CpYJQABcR4gowvTqg6NAn9n4DsOP5RUAS1BuE7BbXW9YlbtaT/XN/FodXNlcmxhbmTYKkUAAQAAAA=="
+  "bytes": "oW13bmZzL3B1Yi9maWxlpGd2ZXJzaW9uZTEuMC4waG1ldGFkYXRhomdjcmVhdGVkAGhtb2RpZmllZABocHJldmlvdXOB2CpYJQABcR4gnUlqtPvJuc9TGulcyp4tJTpwiLWmnLWyb3QxMpeL1wRodXNlcmxhbmTYKkUAAQAAAA=="
 }

--- a/wnfs/src/public/snapshots/wnfs__public__file__snapshot_tests__simple_file.snap
+++ b/wnfs/src/public/snapshots/wnfs__public__file__snapshot_tests__simple_file.snap
@@ -13,8 +13,8 @@ expression: file
       "userland": {
         "/": "baeaaaaa"
       },
-      "version": "0.2.0"
+      "version": "1.0.0"
     }
   },
-  "bytes": "oW13bmZzL3B1Yi9maWxlpGd2ZXJzaW9uZTAuMi4waG1ldGFkYXRhomdjcmVhdGVkAGhtb2RpZmllZABocHJldmlvdXOAaHVzZXJsYW5k2CpFAAEAAAA="
+  "bytes": "oW13bmZzL3B1Yi9maWxlpGd2ZXJzaW9uZTEuMC4waG1ldGFkYXRhomdjcmVhdGVkAGhtb2RpZmllZABocHJldmlvdXOAaHVzZXJsYW5k2CpFAAEAAAA="
 }

--- a/wnfs/src/root_tree.rs
+++ b/wnfs/src/root_tree.rs
@@ -9,7 +9,7 @@ use crate::{
         PrivateDirectory,
     },
     public::PublicDirectory,
-    VERSION,
+    WNFS_VERSION,
 };
 use anyhow::{bail, Result};
 #[cfg(test)]
@@ -311,7 +311,7 @@ where
             public: self.public_root.store(store).await?,
             exchange: self.exchange_root.store(store).await?,
             forest: self.forest.store(store).await?,
-            version: VERSION,
+            version: WNFS_VERSION,
         };
 
         store.put_serializable(&serializable).await

--- a/wnfs/src/snapshots/wnfs__root_tree__snapshot_tests__root_filesystems.snap
+++ b/wnfs/src/snapshots/wnfs__root_tree__snapshot_tests__root_filesystems.snap
@@ -3,54 +3,7 @@ source: wnfs/src/root_tree.rs
 expression: values
 ---
 {
-  "bafkr4ib74i65pgobxftfhdq7lkwcih6catv45npfy5aynl65dka6db2xly": {
-    "value": {
-      "/": {
-        "bytes": "TfJ38ZUJJ4WmfSGKSkGH/HZl6y6Y2NI48THbqRhgSfN/p7ZEEbDp1z00jy7gfNoG8wBEDR4yF4rIlJlRcMSUkDU//YFw9t0zP1MwL7A2rQ4bDSU1mSe+gb1GGUG4JvMUPCIBsGwgkrvhSRnK4pnfhHarFXbtaRE5YMSSuYfoOtXRPpKtZw7o8TRNdxgjt1QLbCI0Q7hZ5EstcymZu2Hlxdf603IsP2T0ieevv5uf9ajCHIQRnMyBW3xf4xXasQ030mSr8KlB0OIFLwjoO7VZx77wQkPj6Ge5e7LMD4AEgvkLSEtryT0HTMeyeDNnsYT35/yujr3LwCVHow6NKOFkgztJhP32C4xv/9sTcRFE0VHNVddrSb5OcnzQY/ItxFWqn27UKdGuVo088BhGxRkvUFn5Lvtk6ywn0BRhKhvuQMfnTrdSnmqaJ5FTAnu32+9w5gphG4v39PcHPNxsVSZKLNMzzooXdEj6Aw7+Ch3kLHFedPGO+iL4y2Lnm7KIpF8NVvrIva9QK/+ApYuS6ipMqueUEnI1oOyLyTqs68wF0kDBYEUQwdm4Eb4lQfejxatfKIBmP4AaR5KpR0wUoi/TuYHouXV/aaguLJljQ/bqs/sKgWgUi5M9mqgkVzS14Yi9RcaPkVK4firhuSsZkrWbmLFExhmjeGPQTEEID4wDO2ydP2nZzHrh8g"
-      }
-    },
-    "bytes": "TfJ38ZUJJ4WmfSGKSkGH/HZl6y6Y2NI48THbqRhgSfN/p7ZEEbDp1z00jy7gfNoG8wBEDR4yF4rIlJlRcMSUkDU//YFw9t0zP1MwL7A2rQ4bDSU1mSe+gb1GGUG4JvMUPCIBsGwgkrvhSRnK4pnfhHarFXbtaRE5YMSSuYfoOtXRPpKtZw7o8TRNdxgjt1QLbCI0Q7hZ5EstcymZu2Hlxdf603IsP2T0ieevv5uf9ajCHIQRnMyBW3xf4xXasQ030mSr8KlB0OIFLwjoO7VZx77wQkPj6Ge5e7LMD4AEgvkLSEtryT0HTMeyeDNnsYT35/yujr3LwCVHow6NKOFkgztJhP32C4xv/9sTcRFE0VHNVddrSb5OcnzQY/ItxFWqn27UKdGuVo088BhGxRkvUFn5Lvtk6ywn0BRhKhvuQMfnTrdSnmqaJ5FTAnu32+9w5gphG4v39PcHPNxsVSZKLNMzzooXdEj6Aw7+Ch3kLHFedPGO+iL4y2Lnm7KIpF8NVvrIva9QK/+ApYuS6ipMqueUEnI1oOyLyTqs68wF0kDBYEUQwdm4Eb4lQfejxatfKIBmP4AaR5KpR0wUoi/TuYHouXV/aaguLJljQ/bqs/sKgWgUi5M9mqgkVzS14Yi9RcaPkVK4firhuSsZkrWbmLFExhmjeGPQTEEID4wDO2ydP2nZzHrh8g=="
-  },
-  "bafkr4ibbqdra5wnhzq7yvkuh45jsw2h7sugu66ypkr35xcnlhcx3w3esxq": {
-    "value": {
-      "inumber": {
-        "/": {
-          "bytes": "+TSv2jieheAn4mBV6tSQfS4IZuigGiXQeCQNRn2Zc2k"
-        }
-      },
-      "name": {
-        "/": {
-          "bytes": "dobIKL6WvlAGN4ZEQRtRphUMtQSIlLQTc2lxc2Je7kKkNq9ooldHWcd1NG55AEAWqCOGbH+Vf3AgX6hNtrutFa6e7KJ/rSF4pTS7uuk6r2G/zOQ1leVnIvVeW+CYE3lcWNPB1yA6WSbMgfia8UIS46rgtOrfsYkMSdRxpkltthEiWmyQ7ahaWZaRXelLksMTYfwLVks+XI+WqG4Bzinvr9cV8eE7uGtIFeK7n2IGyfEv8fpE4jyjlNc51A+j85+VAT21EvT4DNaQwLVQ5PYdSZ/7qHvJOJzDCiluIcmX6TKsQ+XHqNzI4f0oJdzYFCKBG+C5Tjte9T0JyEABfxdvjg"
-        }
-      },
-      "ratchet": {
-        "large": {
-          "/": {
-            "bytes": "9ywQE1NYvFOxpnkYyimeZLlHdo/JPfhWQ8ARmvR7f+I"
-          }
-        },
-        "medium": {
-          "/": {
-            "bytes": "yvO1gGRmolMO5jeGE7tjY26HiIbjJe8zu8b6OHf9Xio"
-          }
-        },
-        "mediumCounter": 20,
-        "salt": {
-          "/": {
-            "bytes": "J6dQrLG9Do1fdEEl6bBBBp3gASVKF4GyoRoIkB5mT2g"
-          }
-        },
-        "small": {
-          "/": {
-            "bytes": "blxep4f4qhR48Wqyr7uuGQh7cdqdWtXm2cjXLef36GY"
-          }
-        },
-        "smallCounter": 40
-      }
-    },
-    "bytes": "qDqUJ6o6X1plKM++6A9STqLXzrm347jtSMhYOIh+yWiTOhHVoZTIMVDTEpvDQumk899LKsB7U/5Q86MSlzmXUcNBQa0vV07WFdAe95WmBFLhn/DSA4d/0+pP0Uh4iyEltgH/xJc9aba314TtRdHIu30on8qtKSRwSuj2IlKngvQjKWniPZ3QE5vClrcL63ld0bPpQoegVnxBgB6lOIXDH62hwVqCXmMe4nwNlt3Vw6ZQq9NYD4SAiH9j5zz1BQuUkEMhz86VkyeSU062WpgG2w+mdDUDKP9Nto2ESGDy6xAaZnWCDcfuIzWbn68zrdwjWRIt8wOYDZQ6kn3yXLR/alQO6InCj7olrcmMedoUchV02tMUOTSpaJ6FEYTRF/wTv8vdkLrSjLMWhTM7jWvZSszAvSYwhO0heV8Yb9dwwGeA1Q3EHwtS4oL84YBAhUvpclS9f45xpBjoulJmf/GVLbvOoN9IZoFeUy9Po5I+sfSsCe3SX/v7DpRVuUsAwb+NPP8b43Q/Ob1IHbSUFZ0pWJufc9gCk+LFUy0xh94D6SrxbguCDGk55m8yjpu9kS2OS2z3C/oLHAP99O9ZiDvVKDFqlQBJBHGyeAKHqVFedM5pMmE7Z8Yr3x19NkEBqiOgddfUXHpNUX/5ALBye4i1ahuo8i86HB/A2yQ6oor8YghHu4rFWr80cA=="
-  },
-  "bafkr4icxspprapdeglyzew5uea542agoqauuvvpihtpo577ll6fqtg6nh4": {
+  "bafkr4ia5qq2otfmijhh2z7dflkcy3vjb57x4wwghefugom3wzurkpzzzei": {
     "value": {
       "inumber": {
         "/": {
@@ -87,43 +40,35 @@ expression: values
         "smallCounter": 139
       }
     },
-    "bytes": "25bmMKnr8Ta28WVnajB4NNNdyZWqT0n/rRaZyuFCZgyGmHbMEZIQn9c+L1kAbULZNYdeVHhfA7AtaHpPiIazPGvV+ciXW8slZR/M6gTwiz7yZWRcXF8AlGAsESOSAtFdPg7I40RHOxbbhT6arohriUkwuQHwEI4naNQp+utBjA3iNFDWlSUH+qBPqLNX1PLKc9+SJHEfXoMp0C5cuFmcx+d4Q9rROUxOSuANajOcN38zt/YeGZrdAX1i58AozXxo4+hqOvsiX4Kn44FGVDJxIiyRoxZkfy/LxpHmxwDx4F4MBisMUBAbBpHUVH7HsE590Tgm34bnqtALCNDs7xXCJpF5VUOmcA9RCWQezSVu/3vbY6WXfv470UpQYDKY7ISLi1GOq4dt18FzNucxRqAfS1ImeICCyb1ORDH/PYilUjzInTc+6gnfhlh5rf6SdF0obLzYgGzuemyh+kLoHdJ3/9/G+FvM8OFkxssHHRDRWQHeBJN5kA2Yil7o09F/nqcTzkE0n5wDhKn5Ea8onseE0TwvSQjwoOsPePQ+3H+iwRhswlwdzLvU4E/a8KiVjoINSPWnDkJGooa4PSU9jFDKDMEqCc5H/S88IqQYz3/bvJEwxre3WBG5kUBfY/h0CqOn+Ubdgw/GIB9/GOdjTMA7BvxZ8ipdNdJtEC6lVRQuVOMZEQOCp+plpA=="
+    "bytes": "yasBVsw4nFEG4bbw1Mcoh0kvcZGKfCEcPvMXscVHgdUpZYoRpoc4s8gUPYNN9A02UhLEV4gVNnIAbwCrxMNPUNxscUJ3a1V1zeK2+71XTraSbdedAujf8jlDeHv+1lhqk/OxvUjJqiDGcMGkV4/xyeu/4fhlQ0dQ2Fw5odBmsEaFHk+w2LBRfWB+C7hqSoi6s95B5zGl4ZFPBWmLpHj9a3AkTsHEE1wBi19ho59tDlgOtv/d1lpGJMsqOMf0go8F1N4Zy4Ru8l7Oh2hPdGZ8yyJCwHlUsgtt7p1kXNqmbR3Sv6rJ8OK8oq6EANOXTGwsi0WpQcu7y9uqDzfbwg+sxFRnWm3ZxQUrCz6S3gRRTOtZKs+WgALrpOyct89qYcnSNGZ8JKLYcd9gW2RzoywgU8hLlBn1Zs/+y5hRjyjgZqNR0qHPabuA3gkG5YiTu9EabEbvQEgw+ZW/N67VNgmJDx0tlSM61/0q9+mih2ByZoBKGb9DvmN0YXXMsWx48SkZx87wRM9RavBorFBrHv4EjS19kTwoBAeKDFpW520Q8uEXnhGIrCd9eZ9q4NG/yZzN+pAUJj+lMZI3J5KA1DfTpaXjCcR/D6xDHD7RuuEgGDjHmWyGR2S1ZZc9K3vWctCgvCCmxGHEUooLxKkg/1PZE7Q9W0SACT4xCD17tgm0V8EP6DSsGlKx0w=="
   },
-  "bafkr4idzbmrcin6k46ngtgh43h257y6h6nzqe4kz3fotddxwfapemffu2i": {
-    "value": {
-      "/": {
-        "bytes": "KureFvu0kYp5e6Es9dauanzuUZVOnWFnyLz1iosg/v79ll3VniQqXucpa/JCZ1G3pMf+JC5/6shSI7QewtqPvVODqsNkopoeH0NAkyIBRMwpFA0ZtqAZQRRkEdtb/9UhuAHb3i4dmCW9AybpmclyPzc9/Qw7EwwfV53gIkDjf+smsxraqr2jssjMmwjGEV1mYLvUouVvaNyuOsvu+tn+NwfGmFj6Im3HOg"
-      }
-    },
-    "bytes": "KureFvu0kYp5e6Es9dauanzuUZVOnWFnyLz1iosg/v79ll3VniQqXucpa/JCZ1G3pMf+JC5/6shSI7QewtqPvVODqsNkopoeH0NAkyIBRMwpFA0ZtqAZQRRkEdtb/9UhuAHb3i4dmCW9AybpmclyPzc9/Qw7EwwfV53gIkDjf+smsxraqr2jssjMmwjGEV1mYLvUouVvaNyuOsvu+tn+NwfGmFj6Im3HOg=="
-  },
-  "bafkr4ih3xae3sm2j4hfs4ewpkoquwmuwjoq7qse7d4idrole7v7xa5myju": {
+  "bafkr4id7tonzrr3j5f33erkpudqpnx3o5qb3g2wq2nn3y6e6sbx22uoaaq": {
     "value": {
       "wnfs/priv/dir": {
         "entries": {
           "videos": {
             "contentCid": {
-              "/": "bafkr4ih5pv7ff7fk2jhrknb3ssfxo6agsrqpc3nq6lu4ijivvi34qsws5m"
+              "/": "bafkr4ieddzi7h76vmyg2uwbwezs3tkoir3kpqi2medlkarebbfcyuyjj5i"
             },
             "label": {
               "/": {
-                "bytes": "SW7ZiVA73mhVUe1OtejRbtCoRZ79PJw9wuUFNV58HkQ"
+                "bytes": "/utq/bjqBVKjDOyd4uoJYyiJUi+9udotQlWu1llBkvE"
               }
             },
             "snapshotKey": {
               "/": {
-                "bytes": "IwHjCI+xRqkSa4cKzwWkqBPhz3N5YU3jR5OHceoFF54"
+                "bytes": "VLvB1/9ylAKfYDf0mHbyi9z4Lqm1ZccFZkDrAFvXsqE"
               }
             },
             "temporalKey": {
               "/": {
-                "bytes": "OcD61sKHcfkozLyxa9Zynzk5dKEp91MTU7NfGzSILKYVPtbgI/LdEA"
+                "bytes": "nTHPSaNnSW4u+wFakpIA4mlJmFjXbdmiLAzKn+DqVkWbjzg0qqMPHw"
               }
             }
           }
         },
         "headerCid": {
-          "/": "bafkr4ibbqdra5wnhzq7yvkuh45jsw2h7sugu66ypkr35xcnlhcx3w3esxq"
+          "/": "bafkr4igjtsmaelhxa6jhlzzaane5zae47ytyvrsr2vufk3fkvrtyd7k6vy"
         },
         "metadata": {
           "created": 0,
@@ -134,24 +79,32 @@ expression: values
             1,
             {
               "/": {
-                "bytes": "CbOH/WVBd654ar9nYH3XNn/5HuEtYh9p/x3k15sas9zkiKJ3oIMMEGHCX0XEXgpt9LvNJ/vZyl4"
+                "bytes": "DU8Yzdq8psunbnnZiDkfxUrSu/AlD7uSMzip0WbZQ0fWluAN6+N4XoojU6cl/qhJ2mp2J4ruWFc"
               }
             }
           ]
         ],
-        "version": "0.2.0"
+        "version": "1.0.0"
       }
     },
-    "bytes": "6isyNxx0srLIYzICld/UOoGiOZiAmQpJpO6DsnsFzF6R9+sRMpW9t+GgDJPj/TEzmKXNAxZgueT4nFceuSt4TUWl24YeNesF2dQ1Ri6LB9DA9TkhXXxO2/LAcoX6R4/IztvV+hahRWrQNng3TRzbH7dlXBA07p62KZc83pKYTfifgZvLFc5Fk48ZCLZtEBc7k/VtKMcU9Yf8ZXC5hWnxCMFr6KdwMKjJ1m6GfKtXsazAuW0GoqV9SpM8Ua5runmmcVzD3wkPsyEMwjKvD63bIhOvp9rY+96vofSRAbLZ/Bx1QR3/Sm0tDJc9KhNUnyf+YG8ht+3gCe1zGyqcCTsfj26NwWu+6vBgmBJQJ8iVVfSJEICcoNPhsm+iQkvWcM7X0HgWnGS5aajDwSXzvsGHZlqVo2QHE+77qZk87Q5MvGI82UJ26NpfwXQAViT1fIdXAtnrk40xbC1OdZoZvNhY7ZaDbWmBUAQzT9e6fan1/jq4UOqg5BYiuFCmPYHvjU6+AA+fXMtNMoPICUejmpOWcte2PMbcITqZ6Rs7WsPZH5h5DIWWcUIbpEPExCqB"
+    "bytes": "6isyNxx0srLIYzICld/UOoGiOZiAmQpJ6Dto2pz79VKRKVfYs++1t5DD2/qGiqpXFzewaV7rn2Iox7yrIs6PVgLkITyHHSguv/A/JLZpUpsRKZISZKNcN0ddAmWlZsKh4b9xXMZSnWw1krvuJKeagjLob+X5UxO1NyDCXg9EpL22vpf+jLXTS/clyjj2EsPmSrgXkoMoI/viZnrI1Fo977Wj15HT+2Ync60N4lliBy1gaR4UFQ9WR8mI2EgyH7T7vTC3dok+vLS+AgsQ7z6imRMOVolXKBE/JsNSknhF0ga+VeeD4i1uijR6sLG7FZ3vftf+j6hAATvcuziwH5uniuGuwyVmuJlDTdhWybuodGdaap0/qMQsR7eQ8WZRKBO3hWJWni8cdJadbtz0TvwQmDKEK/8Q/9/X741Sd/dY8DL5vmdyEcAgjwRXg64VUZOBx1fSlpxG2vTAeVl7EXSrkEjhGMsOwiRdzjqKcUpTMbI2/B+XTvVf3HzP+vQoAUesLy8cR5TgB6N/f1dmcmEpL31aQvuilI8UfruHaECD+kpGb9rXo6XW1RUKLEjL"
   },
-  "bafkr4ih5pv7ff7fk2jhrknb3ssfxo6agsrqpc3nq6lu4ijivvi34qsws5m": {
+  "bafkr4iebdj4gxv437oi4fzjkbrkttr264sx2z6aya4yxiok7c2ffcbzrx4": {
+    "value": {
+      "/": {
+        "bytes": "KureFvu0kYp5e6Es9dauanzuUZVOnWFnWrXiDSrMN67FsZndLhfNsXRhGwwM8iUVm7sSAWvdMUkegIuRHDVvwhSrnZLONfSVljQ6XZOzpRBOLON+flwuHQXcTnXx75SMkNhMw0BIWxgEG3p/FbpnWsluuG5GQq/hY+rH51T/FLNOe/gO2RzAftu2z7rY97ftW87oANjNihypykS3ZmCq91T78Cu457MQDw"
+      }
+    },
+    "bytes": "KureFvu0kYp5e6Es9dauanzuUZVOnWFnWrXiDSrMN67FsZndLhfNsXRhGwwM8iUVm7sSAWvdMUkegIuRHDVvwhSrnZLONfSVljQ6XZOzpRBOLON+flwuHQXcTnXx75SMkNhMw0BIWxgEG3p/FbpnWsluuG5GQq/hY+rH51T/FLNOe/gO2RzAftu2z7rY97ftW87oANjNihypykS3ZmCq91T78Cu457MQDw=="
+  },
+  "bafkr4ieddzi7h76vmyg2uwbwezs3tkoir3kpqi2medlkarebbfcyuyjj5i": {
     "value": {
       "wnfs/priv/file": {
         "content": {
           "external": {
             "baseName": {
               "/": {
-                "bytes": "TK3a+r66dSOpZd8C+FfmdH4XisVb8rt2lf0qsmcRxjO8gx2/xxEiAjk1W+t8zao3LzVUAi7jtrxyOR2CtGRlJQ2G4YRcDUn2JHrWVJJKPu0Tc0u7jYfnGwDSwRoUzwo/Ce26kgQ84+o8VxG9D7t08FV4sCh4H7T0ClW9WVpDe34GcwXz8KuTgmhDplvKDbmalDWoxJmqBBm25phMw8k+tKPZdkIzG8rvwOe0JIYrgIzCRtu9yeXWbAmuzzkB8b8XQSzk4Qsg1GBD671dXHNUkUh5DfS2xekpVuyhQJDKqKm5U5K0qbmXTPYrG8yL3m6MTt3ASubqyF8xzsDQuLfmOw"
+                "bytes": "DUUMhrPcVxAOHt2QgZNZz2qYQk5ni08z/fRelGwDBGzh+tmTfwKZgAki047508dETfAOpwbi/cv9zJEvZPW1HBI7kYimDMkQy4y0s5O9Xtzn6rP6Ei2Cd4Wmiz/NWJj31ZyylIYa9ualtbSfRVdi/mSjZvHYB+DjBhfSCDx8G6wk+cKnYE0uxhLRDaXKnkm1GG0nrtlg6URTnEfYKWAidkat6zEAPlZENHPoYIFuWHEBB5iQ7a0LJ8KPcOCoaBOvY+NXeGqGS79yA2dADvUZ7xAaaAc3yNB2fKX0hE8JjQXJJ0Uz0YeD81Kx1gzzoSNtiZMydTzl7a5zxv9GxjykwQ"
               }
             },
             "blockContentSize": 262104,
@@ -164,17 +117,64 @@ expression: values
           }
         },
         "headerCid": {
-          "/": "bafkr4icxspprapdeglyzew5uea542agoqauuvvpihtpo577ll6fqtg6nh4"
+          "/": "bafkr4ia5qq2otfmijhh2z7dflkcy3vjb57x4wwghefugom3wzurkpzzzei"
         },
         "metadata": {
           "created": 0,
           "modified": 0
         },
         "previous": [],
-        "version": "0.2.0"
+        "version": "1.0.0"
       }
     },
-    "bytes": "mSnOvap3kHBnNt95vtCKWncBu/HIGmawuySjBDS1SqI5F6rEMyGGlbH8ywJJZgc6DOJtpcu2HXok+O6ZhAUxMbQ9R0tSsTHGsrOjW+ef9VBlY5YWarV50fDlpiA/zo8GtEPAl2AlDbzO7TXs/wYr3Dz/RNFWS5Lk/BHmi/7yEu/UH0IyNW1Y4oBFhNBAF/IMiLOpq+mm9CiXDm2HK5YGkgEkdBJP6ckefjMpbhYK+tMdOaQXE0pQ6PbMcNhWrKh0+7r4LyWBc/eW0/uoNqxTTZOVrkm+hDLfOLJj2MAn6fiBfhWF4z+1yNZb6D5AZaAtnr96kd2cglKy6uCvT1GZ49KFjRp8q/5qMjEN+mXpXZSSE5OCv/wBbPG7lc/9dqHdoGE6b7PikjqBy1oBMtxsTGGNM4N1gyBjlgAs25sDA4yx974eOygE43iudnKQ0xshWkr5+QcqRxMTBudUrKBZ7qBpJeaQdK0KivJYzGqmH5JfcXbCSc19il0UDXz7ocy5PPJtZg9t6DP3LBiXJe8wd839bWY/U1mxYJ2WLlr6L4mcnWXkTQklEJuiUXke4hs36G/77Qxn02ZL4IQZBM5pUT8kuKt4atumTZ93SBIZ0oVxPPGFyooKcpAl49/hpx5Ed64hJkdy4vtVuvS7G+j4VeBKkrMRTBrZVmfVkvByu91fhF6z+A2hNw=="
+    "bytes": "mSnOvap3kHBnNt95vtCKWncBu/HIGmawJhKrcM5Zozbld+VdONjH4NDq8Js19zHjyLFEA33Wg27IFR4wiJvIJWuFnda4bvm8U1kOb/zjdbvNz+eSrC5gy6s4PAo4tNcARkTWIz7nWRqjKlF2ZonbOMtBRfTZufHSBGyPkpW14kPIyuBMWV35riWwpqvQIc6HObDNHZZWdh+iJtNwrHBhldql6mrubij2dURLHoZlZqm2DdZX43nU2DTYLjJtX5cBQu83NzhsdHfANha5aX2sRldjxVUdLD9u5tdsvL9WY+XyWYlM0DDrYKjewwCny0oW1qH++u1IbT3qKbHQ/8YyQ5RephmYKYJRYk2Otimas2tieNpvMngfRd2xDpiBbmLrX7KalxhB0tXXxo3CGB9py6HUJSZkHpdMC/VMcV/pfjviVZYD7MQ/i24X6S3Y29ib2Ma0DfbTEnSgEuTXL8uTz4PyJVKdOljDGhNrVxCddt/viV4SybjHjjIg3i1nIdvmsrzLKz5AAtL/E4G4odbT6g/b4Exz9UWPgLFkw2tRYdiS79dkKou7s7zreqPIWczIYI5v+ldWvR1OKKDuiThkRuy5JOLI2Ugt93HS0doLkzI1h7Csp667boeRTnrDaxnoeD5jR/A4ZN4d5572XA/+kFpmzDbKJNIUalxQehq7lmgcKxxsHQXu5g=="
+  },
+  "bafkr4igjtsmaelhxa6jhlzzaane5zae47ytyvrsr2vufk3fkvrtyd7k6vy": {
+    "value": {
+      "inumber": {
+        "/": {
+          "bytes": "+TSv2jieheAn4mBV6tSQfS4IZuigGiXQeCQNRn2Zc2k"
+        }
+      },
+      "name": {
+        "/": {
+          "bytes": "dobIKL6WvlAGN4ZEQRtRphUMtQSIlLQTc2lxc2Je7kKkNq9ooldHWcd1NG55AEAWqCOGbH+Vf3AgX6hNtrutFa6e7KJ/rSF4pTS7uuk6r2G/zOQ1leVnIvVeW+CYE3lcWNPB1yA6WSbMgfia8UIS46rgtOrfsYkMSdRxpkltthEiWmyQ7ahaWZaRXelLksMTYfwLVks+XI+WqG4Bzinvr9cV8eE7uGtIFeK7n2IGyfEv8fpE4jyjlNc51A+j85+VAT21EvT4DNaQwLVQ5PYdSZ/7qHvJOJzDCiluIcmX6TKsQ+XHqNzI4f0oJdzYFCKBG+C5Tjte9T0JyEABfxdvjg"
+        }
+      },
+      "ratchet": {
+        "large": {
+          "/": {
+            "bytes": "9ywQE1NYvFOxpnkYyimeZLlHdo/JPfhWQ8ARmvR7f+I"
+          }
+        },
+        "medium": {
+          "/": {
+            "bytes": "yvO1gGRmolMO5jeGE7tjY26HiIbjJe8zu8b6OHf9Xio"
+          }
+        },
+        "mediumCounter": 20,
+        "salt": {
+          "/": {
+            "bytes": "J6dQrLG9Do1fdEEl6bBBBp3gASVKF4GyoRoIkB5mT2g"
+          }
+        },
+        "small": {
+          "/": {
+            "bytes": "blxep4f4qhR48Wqyr7uuGQh7cdqdWtXm2cjXLef36GY"
+          }
+        },
+        "smallCounter": 40
+      }
+    },
+    "bytes": "/KVWZ/d0jJGnaHzYuseY8Kxdt/qq5iUDG3U/qhbeNx4GT8aL+JWN4/pzcQSfDp4NftdI9gmfuI26xzVcnEbDRSgHCqEHi47gkXcu8qL5cBI8NNpihw3q/T+AN4flMHztDE1SKNqS345MZW30BdFkG3dUI/hiOMgr/fQx/GYa6KDXhY5R/1Z7/IJ7Kxl7rW4g/JGCJuqQDVC489NDQQzwe0Vq4yXQnXYpxcFh469n1NokLfmnNy+lDoeVl9b2OU013jIQhY3Ghyg31ZhS6R1OQap0Z+sghlOUqF35mXg4wLCnp9IyxUcz0xzrjQl/jQdLEuqGlVgTyWkViTAHWysqDKbKR52UgZ0RIxjW6JwACHmJqc9m0OspjrZnMWeXJ1ypFNq4QgSog0MQBf+/Xyt1nH8dwVbbtvDRZXDopnoMdswC0DplhlKWW3/1X2BnmzEcGYCJ6m5NP1CjfG7yvDv7Y+OCGLOCeekYLyDswW+H/GbAHUbCRDyUsZVmCV871qN9Ez/EGlN15u22setZdcOjq6aj3sbvm1Gi9SmnRIIYpalKUWzImtaU2LMgX23Fia4enAhBO530eC89W3PMVrdoRPetjIFwJQCL9lAmCbIuvANhgnhwWjGV8LuAGU+fwL1a6kxhey3uEarwAFSmUKtqpN7Q2oaZh2+e3ar0YZvDSPtA1FfEU7zB7g=="
+  },
+  "bafkr4ihchxthsvjbnmwsdk5pt5ukhk7g3iz6gmbtptamhcwuzpekgckboy": {
+    "value": {
+      "/": {
+        "bytes": "CaIElIejgMlk+GUpLGC40Qd1Zp+ulPs5UR5/75gWam2YgGXr8r2h26Vslc51CGqVQsBfqV3npthQgpqRr55bzU4UpZ22Q9Z6dV4W/5eTatTGjFYXXEbraleqK7NhRes3db42xjpvf019sdcLzXZd2tci9pDu2/N91NDJ1jtLJ8CimeEUvbs7B/Fy7JibFeMaAKa3z/aQMZrPgzVQWQjBbQeCyu+eNOCmiGr20bxtOG+YnQKHocG+3U1MA3tJ7v64IMO9n5AlZaZxJX0CzyGuaxtHHAQP8QY+EK+/a+RzuiUCQKfSJXDJHXj/qg19nmxuZ1mkSZ13ifhZAwJ0bB6zgljqpJ73FxupiejSYcNyKjOq1529Miy4Vtwj28iBtSR9Vq2W3x7t9GGXrNBEPTjIFO9+y4XTlOqqnp5T19fNDPGeApJ8C9rolO55gXa/OVPF2LtOUR4gN2s0P41Pe2damDx90CbT9e6QEZO4UWdsVznszC2QOAT3e0EeSd0T1ADNqv5hJU4WGyEc7hSgFvnIMWnKTcmnCEp8NOfJvs8JFtvl+oS9VK1pu3RVBWLiK+Ocan9lXZB9SKzgr5oj+g4LlxSr4LTfv+xmsqOlGTMH7RE1vLOaN/+4imqI9VXQygayQE6rxLY3lERcaIdp2qatXYHYUtjf8dmZjgHGCnE1Xfv2+SE2RRsxZw"
+      }
+    },
+    "bytes": "CaIElIejgMlk+GUpLGC40Qd1Zp+ulPs5UR5/75gWam2YgGXr8r2h26Vslc51CGqVQsBfqV3npthQgpqRr55bzU4UpZ22Q9Z6dV4W/5eTatTGjFYXXEbraleqK7NhRes3db42xjpvf019sdcLzXZd2tci9pDu2/N91NDJ1jtLJ8CimeEUvbs7B/Fy7JibFeMaAKa3z/aQMZrPgzVQWQjBbQeCyu+eNOCmiGr20bxtOG+YnQKHocG+3U1MA3tJ7v64IMO9n5AlZaZxJX0CzyGuaxtHHAQP8QY+EK+/a+RzuiUCQKfSJXDJHXj/qg19nmxuZ1mkSZ13ifhZAwJ0bB6zgljqpJ73FxupiejSYcNyKjOq1529Miy4Vtwj28iBtSR9Vq2W3x7t9GGXrNBEPTjIFO9+y4XTlOqqnp5T19fNDPGeApJ8C9rolO55gXa/OVPF2LtOUR4gN2s0P41Pe2damDx90CbT9e6QEZO4UWdsVznszC2QOAT3e0EeSd0T1ADNqv5hJU4WGyEc7hSgFvnIMWnKTcmnCEp8NOfJvs8JFtvl+oS9VK1pu3RVBWLiK+Ocan9lXZB9SKzgr5oj+g4LlxSr4LTfv+xmsqOlGTMH7RE1vLOaN/+4imqI9VXQygayQE6rxLY3lERcaIdp2qatXYHYUtjf8dmZjgHGCnE1Xfv2+SE2RRsxZw=="
   },
   "bafkr4ihicyuqqoaiorr2ger3323vm6lprkxfeubscfpozezepvfmnq7dri": {
     "value": {
@@ -184,7 +184,22 @@ expression: values
     },
     "bytes": "JtzBivNEvSIfnxKEEOl2Hi7pfMQAvf0HY3HYYF58iFHxFuoe3pCvJlRsRag9snel5oCR"
   },
-  "bafyr4iblh4a7umjlhqxij3sghyvw3aawybucafmtmgfpaq7mwv4mbyr4bm": {
+  "bafyr4idgh4ldbfxqjlmxgco772vow7ady4hxgq2t6vpypczkb3m6nexvrq": {
+    "value": {
+      "exchange": {
+        "/": "bafyr4ih3k2ipwwqryrlmtmwtolma4t772gknmx7pxqu5opjwsrr2nc27qq"
+      },
+      "forest": {
+        "/": "bafyr4idoqvkdibijvfvmq4kjcdawhytpqerhogq7tnf6m5f6w3csv2lq7i"
+      },
+      "public": {
+        "/": "bafyr4ih3k2ipwwqryrlmtmwtolma4t772gknmx7pxqu5opjwsrr2nc27qq"
+      },
+      "version": "1.0.0"
+    },
+    "bytes": "pGZmb3Jlc3TYKlglAAFxHiBuhVQ0BQmpashxSRDBY+JvgSJ3Gh+bS+Z0vrbFKulw+mZwdWJsaWPYKlglAAFxHiD7VpD7WhHEVsmy03LYDk//0ZTWX++8Kdc9NpRjpotfhGd2ZXJzaW9uZTEuMC4waGV4Y2hhbmdl2CpYJQABcR4g+1aQ+1oRxFbJstNy2A5P/9GU1l/vvCnXPTaUY6aLX4Q="
+  },
+  "bafyr4idoqvkdibijvfvmq4kjcdawhytpqerhogq7tnf6m5f6w3csv2lq7i": {
     "value": {
       "accumulator": {
         "generator": {
@@ -201,7 +216,7 @@ expression: values
       "root": [
         {
           "/": {
-            "bytes": "kUA"
+            "bytes": "NIA"
           }
         },
         [
@@ -209,15 +224,15 @@ expression: values
             [
               {
                 "/": {
-                  "bytes": "GMXr4DO34ZgiSKU5Lu1oJ7y7/qVOgegHdZgCbmS5w5ZcnakoT1eMuGUZiGeg4YBFqcRejtyZNc3D7cBPKN/P9GoNkOnK0A2OQpDnhdionzFoFms8mJmz5gukzgSBDDYAJXH9OKmCOvUbK5IdeAn4LhplHuzJbZ3uNuLK3tXUXdFdaYTUMHp3b9n1zb8H7ZN60m/UrxGfc0YvX+iXpiToQj80n+WIIpzd9oGzFPg2aNialqLADMUaDd741Fx5ricZu6re5dvwnd9DBPuEfOerppv916LgoOxX7Ri5OdVW+ShPIcgvJZtfN2x0El4Rn78QXE2mzBfV077dXOfPZLlV6Q"
+                  "bytes": "PfjGTXoUJKdi2jSyFoPY3aAlEqiVi+BwqYSLe+DxQPCgVwxdSTUZQv6nVJtt/NRb/+nT9UbXQfOY3qHpCyiWQW6DkHBof89sLi855MPr/mA/ZIjcv956Xu1TRnKhJ2axp6pAqrBHPLUexrcN2QAAT7YgzM7pDUW5OYQNm9HrBrqeB54fUSDpgnhGtHTSVRELkBgskdD4tCGBB6ccpIMm4c124VeZXF5uZhey71WtENhAGNIA8jF4GRwPdblzLACmsga5BBiYT3pABcIDe2pcWWcRVxxm2XrT1+wBvkK33wqUQVOOg23t109ZHVwl/RFHWNoGn9Gp4iTz2fqTgZwpSg"
                 }
               },
               [
                 {
-                  "/": "bafkr4ib74i65pgobxftfhdq7lkwcih6catv45npfy5aynl65dka6db2xly"
+                  "/": "bafkr4iebdj4gxv437oi4fzjkbrkttr264sx2z6aya4yxiok7c2ffcbzrx4"
                 },
                 {
-                  "/": "bafkr4idzbmrcin6k46ngtgh43h257y6h6nzqe4kz3fotddxwfapemffu2i"
+                  "/": "bafkr4ihchxthsvjbnmwsdk5pt5ukhk7g3iz6gmbtptamhcwuzpekgckboy"
                 }
               ]
             ]
@@ -226,15 +241,15 @@ expression: values
             [
               {
                 "/": {
-                  "bytes": "p4ip4BRI+Fc2zt0kOZyD1HwlBoPutFOfcg2iPrWg5lGwnwjd7TpBcF1iSzbulnimQEsdoQOrhjc1wrPp2tJPybON3R6FW3kTz6F3aOLl+GuWJQ78S3ItuJPZ8Nst9bdb3RE/He8HXSQYsKbIuikXpdON+wEjXjVI5MgpSkO/p1j5fECzDPmRmXpWZfrGjg2MURUsmE52yNpR59WVBnsSg58BYTGGizE/ro/G0d2MjY1NXWCzWAQjKoc1u0cTtAWb0rNvQXGF2enwkYzqJVv9tstFsQXQkdNpIjZ72m9N5K6q26/p6PrW3N5u+2/GsRP0Gs2/LcSSx2y8xfSZumnE9g"
+                  "bytes": "oFRKVnLhRiA24SFH9unmkPw401RB+tRYqW+c5JRg8x2SYVbhjrCKfXmG8tM5x8b3Vp6BBuWnXHO9a6UZ+/HVmgMzT1VB1lA0fViuHXBPQafHetehZLOUP9jgSyvjgC11fFU+tgSA4Nax0TCuRYt664sL2OfoSBAe56iSEZMJxmdRy23+xzTpHWic6e8qJUW5OCoYQWtwA8CwcY5BOo0H9gcJ9jfoOuQPbeRISGJ4lA085VSPQCxd9stHioUcDRsYW0YDuYaxV0ax9Qr3316fDJ/Ynbpi81bo+5dKPwqmJ8IupcCy9eBOQS9NatFCpBA+KxmQWwuQ9cV2S13VsJUxKQ"
                 }
               },
               [
                 {
-                  "/": "bafkr4icxspprapdeglyzew5uea542agoqauuvvpihtpo577ll6fqtg6nh4"
+                  "/": "bafkr4id7tonzrr3j5f33erkpudqpnx3o5qb3g2wq2nn3y6e6sbx22uoaaq"
                 },
                 {
-                  "/": "bafkr4ih5pv7ff7fk2jhrknb3ssfxo6agsrqpc3nq6lu4ijivvi34qsws5m"
+                  "/": "bafkr4igjtsmaelhxa6jhlzzaane5zae47ytyvrsr2vufk3fkvrtyd7k6vy"
                 }
               ]
             ]
@@ -243,29 +258,29 @@ expression: values
             [
               {
                 "/": {
-                  "bytes": "qWL++hc1hlrI3zuccuC2mYISlAR/KS7W2vpPnRJd86huPyFyUk+ZnHFedPg4biSXjdaHb3SI+OS+O3jCMtReUTg81UeibIIdnKQEDzgK01Z9cPufSSn/Cff2tKHwHDJGL1pwtUuYsebL2KeIVmMz/oBrLeyVhxhp7yImDB+jA2tDGbBioLejOk4A1LYdcJnH8PSoCnlaNYZJCQoZdPHC4sTcJq6vEJNdKYJzv4HSw77FfVSzBI5erWClgZKuDJaKgy09k8Hd4IIwmhxx+sS1ksZqdvP2ww22MLzjUF877n9YHYies0Q5L6NXMpk/HpIkQP0PbG/LUNLWHauqX1iJpQ"
-                }
-              },
-              [
-                {
-                  "/": "bafkr4ibbqdra5wnhzq7yvkuh45jsw2h7sugu66ypkr35xcnlhcx3w3esxq"
-                },
-                {
-                  "/": "bafkr4ih3xae3sm2j4hfs4ewpkoquwmuwjoq7qse7d4idrole7v7xa5myju"
-                }
-              ]
-            ]
-          ],
-          [
-            [
-              {
-                "/": {
-                  "bytes": "eWWp0QfUNWJyB4vo62EmGACdvrb9FT1dZjetzRxIyA7YtI87kz94fuQY4z0FpWr/XFqH6LqNXV+wbxtGCogNhRsMdEtEnsBPlaDkDtySaVxMsJnjtLGuDXBvddU22o0DJ0J7xj19CgIoZYwAg3uFOekXMTK2bi8DG5HFgFhqXut1COSONZqHef/D2mGjEAHIrsTMAinv21n5iS6y4u27ShQxByokbNIky25bsstk/O9OY+rGrL638yquRpDcNdKQwD+fVElPDB2Hi7NnaRBKq8Zdwvvs+144HpGz1f2AekBCaBS6SWcEWpFKIFtwkx+qF7Y8NttYqwnDbeF+ubtfVg"
+                  "bytes": "Qr2ZI+cZd1gPOv4QpAslhNanVZITJ5N+oAkmtxtySyaVupeWsTxYSRiwelVDJEnGDkO/1Iu8WzI/a6lL3lfOImC3ZaSlDBAIHOHZdeh7T74pty233wR8V2CL0X/JG78YGECKczEaCcY/oc3K+nYgna6tx9cRe03aE9XP/SnoKGRvYpS34lNec6fg0jAA0t4JqZM1BJe9y4/pnhEtxd07sCIBbvJIYOThLOIgvkbPj3uKhUYiiZNBhsydl/klMo4XhuksW87bkjjYFwnUnVDzO2M3K8J2EMdMzyu5lsmvlMT8Xd/FB5jJK2LGSb1ShMANhsSiIyJwPTADKBdzCioUbQ"
                 }
               },
               [
                 {
                   "/": "bafkr4ihicyuqqoaiorr2ger3323vm6lprkxfeubscfpozezepvfmnq7dri"
+                }
+              ]
+            ]
+          ],
+          [
+            [
+              {
+                "/": {
+                  "bytes": "mDoQjcWDa6hu3spPu3D/NOaRiXNA8z/CPHQsMn6n25dX+NnA22uDihzaPfWk+pgk6pxp1XMZ8ewttANgcnWvdhhLnyIkZe0614UmFXPFw8A4ywObAUYjCGbNJb+/Py9N+qqYg1/XTh5Ci50qkCWb1B4YnOxAkUOTA0GYpHRcLbXwL61kkuMnv1N5S0VYJfq3Bu/tvJun3nsOgtJx0yPxo5k1fRwzVluE9vuXlKOIXIkCLdlrCVtXMWReTS940PMONioT4MuColdghYRBY9c3ABZGzN9BqoVyY2B/7vH+K9KKQ5I3h5B3kkBBTPaa5aFwYM1uFUL+1lQrpaFgFK0dRg"
+                }
+              },
+              [
+                {
+                  "/": "bafkr4ia5qq2otfmijhh2z7dflkcy3vjb57x4wwghefugom3wzurkpzzzei"
+                },
+                {
+                  "/": "bafkr4ieddzi7h76vmyg2uwbwezs3tkoir3kpqi2medlkarebbfcyuyjj5i"
                 }
               ]
             ]
@@ -275,24 +290,9 @@ expression: values
       "structure": "hamt",
       "version": "0.1.0"
     },
-    "bytes": "pGRyb290gkKRQISBglkBABjF6+Azt+GYIkilOS7taCe8u/6lToHoB3WYAm5kucOWXJ2pKE9XjLhlGYhnoOGARanEXo7cmTXNw+3ATyjfz/RqDZDpytANjkKQ54XYqJ8xaBZrPJiZs+YLpM4EgQw2ACVx/Tipgjr1GyuSHXgJ+C4aZR7syW2d7jbiyt7V1F3RXWmE1DB6d2/Z9c2/B+2TetJv1K8Rn3NGL1/ol6Yk6EI/NJ/liCKc3faBsxT4NmjYmpaiwAzFGg3e+NRcea4nGbuq3uXb8J3fQwT7hHznq6ab/dei4KDsV+0YuTnVVvkoTyHILyWbXzdsdBJeEZ+/EFxNpswX1dO+3Vznz2S5VemC2CpYJQABVR4gP+I915nBuWZTjh9arCQfwgTrzrXlx0GGr90ageGHV17YKlglAAFVHiB5CyIkN8rnmmmY/Nn13+PH83MCcVnZXTGO9igeRhS00oGCWQEAp4ip4BRI+Fc2zt0kOZyD1HwlBoPutFOfcg2iPrWg5lGwnwjd7TpBcF1iSzbulnimQEsdoQOrhjc1wrPp2tJPybON3R6FW3kTz6F3aOLl+GuWJQ78S3ItuJPZ8Nst9bdb3RE/He8HXSQYsKbIuikXpdON+wEjXjVI5MgpSkO/p1j5fECzDPmRmXpWZfrGjg2MURUsmE52yNpR59WVBnsSg58BYTGGizE/ro/G0d2MjY1NXWCzWAQjKoc1u0cTtAWb0rNvQXGF2enwkYzqJVv9tstFsQXQkdNpIjZ72m9N5K6q26/p6PrW3N5u+2/GsRP0Gs2/LcSSx2y8xfSZumnE9oLYKlglAAFVHiBXk98QPGQy8ZJbtCA7zQDOgClK1eg83u7/61+LCZvNP9gqWCUAAVUeIP19flL8qtJPFTQ7lIt3eAaUYPFtsPLpxCUVqjfIStLrgYJZAQCpYv76FzWGWsjfO5xy4LaZghKUBH8pLtba+k+dEl3zqG4/IXJST5mccV50+DhuJJeN1odvdIj45L47eMIy1F5RODzVR6Jsgh2cpAQPOArTVn1w+59JKf8J9/a0ofAcMkYvWnC1S5ix5svYp4hWYzP+gGst7JWHGGnvIiYMH6MDa0MZsGKgt6M6TgDUth1wmcfw9KgKeVo1hkkJChl08cLixNwmrq8Qk10pgnO/gdLDvsV9VLMEjl6tYKWBkq4MloqDLT2Twd3ggjCaHHH6xLWSxmp28/bDDbYwvONQXzvuf1gdiJ6zRDkvo1cymT8ekiRA/Q9sb8tQ0tYdq6pfWImlgtgqWCUAAVUeICGA4g7Zp8w/iqqH51MraP+VDU97D1R324mrOK+7bJK82CpYJQABVR4g+7gJuTNJ4csuEs9ToUsylkuh+EifHxA4uWT9f3B1mE2BglkBAHllqdEH1DVicgeL6OthJhgAnb62/RU9XWY3rc0cSMgO2LSPO5M/eH7kGOM9BaVq/1xah+i6jV1fsG8bRgqIDYUbDHRLRJ7AT5Wg5A7ckmlcTLCZ47Sxrg1wb3XVNtqNAydCe8Y9fQoCKGWMAIN7hTnpFzEytm4vAxuRxYBYal7rdQjkjjWah3n/w9phoxAByK7EzAIp79tZ+YkusuLtu0oUMQcqJGzSJMtuW7LLZPzvTmPqxqy+t/MqrkaQ3DXSkMA/n1RJTwwdh4uzZ2kQSqvGXcL77PteOB6Rs9X9gHpAQmgUuklnBFqRSiBbcJMfqhe2PDbbWKsJw23hfrm7X1aB2CpYJQABVR4g6BYpCDgIdGOjEjvet1Z5b4quUlAyEV7skyR9SsbD44pndmVyc2lvbmUwLjEuMGlzdHJ1Y3R1cmVkaGFtdGthY2N1bXVsYXRvcqJnbW9kdWx1c1kBALXyWPTbNNnYquAHMtuQabNz1Z9QXHcMyMDP6dg/GsWhWlCmTaBXqSS5NLKZt15T3EMT6CYZ+RZfGffuy3W958+Vq4BspE2kVgXUX8On6yzyQNSglWerL2mmryScPGwA4G4GSUeVI1m0jkTG7EM3mjvRDuc5MTvwc/QuoWKCvrEgfVj1HfXnEU/ThFVXc2S67NsJg2MAfVA/wp/IHStYMS6BYIMVTU8SVR5TnBifMjsQFaSpo/Hh46lTElSGGUHGTygKaREsOsnxcGfJtKG7MxbUAzBLpIBxHv7FH5LY2J6iRGhTf+VOgzrhwrjz18EUmY/m2wwJK/2efN0yTlhiUdlpZ2VuZXJhdG9yWQEASxhAYVIS6TcgcK8rZ2LEY9siAPMu12U94+xW09MjqxR22cX+Jb2eeq3ykgWbIo+buUs0tfCxU7TiuFZo6oP5H+7DPbR1vkPAntUel8GJVL97bl2CYlK0UNfkhxGR0jfrbNAkhYCc1A0M4aR6IUCZhMxDhSMKtXnPSd8us+pTpyTuL+SoxAdj+hU8mcsbPg85CPHx/y5H/BFfWjb5BPLtaR2jN4hnOC4kcMkuxa/akWJk4zrPWKPWrX8XvfjkwTyixE5G21eG7c5h99FglAb0glDVptIbaULH2aDkuQnbqp8G6ZPuZvQrT3iOXZxRbj+O3hKOET631tQFVr66eR9ayQ=="
+    "bytes": "pGRyb290gkI0gISBglkBAD34xk16FCSnYto0shaD2N2gJRKolYvgcKmEi3vg8UDwoFcMXUk1GUL+p1SbbfzUW//p0/VG10HzmN6h6QsolkFug5BwaH/PbC4vOeTD6/5gP2SI3L/eel7tU0ZyoSdmsaeqQKqwRzy1Hsa3DdkAAE+2IMzO6Q1FuTmEDZvR6wa6ngeeH1Eg6YJ4RrR00lURC5AYLJHQ+LQhgQenHKSDJuHNduFXmVxebmYXsu9VrRDYQBjSAPIxeBkcD3W5cywAprIGuQQYmE96QAXCA3tqXFlnEVccZtl609fsAb5Ct98KlEFTjoNt7ddPWR1cJf0RR1jaBp/RqeIk89n6k4GcKUqC2CpYJQABVR4ggRp4a9eb+5HC5SoMVTnHXuSvrPgYBzF0OV8WilEHMb/YKlglAAFVHiDiPeZ5VSFrLSGrr59oo6vm2jPjMDN8wMOK1MvIowlBdoGCWQEAoFRKVnLhRiA24SFH9unmkPw401RB+tRYqW+c5JRg8x2SYVbhjrCKfXmG8tM5x8b3Vp6BBuWnXHO9a6UZ+/HVmgMzT1VB1lA0fViuHXBPQafHetehZLOUP9jgSyvjgC11fFU+tgSA4Nax0TCuRYt664sL2OfoSBAe56iSEZMJxmdRy23+xzTpHWic6e8qJUW5OCoYQWtwA8CwcY5BOo0H9gcJ9jfoOuQPbeRISGJ4lA085VSPQCxd9stHioUcDRsYW0YDuYaxV0ax9Qr3316fDJ/Ynbpi81bo+5dKPwqmJ8IupcCy9eBOQS9NatFCpBA+KxmQWwuQ9cV2S13VsJUxKYLYKlglAAFVHiB/m5uYx2npd7JFT6Dg9t9u7AOzatDTW7x4npBvrVHABNgqWCUAAVUeIMmcmAIs9weSdecgA0ncgJz+J4rGUdVoVWyqrGeB/V6ugYJZAQBCvZkj5xl3WA86/hCkCyWE1qdVkhMnk36gCSa3G3JLJpW6l5axPFhJGLB6VUMkScYOQ7/Ui7xbMj9rqUveV84iYLdlpKUMEAgc4dl16HtPvim3LbffBHxXYIvRf8kbvxgYQIpzMRoJxj+hzcr6diCdrq3H1xF7TdoT1c/9KegoZG9ilLfiU15zp+DSMADS3gmpkzUEl73Lj+meES3F3TuwIgFu8khg5OEs4iC+Rs+Pe4qFRiKJk0GGzJ2X+SUyjheG6SxbztuSONgXCdSdUPM7YzcrwnYQx0zPK7mWya+UxPxd38UHmMkrYsZJvVKEwA2GxKIjInA9MAMoF3MKKhRtgdgqWCUAAVUeIOgWKQg4CHRjoxI73rdWeW+KrlJQMhFe7JMkfUrGw+OKgYJZAQCYOhCNxYNrqG7eyk+7cP805pGJc0DzP8I8dCwyfqfbl1f42cDba4OKHNo99aT6mCTqnGnVcxnx7C20A2Byda92GEufIiRl7TrXhSYVc8XDwDjLA5sBRiMIZs0lv78/L036qpiDX9dOHkKLnSqQJZvUHhic7ECRQ5MDQZikdFwttfAvrWSS4ye/U3lLRVgl+rcG7+28m6feew6C0nHTI/GjmTV9HDNWW4T2+5eUo4hciQIt2WsJW1cxZF5NL3jQ8w42KhPgy4KiV2CFhEFj1zcAFkbM30GqhXJjYH/u8f4r0opDkjeHkHeSQEFM9prloXBgzW4VQv7WVCuloWAUrR1GgtgqWCUAAVUeIB2ENOmViEnPrPxlWoWN1SHv78tYxyFoZzN2zSKn5zki2CpYJQABVR4ggx5R8//VZg2qWDYmZbmpyI7U+CNMINagRIEJRYphKepndmVyc2lvbmUwLjEuMGlzdHJ1Y3R1cmVkaGFtdGthY2N1bXVsYXRvcqJnbW9kdWx1c1kBALXyWPTbNNnYquAHMtuQabNz1Z9QXHcMyMDP6dg/GsWhWlCmTaBXqSS5NLKZt15T3EMT6CYZ+RZfGffuy3W958+Vq4BspE2kVgXUX8On6yzyQNSglWerL2mmryScPGwA4G4GSUeVI1m0jkTG7EM3mjvRDuc5MTvwc/QuoWKCvrEgfVj1HfXnEU/ThFVXc2S67NsJg2MAfVA/wp/IHStYMS6BYIMVTU8SVR5TnBifMjsQFaSpo/Hh46lTElSGGUHGTygKaREsOsnxcGfJtKG7MxbUAzBLpIBxHv7FH5LY2J6iRGhTf+VOgzrhwrjz18EUmY/m2wwJK/2efN0yTlhiUdlpZ2VuZXJhdG9yWQEASxhAYVIS6TcgcK8rZ2LEY9siAPMu12U94+xW09MjqxR22cX+Jb2eeq3ykgWbIo+buUs0tfCxU7TiuFZo6oP5H+7DPbR1vkPAntUel8GJVL97bl2CYlK0UNfkhxGR0jfrbNAkhYCc1A0M4aR6IUCZhMxDhSMKtXnPSd8us+pTpyTuL+SoxAdj+hU8mcsbPg85CPHx/y5H/BFfWjb5BPLtaR2jN4hnOC4kcMkuxa/akWJk4zrPWKPWrX8XvfjkwTyixE5G21eG7c5h99FglAb0glDVptIbaULH2aDkuQnbqp8G6ZPuZvQrT3iOXZxRbj+O3hKOET631tQFVr66eR9ayQ=="
   },
-  "bafyr4ihgszubhutgje7sirwgrimkq2oezkae75lz3ydlewww444juhy57u": {
-    "value": {
-      "exchange": {
-        "/": "bafyr4ihn7m344bbloghcqupxlygkskyhmpg5vgqw6ybin4unpcrksuttmy"
-      },
-      "forest": {
-        "/": "bafyr4iblh4a7umjlhqxij3sghyvw3aawybucafmtmgfpaq7mwv4mbyr4bm"
-      },
-      "public": {
-        "/": "bafyr4ihn7m344bbloghcqupxlygkskyhmpg5vgqw6ybin4unpcrksuttmy"
-      },
-      "version": "0.2.0"
-    },
-    "bytes": "pGZmb3Jlc3TYKlglAAFxHiArPwH6MSs8LoTuRj4rbYAWwGggFZNhivBD7LV4wOI8C2ZwdWJsaWPYKlglAAFxHiDt+zfOBCtxjihR914MqSsHY83amhb2AobyjXiiqVJzZmd2ZXJzaW9uZTAuMi4waGV4Y2hhbmdl2CpYJQABcR4g7fs3zgQrcY4oUfdeDKkrB2PN2poW9gKG8o14oqlSc2Y="
-  },
-  "bafyr4ihn7m344bbloghcqupxlygkskyhmpg5vgqw6ybin4unpcrksuttmy": {
+  "bafyr4ih3k2ipwwqryrlmtmwtolma4t772gknmx7pxqu5opjwsrr2nc27qq": {
     "value": {
       "wnfs/pub/dir": {
         "metadata": {
@@ -301,9 +301,9 @@ expression: values
         },
         "previous": [],
         "userland": {},
-        "version": "0.2.0"
+        "version": "1.0.0"
       }
     },
-    "bytes": "oWx3bmZzL3B1Yi9kaXKkZ3ZlcnNpb25lMC4yLjBobWV0YWRhdGGiZ2NyZWF0ZWQAaG1vZGlmaWVkAGhwcmV2aW91c4BodXNlcmxhbmSg"
+    "bytes": "oWx3bmZzL3B1Yi9kaXKkZ3ZlcnNpb25lMS4wLjBobWV0YWRhdGGiZ2NyZWF0ZWQAaG1vZGlmaWVkAGhwcmV2aW91c4BodXNlcmxhbmSg"
   }
 }


### PR DESCRIPTION
- Sets WNFS data format version to 1.0.0 (and updates the version checks. They match against 1.0.x now)
- Updates the domain separation strings (we added versioning to them & changed them from saying `deriv` to saying `derivation`)
- Updates snapshots, since the version number changed & the domain separation strings means the keys changed, too.