### PR TITLE
chore: Update JS package exports

### DIFF
--- a/wnfs-wasm/package.json
+++ b/wnfs-wasm/package.json
@@ -4,7 +4,7 @@
     "The Fission Authors"
   ],
   "description": "WebNative Filesystem API (WebAssembly)",
-  "version": "0.1.24",
+  "version": "0.1.26",
   "license": "Apache-2.0",
   "homepage": "https://fission.codes",
   "repository": {

--- a/wnfs-wasm/package.json
+++ b/wnfs-wasm/package.json
@@ -19,12 +19,12 @@
     "decentralisation"
   ],
   "type": "module",
-  "main": "dist/nodejs/wnfs_wasm.cjs",
   "module": "dist/bundler/wnfs_wasm.js",
   "types": "dist/nodejs/wnfs_wasm.d.ts",
   "exports": {
     ".": {
       "workerd": "./dist/web/workerd.js",
+      "browser": "./dist/bundler/wnfs_wasm.js",
       "node": "./dist/nodejs/wnfs_wasm.cjs",
       "default": "./dist/bundler/wnfs_wasm.js",
       "types": "./dist/nodejs/wnfs_wasm.d.ts"


### PR DESCRIPTION
## Summary

This PR makes the following changes:

- [x] Add `browser` package export
- [x] Remove `main` entry point

This PR brings in improvements from the `wasm-js` project in this PR: https://github.com/fission-codes/wasm-js/pull/7

Adding the `browser` entry point and placing it before the `node` makes sure we resolve the bundler target for SSR in SvelteKit and NextJS.

NextJS unfortunately resolves `main` before anything and is unable to handle CommonJS. As a result, we are dropping `main` which was only intended for projects using older versions of `node`.

## Test plan (required)

Testing this fully would require a SvelteKit and NextJS example app. We have these examples over in the `wasm-js` repo: https://github.com/fission-codes/wasm-js/tree/main/examples

## Closing issues

None yet. Let me know if you'd like one.

## After Merge

- [x] Does this change invalidate any docs or tutorials? No.
- [x] Does this change require a release to be made? Go forth bots and release the changes. 🤖 