### PR TITLE
chore: Update `async-once-cell` to v0.5

### DIFF
--- a/wnfs-common/Cargo.toml
+++ b/wnfs-common/Cargo.toml
@@ -18,7 +18,7 @@ authors = ["The Fission Authors"]
 
 [dependencies]
 anyhow = "1.0"
-async-once-cell = "0.4"
+async-once-cell = "0.5"
 async-trait = "0.1"
 base64 = { version = "0.21", optional = true }
 base64-serde = { version = "0.7", optional = true }

--- a/wnfs-common/src/link.rs
+++ b/wnfs-common/src/link.rs
@@ -197,7 +197,11 @@ where
         match self {
             Self::Encoded { cid, value_cache } => Self::Encoded {
                 cid: *cid,
-                value_cache: OnceCell::new_with(value_cache.get().cloned()),
+                value_cache: value_cache
+                    .get()
+                    .cloned()
+                    .map(OnceCell::new_with)
+                    .unwrap_or_default(),
             },
             Self::Decoded { value } => Self::Decoded {
                 value: value.clone(),
@@ -293,7 +297,12 @@ mod tests {
         fn clone(&self) -> Self {
             Self {
                 price: self.price,
-                persisted_as: OnceCell::new_with(self.persisted_as.get().cloned()),
+                persisted_as: self
+                    .persisted_as
+                    .get()
+                    .cloned()
+                    .map(OnceCell::new_with)
+                    .unwrap_or_default(),
             }
         }
     }

--- a/wnfs-hamt/Cargo.toml
+++ b/wnfs-hamt/Cargo.toml
@@ -18,7 +18,7 @@ authors = ["The Fission Authors"]
 
 [dependencies]
 anyhow = "1.0"
-async-once-cell = "0.4"
+async-once-cell = "0.5"
 async-recursion = "1.0"
 async-trait = "0.1"
 bitvec = { version = "1.0", features = ["serde"] }

--- a/wnfs-hamt/src/node.rs
+++ b/wnfs-hamt/src/node.rs
@@ -770,7 +770,12 @@ impl<K, V, H: Hasher> Node<K, V, H> {
 impl<K: Clone, V: Clone, H: Hasher> Clone for Node<K, V, H> {
     fn clone(&self) -> Self {
         Self {
-            persisted_as: OnceCell::new_with(self.persisted_as.get().cloned()),
+            persisted_as: self
+                .persisted_as
+                .get()
+                .cloned()
+                .map(OnceCell::new_with)
+                .unwrap_or_default(),
             bitmask: self.bitmask,
             pointers: self.pointers.clone(),
             hasher: PhantomData,

--- a/wnfs/Cargo.toml
+++ b/wnfs/Cargo.toml
@@ -19,7 +19,7 @@ authors = ["The Fission Authors"]
 [dependencies]
 aes-kw = { version = "0.2", features = ["alloc"] }
 anyhow = "1.0"
-async-once-cell = "0.4"
+async-once-cell = "0.5"
 async-recursion = "1.0"
 async-stream = "0.3"
 async-trait = "0.1"

--- a/wnfs/src/private/directory.rs
+++ b/wnfs/src/private/directory.rs
@@ -1290,7 +1290,7 @@ impl PrivateDirectory {
         }
 
         let content = PrivateDirectoryContent {
-            persisted_as: OnceCell::new_with(Some(cid)),
+            persisted_as: OnceCell::new_with(cid),
             metadata: serializable.metadata,
             previous: serializable.previous.into_iter().collect(),
             entries: entries_decrypted,
@@ -1395,7 +1395,12 @@ impl PartialEq for PrivateDirectoryContent {
 impl Clone for PrivateDirectoryContent {
     fn clone(&self) -> Self {
         Self {
-            persisted_as: OnceCell::new_with(self.persisted_as.get().cloned()),
+            persisted_as: self
+                .persisted_as
+                .get()
+                .cloned()
+                .map(OnceCell::new_with)
+                .unwrap_or_default(),
             previous: self.previous.clone(),
             metadata: self.metadata.clone(),
             entries: self.entries.clone(),

--- a/wnfs/src/private/file.rs
+++ b/wnfs/src/private/file.rs
@@ -750,7 +750,7 @@ impl PrivateFile {
         }
 
         let content = PrivateFileContent {
-            persisted_as: OnceCell::new_with(Some(cid)),
+            persisted_as: OnceCell::new_with(cid),
             previous: serializable.previous.into_iter().collect(),
             metadata: serializable.metadata,
             content: serializable.content,
@@ -824,7 +824,12 @@ impl PartialEq for PrivateFileContent {
 impl Clone for PrivateFileContent {
     fn clone(&self) -> Self {
         Self {
-            persisted_as: OnceCell::new_with(self.persisted_as.get().cloned()),
+            persisted_as: self
+                .persisted_as
+                .get()
+                .cloned()
+                .map(OnceCell::new_with)
+                .unwrap_or_default(),
             previous: self.previous.clone(),
             metadata: self.metadata.clone(),
             content: self.content.clone(),

--- a/wnfs/src/private/link.rs
+++ b/wnfs/src/private/link.rs
@@ -169,7 +169,11 @@ impl Clone for PrivateLink {
         match self {
             Self::Encrypted { private_ref, cache } => Self::Encrypted {
                 private_ref: private_ref.clone(),
-                cache: OnceCell::new_with(cache.get().cloned()),
+                cache: cache
+                    .get()
+                    .cloned()
+                    .map(OnceCell::new_with)
+                    .unwrap_or_default(),
             },
             Self::Decrypted { node } => Self::Decrypted { node: node.clone() },
         }

--- a/wnfs/src/public/directory.rs
+++ b/wnfs/src/public/directory.rs
@@ -802,7 +802,12 @@ impl PartialEq for PublicDirectory {
 impl Clone for PublicDirectory {
     fn clone(&self) -> Self {
         Self {
-            persisted_as: OnceCell::new_with(self.persisted_as.get().cloned()),
+            persisted_as: self
+                .persisted_as
+                .get()
+                .cloned()
+                .map(OnceCell::new_with)
+                .unwrap_or_default(),
             metadata: self.metadata.clone(),
             userland: self.userland.clone(),
             previous: self.previous.clone(),

--- a/wnfs/src/public/file.rs
+++ b/wnfs/src/public/file.rs
@@ -199,7 +199,12 @@ impl PartialEq for PublicFile {
 impl Clone for PublicFile {
     fn clone(&self) -> Self {
         Self {
-            persisted_as: OnceCell::new_with(self.persisted_as.get().cloned()),
+            persisted_as: self
+                .persisted_as
+                .get()
+                .cloned()
+                .map(OnceCell::new_with)
+                .unwrap_or_default(),
             metadata: self.metadata.clone(),
             userland: self.userland,
             previous: self.previous.clone(),


### PR DESCRIPTION
Subsumes #245 

They had an API change where `OnceCell::new_with` would now only build *filled* `OnceCell`s, not empty ones anymore, so its parameter type changed from `Option<T>` to just `T`.

Means I had simply had to either call `OnceCell::new_with` when it's `Some` or otherwise use `OnceCell::new()` (via `Default`).