### PR TITLE
fix: Fix `search_latest` on `write` and file mountpoints

### DIFF
--- a/wnfs-nameaccumulator/src/name.rs
+++ b/wnfs-nameaccumulator/src/name.rs
@@ -677,6 +677,33 @@ mod tests {
         Ok(())
     }
 
+    #[test]
+    fn serialized_equals_unserialized() -> Result<()> {
+        let rng = &mut thread_rng();
+        let setup = &AccumulatorSetup::from_rsa_2048(rng);
+
+        let mut name_one = NameAccumulator::empty(setup);
+        let mut name_two = NameAccumulator::empty(setup);
+
+        assert_eq!(name_one, name_two);
+
+        name_one.as_bytes(); // Force serialization
+
+        assert_eq!(name_one, name_two);
+
+        let segment = NameSegment::new(rng);
+        name_one.add(Some(&segment), setup);
+        name_two.add(Some(&segment), setup);
+
+        assert_eq!(name_one, name_two);
+
+        name_one.as_bytes(); // Force serialization
+
+        assert_eq!(name_one, name_two);
+
+        Ok(())
+    }
+
     #[proptest(cases = 32)]
     fn batch_proofs(do_batch_step: [bool; 4], do_verify_step: [bool; 4], seed: u64) {
         let rng = &mut ChaCha12Rng::seed_from_u64(seed);

--- a/wnfs-nameaccumulator/src/name.rs
+++ b/wnfs-nameaccumulator/src/name.rs
@@ -678,7 +678,7 @@ mod tests {
     }
 
     #[test]
-    fn serialized_equals_unserialized() -> Result<()> {
+    fn equals_ignores_serialization_cache() -> Result<()> {
         let rng = &mut thread_rng();
         let setup = &AccumulatorSetup::from_rsa_2048(rng);
 

--- a/wnfs/src/private/directory.rs
+++ b/wnfs/src/private/directory.rs
@@ -304,6 +304,10 @@ impl PrivateDirectory {
         forest: &impl PrivateForest,
         store: &impl BlockStore,
     ) -> Result<SearchResult<&'a mut Self>> {
+        if search_latest {
+            *self = self.clone().search_latest(forest, store).await?;
+        }
+
         let mut working_dir = self.prepare_next_revision()?;
         for (depth, segment) in path_segments.iter().enumerate() {
             match working_dir
@@ -2157,6 +2161,85 @@ mod tests {
         let read_back = old_dir.read(path, true, forest, store).await?;
 
         assert_eq!(&read_back, content);
+
+        Ok(())
+    }
+
+    #[async_std::test]
+    async fn test_regression_read_old_access_key() -> Result<()> {
+        let rng = &mut thread_rng();
+        let store = &MemoryBlockStore::new();
+        let forest = &mut HamtForest::new_rsa_2048(rng);
+        let mut dir =
+            PrivateDirectory::new_and_store(&forest.empty_name(), Utc::now(), forest, store, rng)
+                .await?;
+
+        let access_key = dir.as_node().store(forest, store, rng).await?;
+
+        let first = b"Hi".to_vec();
+        let second = b"Hi again".to_vec();
+        let path = &["test.txt".into()];
+
+        dir.write(path, true, Utc::now(), first.clone(), forest, store, rng)
+            .await?;
+
+        dir.as_node().store(forest, store, rng).await?;
+
+        let mut loaded_dir = PrivateNode::load(&access_key, forest, store, None)
+            .await?
+            .as_dir()?;
+
+        assert_eq!(loaded_dir.read(path, true, forest, store).await?, first);
+
+        loaded_dir
+            .write(path, true, Utc::now(), second.clone(), forest, store, rng)
+            .await?;
+
+        loaded_dir.as_node().store(forest, store, rng).await?;
+
+        // regression: This assertion used to fail
+        assert_eq!(loaded_dir.read(path, true, forest, store).await?, second);
+
+        Ok(())
+    }
+
+    #[async_std::test]
+    async fn test_regression_read_old_file_access_key() -> Result<()> {
+        let rng = &mut thread_rng();
+        let store = &MemoryBlockStore::new();
+        let forest = &mut HamtForest::new_rsa_2048(rng);
+        let mut dir =
+            PrivateDirectory::new_and_store(&forest.empty_name(), Utc::now(), forest, store, rng)
+                .await?;
+
+        let first = b"Hi".to_vec();
+        let second = b"Hi again".to_vec();
+        let path = &["test.txt".into()];
+
+        dir.write(path, true, Utc::now(), first.clone(), forest, store, rng)
+            .await?;
+
+        dir.as_node().store(forest, store, rng).await?;
+
+        let file_access_key = dir
+            .get_node(path, true, forest, store)
+            .await?
+            .unwrap()
+            .store(forest, store, rng)
+            .await?;
+
+        dir.write(path, true, Utc::now(), second.clone(), forest, store, rng)
+            .await?;
+
+        dir.as_node().store(forest, store, rng).await?;
+
+        let node = PrivateNode::load(&file_access_key, forest, store, None).await?;
+        // regression: This call used to fail
+        let loaded_file = node.search_latest(forest, store).await?.as_file()?;
+
+        let content = loaded_file.get_content(forest, store).await?;
+
+        assert_eq!(content, second);
 
         Ok(())
     }

--- a/wnfs/src/private/node/node.rs
+++ b/wnfs/src/private/node/node.rs
@@ -413,7 +413,7 @@ impl PrivateNode {
         store: &impl BlockStore,
     ) -> Result<Vec<PrivateNode>> {
         let header = self.get_header();
-        let mountpoint = header.name.parent().unwrap_or_else(|| forest.empty_name());
+        let mountpoint = header.name.parent();
 
         let current_name = &header.get_revision_name();
         if !forest.has(current_name, store).await? {
@@ -451,18 +451,17 @@ impl PrivateNode {
         let name_hash =
             blake3::Hasher::hash(&forest.get_accumulated_name(&current_header.get_revision_name()));
 
-        Ok(forest
+        forest
             .get_multivalue_by_hash(
                 &name_hash,
                 &current_header.derive_temporal_key(),
                 store,
-                Some(mountpoint),
+                mountpoint,
             )
             .collect::<Vec<Result<PrivateNode>>>()
             .await
             .into_iter()
-            .filter_map(|result| result.ok()) // Should we filter out errors?
-            .collect())
+            .collect::<Result<Vec<_>>>()
     }
 
     /// Tries to deserialize and decrypt a PrivateNode at provided PrivateRef


### PR DESCRIPTION
This fixes two bugs reported by @icidasset:
- We don't respect the `search_latest` parameter during calls like `write` or `mkdir` for the root directory.
- The mountpoint was incorrectly set in `search_latest_node` to the empty name accumulator in some cases.