### PR TITLE
Big integer abstraction for Name accumulators & `rug`-based BigInt backend

### DIFF
--- a/wnfs-bench/Cargo.toml
+++ b/wnfs-bench/Cargo.toml
@@ -16,7 +16,7 @@ rand = "0.8"
 wnfs = { path = "../wnfs" }
 wnfs-common = { path = "../wnfs-common", features = ["test_utils"] }
 wnfs-hamt = { path = "../wnfs-hamt", features = ["test_utils"] }
-wnfs-nameaccumulator = { path = "../wnfs-nameaccumulator" }
+wnfs-nameaccumulator = { path = "../wnfs-nameaccumulator", features = ["num-bigint-dig", "rug"] }
 
 [[bench]]
 name = "hamt"

--- a/wnfs-bench/nameaccumulator.rs
+++ b/wnfs-bench/nameaccumulator.rs
@@ -1,41 +1,72 @@
 use criterion::{criterion_group, criterion_main, BatchSize, Criterion};
 use rand::{thread_rng, Rng};
-use wnfs_nameaccumulator::{AccumulatorSetup, NameAccumulator, NameSegment};
+use wnfs_nameaccumulator::{AccumulatorSetup, BigNumDig, BigNumRug, NameAccumulator, NameSegment};
 
 fn name_segment_from_digest(c: &mut Criterion) {
-    c.bench_function("NameSegment::new_hashed", |b| {
+    c.bench_function("NameSegment::<BigNumDig>::new_hashed", |b| {
         b.iter_batched(
             || thread_rng().gen::<[u8; 32]>(),
-            |sth| NameSegment::new_hashed("wnfs benchmarks", sth),
+            |sth| NameSegment::<BigNumDig>::new_hashed("wnfs benchmarks", sth),
+            BatchSize::SmallInput,
+        );
+    });
+    c.bench_function("NameSegment::<BigNumRug>::new_hashed", |b| {
+        b.iter_batched(
+            || thread_rng().gen::<[u8; 32]>(),
+            |sth| NameSegment::<BigNumRug>::new_hashed("wnfs benchmarks", sth),
             BatchSize::SmallInput,
         );
     });
 }
 
 fn name_segment_rng(c: &mut Criterion) {
-    c.bench_function("NameSegment::new(rng)", |b| {
-        b.iter(|| NameSegment::new(&mut thread_rng()));
+    c.bench_function("NameSegment::<BigNumDig>::new(rng)", |b| {
+        b.iter(|| NameSegment::<BigNumDig>::new(&mut thread_rng()));
+    });
+    c.bench_function("NameSegment::<BigNumRug>::new(rng)", |b| {
+        b.iter(|| NameSegment::<BigNumRug>::new(&mut thread_rng()));
     });
 }
 
 fn name_accumulator_add(c: &mut Criterion) {
-    let setup = &AccumulatorSetup::from_rsa_2048(&mut thread_rng());
-    c.bench_function("NameAccumulator::add", |b| {
+    let setup = &AccumulatorSetup::<BigNumDig>::from_rsa_2048(&mut thread_rng());
+    c.bench_function("NameAccumulator::<BigNumDig>::add", |b| {
         b.iter_batched(
-            || NameSegment::new(&mut thread_rng()),
-            |segment| NameAccumulator::empty(setup).add(Some(&segment), setup),
+            || NameSegment::<BigNumDig>::new(&mut thread_rng()),
+            |segment| NameAccumulator::<BigNumDig>::empty(setup).add(Some(&segment), setup),
+            BatchSize::SmallInput,
+        )
+    });
+    let setup = &AccumulatorSetup::<BigNumRug>::from_rsa_2048(&mut thread_rng());
+    c.bench_function("NameAccumulator::<BigNumRug>::add", |b| {
+        b.iter_batched(
+            || NameSegment::<BigNumRug>::new(&mut thread_rng()),
+            |segment| NameAccumulator::<BigNumRug>::empty(setup).add(Some(&segment), setup),
             BatchSize::SmallInput,
         )
     });
 }
 
 fn name_accumulator_serialize(c: &mut Criterion) {
-    let setup = &AccumulatorSetup::from_rsa_2048(&mut thread_rng());
-    c.bench_function("NameAccumulator serialization", |b| {
+    let setup = &AccumulatorSetup::<BigNumDig>::from_rsa_2048(&mut thread_rng());
+    c.bench_function("NameAccumulator::<BigNumDig> serialization", |b| {
         b.iter_batched(
             || {
-                let segment = NameSegment::new(&mut thread_rng());
-                let mut name = NameAccumulator::empty(setup);
+                let segment = NameSegment::<BigNumDig>::new(&mut thread_rng());
+                let mut name = NameAccumulator::<BigNumDig>::empty(setup);
+                name.add(Some(&segment), setup);
+                name
+            },
+            |name| name.into_bytes(),
+            BatchSize::SmallInput,
+        )
+    });
+    let setup = &AccumulatorSetup::<BigNumRug>::from_rsa_2048(&mut thread_rng());
+    c.bench_function("NameAccumulator::<BigNumRug> serialization", |b| {
+        b.iter_batched(
+            || {
+                let segment = NameSegment::<BigNumRug>::new(&mut thread_rng());
+                let mut name = NameAccumulator::<BigNumRug>::empty(setup);
                 name.add(Some(&segment), setup);
                 name
             },

--- a/wnfs-nameaccumulator/Cargo.toml
+++ b/wnfs-nameaccumulator/Cargo.toml
@@ -20,12 +20,12 @@ authors = ["The Fission Authors"]
 anyhow = "1.0"
 blake3 = { version = "1.4", features = ["traits-preview"] }
 libipld = { version = "0.16", features = ["dag-cbor", "derive", "serde-codec"] }
-num-bigint-dig = { version = "0.8.2", features = ["prime", "zeroize"] }
+num-bigint-dig = { version = "0.8.2", features = ["prime", "zeroize"], optional = true }
 num-integer = "0.1.45"
 num-traits = "0.2.15"
 once_cell = "1.0"
 rand_core = "0.6"
-rug = "1.22.0"
+rug = { version = "1.22", optional = true, default-features = false, features = ["rand", "integer"] }
 serde = { version = "1.0", features = ["rc"] }
 serde_bytes = "0.11.9"
 thiserror = "1.0"
@@ -41,3 +41,8 @@ rand_chacha = "0.3"
 serde_json = "1.0.103"
 test-strategy = "0.3"
 wnfs-common = { path = "../wnfs-common", features = ["test_utils"] }
+
+[features]
+default = ["num-bigint-dig"]
+rug = ["dep:rug"]
+num-bigint-dig = ["dep:num-bigint-dig"]

--- a/wnfs-nameaccumulator/Cargo.toml
+++ b/wnfs-nameaccumulator/Cargo.toml
@@ -25,6 +25,7 @@ num-integer = "0.1.45"
 num-traits = "0.2.15"
 once_cell = "1.0"
 rand_core = "0.6"
+rug = "1.22.0"
 serde = { version = "1.0", features = ["rc"] }
 serde_bytes = "0.11.9"
 thiserror = "1.0"

--- a/wnfs-nameaccumulator/proptest-regressions/name.txt
+++ b/wnfs-nameaccumulator/proptest-regressions/name.txt
@@ -5,3 +5,4 @@
 # It is recommended to check this file in to source control so that
 # everyone who runs the test benefits from these saved cases.
 cc 981ff5c92ddd0a53eb8569b94c7aa0184603de547961d5562c40e1c8643a7275 # shrinks to input = _PaddedBiguintEncodingRoundtripsArgs { num: 1 }
+cc 96d340fe66ed56e3479dd02bbccc0a500237d7720fb1488557806d6a61972205 # shrinks to input = _BatchProofsArgs { do_batch_step: [false, false, true, true], do_verify_step: [false, true, true, false], seed: 0 }

--- a/wnfs-nameaccumulator/src/error.rs
+++ b/wnfs-nameaccumulator/src/error.rs
@@ -16,4 +16,7 @@ pub enum VerificationError {
 
     #[error("NameAccumulator batched proof validation failed")]
     ValidationFailed,
+
+    #[error("Couldn't invert base accumulator state")]
+    NoInverse,
 }

--- a/wnfs-nameaccumulator/src/fns.rs
+++ b/wnfs-nameaccumulator/src/fns.rs
@@ -1,5 +1,5 @@
+use crate::Big;
 use blake3::traits::digest::{ExtendableOutput, ExtendableOutputReset};
-use num_bigint_dig::{prime::probably_prime, BigUint};
 use num_traits::One;
 
 #[cfg(test)]
@@ -11,31 +11,34 @@ const TEST_DSI: &str = "rs-wnfs tests";
 ///
 /// With `(base_i, exponent_i) = bases_and_exponents_i`, it computes the product of
 /// `base_i ^ (product of exponent_j with j != i)`.
-pub(crate) fn multi_exp(bases_and_exponents: &[(BigUint, BigUint)], modulus: &BigUint) -> BigUint {
+pub(crate) fn multi_exp<B: Big>(
+    bases_and_exponents: &[(B::Num, B::Num)],
+    modulus: &B::Num,
+) -> B::Num {
     match bases_and_exponents {
-        &[] => BigUint::one(),
+        &[] => B::Num::one(),
         [(base, _)] => base.clone() % modulus,
         other => {
             let mid = other.len() / 2;
             let (left, right) = other.split_at(mid);
-            let x_star_left = nlogn_product(left, |(_, x_i)| x_i);
-            let x_star_right = nlogn_product(right, |(_, x_i)| x_i);
-            (multi_exp(left, modulus).modpow(&x_star_right, modulus)
-                * multi_exp(right, modulus).modpow(&x_star_left, modulus))
+            let x_star_left = nlogn_product::<_, B>(left, |(_, x_i)| x_i);
+            let x_star_right = nlogn_product::<_, B>(right, |(_, x_i)| x_i);
+            (B::modpow(&multi_exp::<B>(left, modulus), &x_star_right, modulus)
+                * B::modpow(&multi_exp::<B>(right, modulus), &x_star_left, modulus))
                 % modulus
         }
     }
 }
 
 /// Computes the product of all factors in O(n log n) time.
-pub(crate) fn nlogn_product<A>(factors: &[A], f: fn(&A) -> &BigUint) -> BigUint {
+pub(crate) fn nlogn_product<A, B: Big>(factors: &[A], f: fn(&A) -> &B::Num) -> B::Num {
     match factors {
-        [] => BigUint::one(),
+        [] => B::Num::one(),
         [factor] => f(factor).clone(),
         other => {
             let mid = other.len() / 2;
             let (left, right) = factors.split_at(mid);
-            nlogn_product(left, f) * nlogn_product(right, f)
+            nlogn_product::<A, B>(left, f) * nlogn_product::<A, B>(right, f)
         }
     }
 }
@@ -44,11 +47,11 @@ pub(crate) fn nlogn_product<A>(factors: &[A], f: fn(&A) -> &BigUint) -> BigUint 
 ///
 /// The output includes both the prime and a 32-bit counter
 /// that helps verifying the prime digest.
-pub(crate) fn blake3_prime_digest(
+pub(crate) fn blake3_prime_digest<B: Big>(
     domain_separation_info: &str,
     bytes: impl AsRef<[u8]>,
     hash_len: usize,
-) -> (BigUint, u32) {
+) -> (B::Num, u32) {
     let mut counter: u32 = 0;
     let mut hasher = blake3::Hasher::new_derive_key(domain_separation_info);
     let mut hash = vec![0u8; hash_len];
@@ -59,11 +62,11 @@ pub(crate) fn blake3_prime_digest(
         hasher.update(&counter.to_le_bytes());
         hasher.finalize_xof_reset_into(&mut hash);
 
-        let mut candidate = BigUint::from_bytes_le(&hash);
+        let mut candidate = B::from_bytes_le(&hash);
 
-        candidate |= BigUint::one();
+        candidate |= B::Num::one();
 
-        if probably_prime(&candidate, 20) {
+        if B::is_probably_prime(&candidate) {
             return (candidate, counter);
         }
 
@@ -74,22 +77,22 @@ pub(crate) fn blake3_prime_digest(
 /// Finalizes a digest fast, if it has been computed before given the counter from
 /// a previous invocation of `prime_digest`.
 /// This will make sure that the returned digest is prime.
-pub(crate) fn blake3_prime_digest_fast(
+pub(crate) fn blake3_prime_digest_fast<B: Big>(
     domain_separation_info: &str,
     bytes: impl AsRef<[u8]>,
     hash_len: usize,
     counter: u32,
-) -> Option<BigUint> {
+) -> Option<B::Num> {
     let mut hash = vec![0u8; hash_len];
     let mut hasher = blake3::Hasher::new_derive_key(domain_separation_info);
     hasher.update(bytes.as_ref());
     hasher.update(&counter.to_le_bytes());
     hasher.finalize_xof_into(&mut hash);
 
-    let mut to_verify = BigUint::from_bytes_le(&hash);
-    to_verify |= BigUint::one();
+    let mut to_verify = B::from_bytes_le(&hash);
+    to_verify |= B::Num::one();
 
-    if !probably_prime(&to_verify, 20) {
+    if !B::is_probably_prime(&to_verify) {
         None
     } else {
         Some(to_verify)
@@ -99,12 +102,13 @@ pub(crate) fn blake3_prime_digest_fast(
 #[cfg(test)]
 mod tests {
     use super::{blake3_prime_digest, TEST_DSI};
+    use crate::BigNumDig;
 
     /// This test makes sure we don't accidentally (only intentionally)
     /// change hash outputs between versions.
     #[test]
     fn test_fixture_prime_hash() {
-        let (output, counter) = blake3_prime_digest(TEST_DSI, "Hello, World!", 16);
+        let (output, counter) = blake3_prime_digest::<BigNumDig>(TEST_DSI, "Hello, World!", 16);
         assert_eq!(
             (output.to_str_radix(16), counter),
             ("9ef50db608f1e61acedaf2fe6ad982ed".into(), 6)
@@ -114,8 +118,9 @@ mod tests {
 
 #[cfg(test)]
 mod proptests {
-    use crate::fns::{
-        blake3_prime_digest, blake3_prime_digest_fast, multi_exp, nlogn_product, TEST_DSI,
+    use crate::{
+        fns::{blake3_prime_digest, blake3_prime_digest_fast, multi_exp, nlogn_product, TEST_DSI},
+        BigNumDig,
     };
     use num_bigint_dig::{prime::probably_prime, BigUint, RandPrime};
     use num_traits::One;
@@ -128,10 +133,10 @@ mod proptests {
 
     #[proptest(cases = 1000)]
     fn test_prime_digest(#[strategy(vec(any::<u8>(), 0..100))] bytes: Vec<u8>) {
-        let (prime_hash, inc) = blake3_prime_digest(TEST_DSI, &bytes, 16);
+        let (prime_hash, inc) = blake3_prime_digest::<BigNumDig>(TEST_DSI, &bytes, 16);
         prop_assert!(probably_prime(&prime_hash, 20));
         prop_assert_eq!(
-            blake3_prime_digest_fast(TEST_DSI, &bytes, 16, inc),
+            blake3_prime_digest_fast::<BigNumDig>(TEST_DSI, &bytes, 16, inc),
             Some(prime_hash)
         );
     }
@@ -146,13 +151,13 @@ mod proptests {
             .map(|(b, e)| (BigUint::from(*b), BigUint::from(*e)))
             .collect();
 
-        let actual = multi_exp(&bases_and_exponents, &modulus);
+        let actual = multi_exp::<BigNumDig>(&bases_and_exponents, &modulus);
         let expected = multi_exp_naive(&bases_and_exponents, &modulus);
         prop_assert_eq!(actual, expected);
     }
 
     fn multi_exp_naive(bases_and_exponents: &[(BigUint, BigUint)], modulus: &BigUint) -> BigUint {
-        let x_star = nlogn_product(bases_and_exponents, |(_, x_i)| x_i);
+        let x_star = nlogn_product::<_, BigNumDig>(bases_and_exponents, |(_, x_i)| x_i);
 
         let mut product = BigUint::one();
         for (alpha_i, x_i) in bases_and_exponents {

--- a/wnfs-nameaccumulator/src/fns.rs
+++ b/wnfs-nameaccumulator/src/fns.rs
@@ -1,6 +1,5 @@
 use crate::Big;
 use blake3::traits::digest::{ExtendableOutput, ExtendableOutputReset};
-use num_traits::One;
 
 #[cfg(test)]
 const TEST_DSI: &str = "rs-wnfs tests";
@@ -16,7 +15,7 @@ pub(crate) fn multi_exp<B: Big>(
     modulus: &B::Num,
 ) -> B::Num {
     match bases_and_exponents {
-        &[] => B::Num::one(),
+        &[] => B::one(),
         [(base, _)] => base.clone() % modulus,
         other => {
             let mid = other.len() / 2;
@@ -33,7 +32,7 @@ pub(crate) fn multi_exp<B: Big>(
 /// Computes the product of all factors in O(n log n) time.
 pub(crate) fn nlogn_product<A, B: Big>(factors: &[A], f: fn(&A) -> &B::Num) -> B::Num {
     match factors {
-        [] => B::Num::one(),
+        [] => B::one(),
         [factor] => f(factor).clone(),
         other => {
             let mid = other.len() / 2;
@@ -64,7 +63,7 @@ pub(crate) fn blake3_prime_digest<B: Big>(
 
         let mut candidate = B::from_bytes_le(&hash);
 
-        candidate |= B::Num::one();
+        candidate |= B::one();
 
         if B::is_probably_prime(&candidate) {
             return (candidate, counter);
@@ -90,7 +89,7 @@ pub(crate) fn blake3_prime_digest_fast<B: Big>(
     hasher.finalize_xof_into(&mut hash);
 
     let mut to_verify = B::from_bytes_le(&hash);
-    to_verify |= B::Num::one();
+    to_verify |= B::one();
 
     if !B::is_probably_prime(&to_verify) {
         None

--- a/wnfs-nameaccumulator/src/lib.rs
+++ b/wnfs-nameaccumulator/src/lib.rs
@@ -5,6 +5,8 @@
 mod error;
 mod fns;
 mod name;
+mod traits;
 mod uint256_serde_be;
 
 pub use name::*;
+pub use traits::*;

--- a/wnfs-nameaccumulator/src/name.rs
+++ b/wnfs-nameaccumulator/src/name.rs
@@ -1,17 +1,14 @@
 use crate::{
     error::VerificationError,
-    fns::{blake3_prime_digest, blake3_prime_digest_fast, multi_exp, nlogn_product},
-    uint256_serde_be::to_bytes_helper,
+    fns::{blake3_prime_digest, blake3_prime_digest_fast, multi_exp},
+    traits::Big,
 };
 use anyhow::Result;
-use num_bigint_dig::{BigUint, ModInverse, RandBigInt, RandPrime};
-use num_integer::Integer;
 use num_traits::One;
 use once_cell::sync::OnceCell;
 use rand_core::CryptoRngCore;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use std::{hash::Hash, str::FromStr};
-use zeroize::Zeroize;
 
 /// The domain separation string for deriving the l hash in the PoKE* protocol.
 const L_HASH_DSI: &str = "wnfs/1.0/PoKE*/l 128-bit hash derivation";
@@ -27,25 +24,29 @@ const L_HASH_DSI: &str = "wnfs/1.0/PoKE*/l 128-bit hash derivation";
 /// to prove a relationship between two names, e.g a file being contained in
 /// a sub-directory of a directory while leaking as little information as possible.
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
-pub struct Name {
-    relative_to: NameAccumulator,
-    segments: Vec<NameSegment>,
+pub struct Name<B: Big> {
+    relative_to: NameAccumulator<B>,
+    segments: Vec<NameSegment<B>>,
 }
 
 /// Represents a setup needed for RSA accumulator operation.
 #[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Deserialize, Serialize)]
-pub struct AccumulatorSetup {
-    #[serde(with = "crate::uint256_serde_be")]
-    modulus: BigUint,
-    #[serde(with = "crate::uint256_serde_be")]
-    pub generator: BigUint,
+pub struct AccumulatorSetup<B: Big> {
+    #[serde(bound = "B: Big")]
+    #[serde(deserialize_with = "crate::uint256_serde_be::deserialize::<B, _>")]
+    #[serde(serialize_with = "crate::uint256_serde_be::serialize::<B, _>")]
+    modulus: B::Num,
+    #[serde(bound = "B: Big")]
+    #[serde(deserialize_with = "crate::uint256_serde_be::deserialize::<B, _>")]
+    #[serde(serialize_with = "crate::uint256_serde_be::serialize::<B, _>")]
+    pub generator: B::Num,
 }
 
 /// A WNFS name represented as the RSA accumulator of all of its name segments.
 #[derive(Clone, Eq)]
-pub struct NameAccumulator {
+pub struct NameAccumulator<B: Big> {
     /// A 2048-bit number
-    state: BigUint,
+    state: B::Num,
     /// A cache for its serialized form
     serialized_cache: OnceCell<[u8; 256]>,
 }
@@ -53,65 +54,67 @@ pub struct NameAccumulator {
 /// A name accumluator segment. A name accumulator commits to a set of these.
 /// They are represented as 256-bit prime numbers.
 #[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct NameSegment(
+pub struct NameSegment<B: Big>(
     /// Invariant: Must be a 256-bit prime
-    BigUint,
+    B::Num,
 );
 
 /// PoKE* (Proof of Knowledge of Exponent),
 /// assuming that the base is trusted
 /// (e.g. part of a common reference string).
 #[derive(Clone, PartialEq, Eq)]
-pub struct ElementsProof {
+pub struct ElementsProof<B: Big> {
     /// The accumulator's base, $u$
-    pub base: BigUint,
+    pub base: B::Num,
     /// A part of the proof, $Q = u^q$, where $element = q*l + r$
-    pub big_q: BigUint,
+    pub big_q: B::Num,
     /// Part of the proof that can't be batched
-    pub part: UnbatchableProofPart,
+    pub part: UnbatchableProofPart<B>,
 }
 
 /// The part of PoKE* (Proof of Knowledge of Exponent) proofs that can't be batched.
 /// This is very small (serialized typically <20 bytes, most likely just 17 bytes).
 #[derive(Clone, PartialEq, Eq)]
-pub struct UnbatchableProofPart {
+pub struct UnbatchableProofPart<B: Big> {
     /// The number to increase a hash by to land on the next prime.
     /// Helps to more quickly generate/verify the prime number $l$.
     pub l_hash_inc: u32,
     /// A part of the proof, the residue of the element that's proven, i.e. $r$ in $element = q*l + r$
-    pub r: BigUint,
+    pub r: B::Num,
 }
 
 /// The part of a name accumulator proof that can be batched,
 /// i.e. the size of this part of the proof is independent of
 /// the number of elements being proven. It's always 2048-bit.
 #[derive(Clone, Eq, PartialEq, Serialize, Deserialize)]
-pub struct BatchedProofPart {
-    #[serde(with = "crate::uint256_serde_be")]
-    big_q_product: BigUint,
+pub struct BatchedProofPart<B: Big> {
+    #[serde(bound = "B: Big")]
+    #[serde(deserialize_with = "crate::uint256_serde_be::deserialize::<B, _>")]
+    #[serde(serialize_with = "crate::uint256_serde_be::serialize::<B, _>")]
+    big_q_product: B::Num,
 }
 
 /// Data that is kept around for verifying batch proofs.
-pub struct BatchedProofVerification<'a> {
-    bases_and_exponents: Vec<(BigUint, BigUint)>,
-    setup: &'a AccumulatorSetup,
+pub struct BatchedProofVerification<'a, B: Big> {
+    bases_and_exponents: Vec<(B::Num, B::Num)>,
+    setup: &'a AccumulatorSetup<B>,
 }
 
 //--------------------------------------------------------------------------------------------------
 // Implementations
 //--------------------------------------------------------------------------------------------------
 
-impl Name {
+impl<B: Big> Name<B> {
     /// Create the empty name
-    pub fn empty(setup: &AccumulatorSetup) -> Self {
+    pub fn empty(setup: &AccumulatorSetup<B>) -> Self {
         Self::new(NameAccumulator::empty(setup), None)
     }
 
     /// Create a name relative to some other committed name
     /// and with given segments added to that name.
     pub fn new(
-        relative_to: NameAccumulator,
-        segments: impl IntoIterator<Item = NameSegment>,
+        relative_to: NameAccumulator<B>,
+        segments: impl IntoIterator<Item = NameSegment<B>>,
     ) -> Self {
         Self {
             relative_to,
@@ -131,7 +134,7 @@ impl Name {
     }
 
     /// Return the parent name, if possible.
-    pub fn parent(&self) -> Option<Name> {
+    pub fn parent(&self) -> Option<Name<B>> {
         if self.is_root() {
             None
         } else {
@@ -141,15 +144,15 @@ impl Name {
         }
     }
 
-    pub fn get_segments(&self) -> &Vec<NameSegment> {
+    pub fn get_segments(&self) -> &Vec<NameSegment<B>> {
         &self.segments
     }
 
-    pub fn add_segments(&mut self, segments: impl IntoIterator<Item = NameSegment>) {
+    pub fn add_segments(&mut self, segments: impl IntoIterator<Item = NameSegment<B>>) {
         self.segments.extend(segments);
     }
 
-    pub fn with_segments_added(&self, segments: impl IntoIterator<Item = NameSegment>) -> Self {
+    pub fn with_segments_added(&self, segments: impl IntoIterator<Item = NameSegment<B>>) -> Self {
         let mut clone = self.clone();
         clone.add_segments(segments);
         clone
@@ -162,22 +165,22 @@ impl Name {
     /// This proof process is memoized. Running it twice won't duplicate work.
     pub fn into_proven_accumulator(
         &self,
-        setup: &AccumulatorSetup,
-    ) -> (NameAccumulator, ElementsProof) {
+        setup: &AccumulatorSetup<B>,
+    ) -> (NameAccumulator<B>, ElementsProof<B>) {
         let mut name = self.relative_to.clone();
         let proof = name.add(self.segments.iter(), setup);
         (name, proof)
     }
 
     /// Return what name accumulator this name commits to.
-    pub fn into_accumulator(&self, setup: &AccumulatorSetup) -> NameAccumulator {
+    pub fn into_accumulator(&self, setup: &AccumulatorSetup<B>) -> NameAccumulator<B> {
         self.into_proven_accumulator(setup).0
     }
 }
 
-impl NameAccumulator {
+impl<B: Big> NameAccumulator<B> {
     /// Create the empty accumulator.
-    pub fn empty(setup: &AccumulatorSetup) -> Self {
+    pub fn empty(setup: &AccumulatorSetup<B>) -> Self {
         Self {
             state: setup.generator.clone(),
             serialized_cache: OnceCell::new(),
@@ -186,9 +189,12 @@ impl NameAccumulator {
 
     /// Create an accumulator with given segments inside.
     pub fn with_segments<'a>(
-        segments: impl IntoIterator<Item = &'a NameSegment>,
-        setup: &AccumulatorSetup,
-    ) -> Self {
+        segments: impl IntoIterator<Item = &'a NameSegment<B>> + Clone,
+        setup: &AccumulatorSetup<B>,
+    ) -> Self
+    where
+        B: 'a,
+    {
         let mut acc = Self::empty(setup);
         acc.add(segments, setup); // ignore proof
         acc
@@ -198,7 +204,7 @@ impl NameAccumulator {
     ///
     /// This needs to be a 2048-bit number in the RSA group from
     /// the accumulator setup used.
-    pub fn from_state(state: BigUint) -> Self {
+    pub fn from_state(state: B::Num) -> Self {
         Self {
             state,
             serialized_cache: OnceCell::new(),
@@ -209,26 +215,31 @@ impl NameAccumulator {
     /// elements proof that verifies the change of state of the accumulator.
     pub fn add<'a>(
         &mut self,
-        segments: impl IntoIterator<Item = &'a NameSegment>,
-        setup: &AccumulatorSetup,
-    ) -> ElementsProof {
+        segments: impl IntoIterator<Item = &'a NameSegment<B>> + Clone,
+        setup: &AccumulatorSetup<B>,
+    ) -> ElementsProof<B>
+    where
+        B: 'a,
+    {
         // Reset the serialized state
         self.serialized_cache = OnceCell::new();
-
-        let mut product = BigUint::one();
-        for segment in segments {
-            product *= &segment.0;
-        }
-
         let witness = self.state.clone();
-        self.state = self.state.modpow(&product, &setup.modulus);
 
-        let data = poke_fiat_shamir_l_hash_data(&setup.modulus, &witness, &self.state);
-        let (l, l_hash_inc) = blake3_prime_digest(L_HASH_DSI, data, 16);
+        let segment_nums = segments
+            .into_iter()
+            .map(|s| s.0.clone())
+            .collect::<Vec<_>>();
 
-        let (q, r) = product.div_mod_floor(&l);
+        let exponents = segment_nums.clone().into_iter();
+        self.state = B::modpow_product(&self.state, exponents, &setup.modulus);
 
-        let big_q = witness.modpow(&q, &setup.modulus);
+        let data = poke_fiat_shamir_l_hash_data::<B>(&setup.modulus, &witness, &self.state);
+        let (l, l_hash_inc) = blake3_prime_digest::<B>(L_HASH_DSI, data, 16);
+
+        let factors = segment_nums.into_iter();
+        let (q, r) = B::quotrem_product(factors, &l);
+
+        let big_q = B::modpow(&witness, &q, &setup.modulus);
 
         ElementsProof {
             base: witness,
@@ -248,7 +259,7 @@ impl NameAccumulator {
 
     /// Deserialize a name accumulator from bytes.
     pub fn parse_slice(slice: [u8; 256]) -> Self {
-        let state = BigUint::from_bytes_be(&slice);
+        let state = B::from_bytes_be(&slice);
         Self {
             state,
             serialized_cache: OnceCell::from(slice),
@@ -261,7 +272,7 @@ impl NameAccumulator {
         let state = self.state;
         cache
             .into_inner()
-            .unwrap_or_else(|| to_bytes_helper(&state))
+            .unwrap_or_else(|| B::to_256_bytes_be(&state))
     }
 
     /// Serialize a name accumulator to bytes and return a reference.
@@ -269,33 +280,31 @@ impl NameAccumulator {
     /// This call is memoized, serializing twice won't duplicate work.
     pub fn as_bytes(&self) -> &[u8; 256] {
         self.serialized_cache
-            .get_or_init(|| to_bytes_helper(&self.state))
+            .get_or_init(|| B::to_256_bytes_be(&self.state))
     }
 }
 
-fn poke_fiat_shamir_l_hash_data(
-    modulus: &BigUint,
-    base: &BigUint,
-    commitment: &BigUint,
+fn poke_fiat_shamir_l_hash_data<B: Big>(
+    modulus: &B::Num,
+    base: &B::Num,
+    commitment: &B::Num,
 ) -> impl AsRef<[u8]> {
     [
-        to_bytes_helper::<256>(modulus),
-        to_bytes_helper::<256>(base),
-        to_bytes_helper::<256>(commitment),
+        B::to_256_bytes_be(modulus),
+        B::to_256_bytes_be(base),
+        B::to_256_bytes_be(commitment),
     ]
     .concat()
 }
 
-impl AccumulatorSetup {
+impl<B: Big> AccumulatorSetup<B> {
     /// Finishes a setup given a 2048-bit RSA modulus encoded in big-endian.
     ///
     /// Remaining work is safe and doesn't require a trusted environment.
     pub fn with_modulus(modulus_big_endian: &[u8; 256], rng: &mut impl CryptoRngCore) -> Self {
-        let modulus = BigUint::from_bytes_be(modulus_big_endian);
+        let modulus = B::from_bytes_be(modulus_big_endian);
         // The generator is just some random quadratic residue.
-        let generator = rng
-            .gen_biguint_below(&modulus)
-            .modpow(&BigUint::from(2u8), &modulus);
+        let generator = B::squaremod(&B::rand_below(&modulus, rng), &modulus);
         Self { modulus, generator }
     }
 
@@ -307,19 +316,9 @@ impl AccumulatorSetup {
     /// priviliged process to observe the memory and copy out the toxic waste
     /// before it's deleted.
     pub fn trusted(rng: &mut impl CryptoRngCore) -> Self {
-        // This is a trusted setup.
-        // The prime factors are "toxic waste", they need to be
-        // disposed immediately.
-        let mut p = rng.gen_prime(1024);
-        let mut q = rng.gen_prime(1024);
-        let modulus = &p * &q;
-        // Make sure to delete toxic waste
-        p.zeroize();
-        q.zeroize();
+        let modulus = B::rand_rsa_modulus(rng);
         // The generator is just some random quadratic residue.
-        let generator = rng
-            .gen_biguint_below(&modulus)
-            .modpow(&BigUint::from(2u8), &modulus);
+        let generator = B::squaremod(&B::rand_below(&modulus, rng), &modulus);
         Self { modulus, generator }
     }
 
@@ -330,47 +329,45 @@ impl AccumulatorSetup {
     ///
     /// [rsa factoring challenge]: https://en.wikipedia.org/wiki/RSA_numbers#RSA-2048
     pub fn from_rsa_2048(rng: &mut impl CryptoRngCore) -> Self {
-        let modulus = BigUint::from_str(
+        let modulus = B::Num::from_str(
             "25195908475657893494027183240048398571429282126204032027777137836043662020707595556264018525880784406918290641249515082189298559149176184502808489120072844992687392807287776735971418347270261896375014971824691165077613379859095700097330459748808428401797429100642458691817195118746121515172654632282216869987549182422433637259085141865462043576798423387184774447920739934236584823824281198163815010674810451660377306056201619676256133844143603833904414952634432190114657544454178424020924616515723350778707749817125772467962926386356373289912154831438167899885040445364023527381951378636564391212010397122822120720357",
-        ).unwrap();
-        let generator = rng
-            .gen_biguint_below(&modulus)
-            .modpow(&BigUint::from(2u8), &modulus);
+        ).ok().unwrap();
+        let generator = B::squaremod(&B::rand_below(&modulus, rng), &modulus);
         Self { modulus, generator }
     }
 }
 
-impl NameSegment {
+impl<B: Big> NameSegment<B> {
     /// Create a new, random name segment
     pub fn new(rng: &mut impl CryptoRngCore) -> Self {
-        Self(rng.gen_prime(256))
+        Self(B::rand_prime_256bit(rng))
     }
 
     /// Derive a name segment as the hash from some data
     pub fn new_hashed(domain_separation_info: &str, data: impl AsRef<[u8]>) -> Self {
-        Self(blake3_prime_digest(domain_separation_info, data, 32).0)
+        Self(blake3_prime_digest::<B>(domain_separation_info, data, 32).0)
     }
 }
 
-impl BatchedProofPart {
+impl<B: Big> BatchedProofPart<B> {
     /// Create a new proof batcher.
     pub fn new() -> Self {
         Self {
-            big_q_product: BigUint::one(),
+            big_q_product: B::Num::one(),
         }
     }
 
     /// Add the batchable portion of a proof of elements
     /// for a certain name accumulator to this batch proof.
-    pub fn add(&mut self, proof: &ElementsProof, setup: &AccumulatorSetup) {
+    pub fn add(&mut self, proof: &ElementsProof<B>, setup: &AccumulatorSetup<B>) {
         self.big_q_product *= &proof.big_q;
         self.big_q_product %= &setup.modulus;
     }
 }
 
-impl<'a> BatchedProofVerification<'a> {
+impl<'a, B: Big> BatchedProofVerification<'a, B> {
     /// Create a new verifier
-    pub fn new(setup: &'a AccumulatorSetup) -> Self {
+    pub fn new(setup: &'a AccumulatorSetup<B>) -> Self {
         Self {
             bases_and_exponents: Vec::new(),
             setup,
@@ -387,26 +384,26 @@ impl<'a> BatchedProofVerification<'a> {
     /// don't fit this proof part.
     pub fn add(
         &mut self,
-        base: &NameAccumulator,
-        commitment: &NameAccumulator,
-        proof_part: &UnbatchableProofPart,
+        base: &NameAccumulator<B>,
+        commitment: &NameAccumulator<B>,
+        proof_part: &UnbatchableProofPart<B>,
     ) -> Result<()> {
         let hasher =
-            poke_fiat_shamir_l_hash_data(&self.setup.modulus, &base.state, &commitment.state);
-        let l = blake3_prime_digest_fast(L_HASH_DSI, hasher, 16, proof_part.l_hash_inc)
+            poke_fiat_shamir_l_hash_data::<B>(&self.setup.modulus, &base.state, &commitment.state);
+        let l = blake3_prime_digest_fast::<B>(L_HASH_DSI, hasher, 16, proof_part.l_hash_inc)
             .ok_or(VerificationError::LHashNonPrime)?;
 
         if proof_part.r >= l {
             Err(VerificationError::ResidueOutsideRange)?;
         }
 
-        let proof_kcr_base = (&commitment.state
-            * (&base.state)
-                .mod_inverse(&self.setup.modulus)
-                .unwrap()
-                .to_biguint()
-                .unwrap()
-                .modpow(&proof_part.r, &self.setup.modulus))
+        let proof_kcr_base = (commitment.state.clone()
+            * B::modpow(
+                &B::mod_inv(&base.state, &self.setup.modulus)
+                    .ok_or_else(|| VerificationError::NoInverse)?,
+                &proof_part.r,
+                &self.setup.modulus,
+            ))
             % &self.setup.modulus;
 
         self.bases_and_exponents.push((proof_kcr_base, l));
@@ -418,14 +415,11 @@ impl<'a> BatchedProofVerification<'a> {
     /// the batched proof.
     ///
     /// Will return an error if verification fails.
-    pub fn verify(&self, batched_proof: &BatchedProofPart) -> Result<()> {
-        let l_star = nlogn_product(&self.bases_and_exponents, |(_, l)| l);
+    pub fn verify(&self, batched_proof: &BatchedProofPart<B>) -> Result<()> {
+        let exponents = self.bases_and_exponents.iter().map(|(_, l)| l).cloned();
+        let tmp = B::modpow_product(&batched_proof.big_q_product, exponents, &self.setup.modulus);
 
-        if batched_proof
-            .big_q_product
-            .modpow(&l_star, &self.setup.modulus)
-            != multi_exp(&self.bases_and_exponents, &self.setup.modulus)
-        {
+        if tmp != multi_exp::<B>(&self.bases_and_exponents, &self.setup.modulus) {
             return Err(VerificationError::ValidationFailed.into());
         }
 
@@ -433,26 +427,26 @@ impl<'a> BatchedProofVerification<'a> {
     }
 }
 
-impl Serialize for NameSegment {
+impl<B: Big> Serialize for NameSegment<B> {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
-        serde_bytes::serialize(to_bytes_helper::<32>(&self.0).as_ref(), serializer)
+        serde_bytes::serialize(B::to_bytes_le::<32>(&self.0).as_ref(), serializer)
     }
 }
 
-impl<'de> Deserialize<'de> for NameSegment {
+impl<'de, B: Big> Deserialize<'de> for NameSegment<B> {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
         let bytes: Vec<u8> = serde_bytes::deserialize(deserializer)?;
-        Ok(NameSegment(BigUint::from_bytes_be(&bytes)))
+        Ok(NameSegment(B::from_bytes_be(&bytes)))
     }
 }
 
-impl<'de> Deserialize<'de> for NameAccumulator {
+impl<'de, B: Big> Deserialize<'de> for NameAccumulator<B> {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
@@ -462,7 +456,7 @@ impl<'de> Deserialize<'de> for NameAccumulator {
     }
 }
 
-impl Serialize for NameAccumulator {
+impl<B: Big> Serialize for NameAccumulator<B> {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
@@ -471,47 +465,47 @@ impl Serialize for NameAccumulator {
     }
 }
 
-impl<'de> Deserialize<'de> for UnbatchableProofPart {
+impl<'de, B: Big> Deserialize<'de> for UnbatchableProofPart<B> {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: Deserializer<'de>,
     {
         let (l_hash_inc, r): (u32, &serde_bytes::Bytes) = Deserialize::deserialize(deserializer)?;
-        let r = BigUint::from_bytes_be(r);
+        let r = B::from_bytes_be(r);
         Ok(Self { l_hash_inc, r })
     }
 }
 
-impl Serialize for UnbatchableProofPart {
+impl<B: Big> Serialize for UnbatchableProofPart<B> {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,
     {
-        let residue = to_bytes_helper::<16>(&self.r);
+        let residue = B::to_bytes_le::<16>(&self.r);
         let r = serde_bytes::Bytes::new(&residue);
         (self.l_hash_inc, r).serialize(serializer)
     }
 }
 
-impl PartialEq for NameAccumulator {
+impl<B: Big> PartialEq for NameAccumulator<B> {
     fn eq(&self, other: &Self) -> bool {
         self.state == other.state
     }
 }
 
-impl Ord for NameAccumulator {
+impl<B: Big> Ord for NameAccumulator<B> {
     fn cmp(&self, other: &Self) -> std::cmp::Ordering {
         self.state.cmp(&other.state)
     }
 }
 
-impl PartialOrd for NameAccumulator {
+impl<B: Big> PartialOrd for NameAccumulator<B> {
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
         Some(self.cmp(other))
     }
 }
 
-impl std::fmt::Debug for NameAccumulator {
+impl<B: Big> std::fmt::Debug for NameAccumulator<B> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("NameAccumulator")
             .field("state", &self.state.to_string())
@@ -519,25 +513,25 @@ impl std::fmt::Debug for NameAccumulator {
     }
 }
 
-impl Hash for NameAccumulator {
+impl<B: Big> Hash for NameAccumulator<B> {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
         self.state.hash(state);
     }
 }
 
-impl AsRef<[u8]> for NameAccumulator {
+impl<B: Big> AsRef<[u8]> for NameAccumulator<B> {
     fn as_ref(&self) -> &[u8] {
         self.as_bytes()
     }
 }
 
-impl Default for BatchedProofPart {
+impl<B: Big> Default for BatchedProofPart<B> {
     fn default() -> Self {
         Self::new()
     }
 }
 
-impl std::fmt::Debug for NameSegment {
+impl<B: Big> std::fmt::Debug for NameSegment<B> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_tuple("NameSegment")
             .field(&self.0.to_string())
@@ -545,7 +539,7 @@ impl std::fmt::Debug for NameSegment {
     }
 }
 
-impl std::fmt::Debug for AccumulatorSetup {
+impl<B: Big> std::fmt::Debug for AccumulatorSetup<B> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("AccumulatorSetup")
             .field("modulus", &self.modulus.to_string())
@@ -554,7 +548,7 @@ impl std::fmt::Debug for AccumulatorSetup {
     }
 }
 
-impl std::fmt::Debug for UnbatchableProofPart {
+impl<B: Big> std::fmt::Debug for UnbatchableProofPart<B> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("UnbatchableProofPart")
             .field("l_hash_inc", &self.l_hash_inc)
@@ -563,7 +557,7 @@ impl std::fmt::Debug for UnbatchableProofPart {
     }
 }
 
-impl std::fmt::Debug for ElementsProof {
+impl<B: Big> std::fmt::Debug for ElementsProof<B> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("ElementsProof")
             .field("base", &self.base.to_string())
@@ -573,7 +567,7 @@ impl std::fmt::Debug for ElementsProof {
     }
 }
 
-impl std::fmt::Debug for BatchedProofPart {
+impl<B: Big> std::fmt::Debug for BatchedProofPart<B> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("BatchedProofPart")
             .field("big_q_product", &self.big_q_product.to_string())
@@ -589,7 +583,7 @@ impl std::fmt::Debug for BatchedProofPart {
 mod tests {
     use crate::{
         uint256_serde_be::to_bytes_helper, AccumulatorSetup, BatchedProofPart,
-        BatchedProofVerification, Name, NameAccumulator, NameSegment,
+        BatchedProofVerification, BigNumDig, Name, NameAccumulator, NameSegment,
     };
     use anyhow::Result;
     use libipld::{
@@ -611,7 +605,7 @@ mod tests {
         let segment = NameSegment::new(rng);
 
         let bytes = encode(&segment, DagCborCodec).unwrap();
-        let segment_back: NameSegment = decode(&bytes, DagCborCodec).unwrap();
+        let segment_back: NameSegment<BigNumDig> = decode(&bytes, DagCborCodec).unwrap();
 
         assert_eq!(segment_back, segment);
     }
@@ -620,7 +614,7 @@ mod tests {
     fn name_accumulator_serialize_roundtrip() {
         let rng = &mut thread_rng();
         let setup = &AccumulatorSetup::from_rsa_2048(rng);
-        let mut acc = NameAccumulator::empty(setup);
+        let mut acc = NameAccumulator::<BigNumDig>::empty(setup);
 
         acc.add(
             &[
@@ -636,7 +630,7 @@ mod tests {
         ipld.encode(DagCborCodec, &mut bytes).unwrap();
 
         let ipld = Ipld::decode(DagCborCodec, &mut Cursor::new(bytes)).unwrap();
-        let acc_back = libipld::serde::from_ipld::<NameAccumulator>(ipld).unwrap();
+        let acc_back = libipld::serde::from_ipld::<NameAccumulator<BigNumDig>>(ipld).unwrap();
 
         assert_eq!(acc_back, acc);
     }
@@ -644,7 +638,7 @@ mod tests {
     #[test]
     fn name_batched_proof_example() -> Result<()> {
         let rng = &mut thread_rng();
-        let setup = &AccumulatorSetup::from_rsa_2048(rng);
+        let setup = &AccumulatorSetup::<BigNumDig>::from_rsa_2048(rng);
         let mut name_note = Name::empty(setup);
         let mut name_image = Name::empty(setup);
 
@@ -680,7 +674,7 @@ mod tests {
     #[test]
     fn equals_ignores_serialization_cache() -> Result<()> {
         let rng = &mut thread_rng();
-        let setup = &AccumulatorSetup::from_rsa_2048(rng);
+        let setup = &AccumulatorSetup::<BigNumDig>::from_rsa_2048(rng);
 
         let mut name_one = NameAccumulator::empty(setup);
         let mut name_two = NameAccumulator::empty(setup);
@@ -707,7 +701,7 @@ mod tests {
     #[proptest(cases = 32)]
     fn batch_proofs(do_batch_step: [bool; 4], do_verify_step: [bool; 4], seed: u64) {
         let rng = &mut ChaCha12Rng::seed_from_u64(seed);
-        let setup = &AccumulatorSetup::from_rsa_2048(rng);
+        let setup = &AccumulatorSetup::<BigNumDig>::from_rsa_2048(rng);
         let base_a = NameAccumulator::with_segments(&[NameSegment::new(rng)], setup);
         let base_b = NameAccumulator::with_segments(&[NameSegment::new(rng)], setup);
 
@@ -781,7 +775,7 @@ mod tests {
 #[cfg(test)]
 mod snapshot_tests {
     use super::*;
-    use crate::NameSegment;
+    use crate::{BigNumDig, NameSegment};
     use rand_chacha::ChaCha12Rng;
     use rand_core::SeedableRng;
     use wnfs_common::{utils::SnapshotBlockStore, BlockStore};
@@ -790,7 +784,7 @@ mod snapshot_tests {
     async fn test_name_accumulator() {
         let rng = &mut ChaCha12Rng::seed_from_u64(0);
         let store = &SnapshotBlockStore::default();
-        let setup = &AccumulatorSetup::from_rsa_2048(rng);
+        let setup = &AccumulatorSetup::<BigNumDig>::from_rsa_2048(rng);
         let mut acc = NameAccumulator::empty(setup);
 
         acc.add(

--- a/wnfs-nameaccumulator/src/traits.rs
+++ b/wnfs-nameaccumulator/src/traits.rs
@@ -1,20 +1,25 @@
+#[cfg(feature = "num-bigint-dig")]
+use num_bigint_dig::{prime::probably_prime, BigUint, ModInverse, RandBigInt, RandPrime};
+#[cfg(feature = "num-bigint-dig")]
+use num_traits::{One, Zero};
+use rand_core::CryptoRngCore;
+#[cfg(feature = "rug")]
+use rug::{
+    integer::{IsPrime, Order},
+    rand::RandState,
+    Integer,
+};
 use std::{
     fmt::{Debug, Display},
     hash::Hash,
     ops::{BitOr, BitOrAssign, Mul, MulAssign, Rem, RemAssign},
     str::FromStr,
 };
-
-use num_bigint_dig::{prime::probably_prime, BigUint, ModInverse, RandBigInt, RandPrime};
-use num_integer::Integer;
-use num_traits::One;
-use rand_core::CryptoRngCore;
+#[cfg(feature = "num-bigint-dig")]
 use zeroize::Zeroize;
 
-use crate::uint256_serde_be::to_bytes_helper;
-
 /// Necessary implementations for the nameaccumulator backend that implements big integer math
-pub trait Big: Eq + Clone {
+pub trait Big: Eq + Clone + Hash {
     /// The big unsigned integer for this backend
     type Num: Clone
         + Debug
@@ -23,21 +28,26 @@ pub trait Big: Eq + Clone {
         + Eq
         + Hash
         + Ord
-        + Mul
+        + Mul<Output = Self::Num>
         + for<'a> MulAssign<&'a Self::Num>
         + for<'a> RemAssign<&'a Self::Num>
         + for<'a> Rem<&'a Self::Num, Output = Self::Num>
-        + One
         + BitOr
         + BitOrAssign
         + From<u8>
         + FromStr;
 
+    fn one() -> Self::Num;
+
+    fn is_zero(n: &Self::Num) -> bool;
+
     fn modpow_product<'a>(
         base: &Self::Num,
-        exponents: impl Iterator<Item = Self::Num>,
+        exponents: impl Iterator<Item = &'a Self::Num>,
         modulus: &Self::Num,
-    ) -> Self::Num;
+    ) -> Self::Num
+    where
+        Self::Num: 'a;
 
     fn modpow(base: &Self::Num, exponent: &Self::Num, modulus: &Self::Num) -> Self::Num;
 
@@ -45,10 +55,12 @@ pub trait Big: Eq + Clone {
 
     fn squaremod(base: &Self::Num, modulus: &Self::Num) -> Self::Num;
 
-    fn quotrem_product(
-        factors: impl Iterator<Item = Self::Num>,
+    fn quotrem_product<'a>(
+        factors: impl Iterator<Item = &'a Self::Num>,
         divisor: &Self::Num,
-    ) -> (Self::Num, Self::Num);
+    ) -> (Self::Num, Self::Num)
+    where
+        Self::Num: 'a;
 
     fn from_bytes_le(bytes: &[u8]) -> Self::Num;
 
@@ -67,18 +79,28 @@ pub trait Big: Eq + Clone {
     fn rand_prime_256bit(rng: &mut impl CryptoRngCore) -> Self::Num;
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg(feature = "num-bigint-dig")]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct BigNumDig;
 
+#[cfg(feature = "num-bigint-dig")]
 impl Big for BigNumDig {
     type Num = BigUint;
 
+    fn one() -> Self::Num {
+        BigUint::one()
+    }
+
+    fn is_zero(n: &Self::Num) -> bool {
+        n.is_zero()
+    }
+
     fn modpow_product<'a>(
         base: &Self::Num,
-        exponents: impl Iterator<Item = Self::Num>,
+        exponents: impl Iterator<Item = &'a Self::Num>,
         modulus: &Self::Num,
     ) -> Self::Num {
-        let mut product = BigUint::one();
+        let mut product = Self::one();
         for exponent in exponents {
             product *= exponent;
         }
@@ -98,8 +120,8 @@ impl Big for BigNumDig {
         base.modpow(&BigUint::from(2u8), modulus)
     }
 
-    fn quotrem_product(
-        factors: impl Iterator<Item = Self::Num>,
+    fn quotrem_product<'a>(
+        factors: impl Iterator<Item = &'a Self::Num>,
         divisor: &Self::Num,
     ) -> (Self::Num, Self::Num) {
         let mut product = BigUint::one();
@@ -107,6 +129,7 @@ impl Big for BigNumDig {
             product *= factor;
         }
 
+        use num_integer::Integer;
         product.div_mod_floor(divisor)
     }
 
@@ -115,7 +138,11 @@ impl Big for BigNumDig {
     }
 
     fn to_bytes_le<const N: usize>(n: &Self::Num) -> [u8; N] {
-        to_bytes_helper::<N>(n)
+        let vec = n.to_bytes_le();
+        let mut bytes = [0u8; N];
+        let zero_bytes = N - vec.len();
+        bytes[zero_bytes..].copy_from_slice(&vec);
+        bytes
     }
 
     fn from_bytes_be(bytes: &[u8]) -> Self::Num {
@@ -123,7 +150,7 @@ impl Big for BigNumDig {
     }
 
     fn to_256_bytes_be(n: &Self::Num) -> [u8; 256] {
-        to_bytes_helper(n)
+        Self::to_bytes_helper(n)
     }
 
     fn is_probably_prime(candidate: &Self::Num) -> bool {
@@ -149,5 +176,135 @@ impl Big for BigNumDig {
 
     fn rand_prime_256bit(rng: &mut impl CryptoRngCore) -> Self::Num {
         rng.gen_prime(256)
+    }
+}
+
+#[cfg(feature = "num-bigint-dig")]
+impl BigNumDig {
+    pub(crate) fn to_bytes_helper<const N: usize>(state: &BigUint) -> [u8; N] {
+        let vec = state.to_bytes_be();
+        let mut bytes = [0u8; N];
+        let zero_bytes = N - vec.len();
+        bytes[zero_bytes..].copy_from_slice(&vec);
+        bytes
+    }
+}
+
+#[cfg(feature = "rug")]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct BigNumRug;
+
+#[cfg(feature = "rug")]
+impl Big for BigNumRug {
+    type Num = Integer;
+
+    fn one() -> Self::Num {
+        Integer::from_digits(&[1u8], Order::LsfLe)
+    }
+
+    fn is_zero(n: &Self::Num) -> bool {
+        n.is_zero()
+    }
+
+    fn modpow_product<'a>(
+        base: &Self::Num,
+        exponents: impl Iterator<Item = &'a Self::Num>,
+        modulus: &Self::Num,
+    ) -> Self::Num {
+        let mut product = Self::one();
+        for exponent in exponents {
+            product *= exponent;
+        }
+
+        base.clone().secure_pow_mod(&product, modulus)
+    }
+
+    fn modpow(base: &Self::Num, exponent: &Self::Num, modulus: &Self::Num) -> Self::Num {
+        base.clone().secure_pow_mod(exponent, modulus)
+    }
+
+    fn mod_inv(base: &Self::Num, modulus: &Self::Num) -> Option<Self::Num> {
+        base.clone().invert(modulus).ok()
+    }
+
+    fn squaremod(base: &Self::Num, modulus: &Self::Num) -> Self::Num {
+        base.clone()
+            .pow_mod(&Integer::from_digits(&[2u8], Order::LsfLe), modulus)
+            .unwrap()
+    }
+
+    fn quotrem_product<'a>(
+        factors: impl Iterator<Item = &'a Self::Num>,
+        divisor: &Self::Num,
+    ) -> (Self::Num, Self::Num) {
+        let mut product = Self::one();
+        for factor in factors {
+            product *= factor;
+        }
+
+        product.div_rem_floor(divisor.clone())
+    }
+
+    fn from_bytes_le(bytes: &[u8]) -> Self::Num {
+        Integer::from_digits(bytes, Order::LsfLe)
+    }
+
+    fn to_bytes_le<const N: usize>(n: &Self::Num) -> [u8; N] {
+        let vec = n.to_digits(Order::LsfLe);
+        let mut bytes = [0u8; N];
+        let zero_bytes = N - vec.len();
+        bytes[zero_bytes..].copy_from_slice(&vec);
+        bytes
+    }
+
+    fn from_bytes_be(bytes: &[u8]) -> Self::Num {
+        Integer::from_digits(bytes, Order::MsfBe)
+    }
+
+    fn to_256_bytes_be(n: &Self::Num) -> [u8; 256] {
+        let vec = n.to_digits(Order::MsfBe);
+        let mut bytes = [0u8; 256];
+        let zero_bytes = 256 - vec.len();
+        bytes[zero_bytes..].copy_from_slice(&vec);
+        bytes
+    }
+
+    fn is_probably_prime(candidate: &Self::Num) -> bool {
+        match candidate.is_probably_prime(20) {
+            IsPrime::No => false,
+            IsPrime::Probably => true,
+            IsPrime::Yes => true,
+        }
+    }
+
+    fn rand_below(ceiling: &Self::Num, rng: &mut impl CryptoRngCore) -> Self::Num {
+        let mut rng = Self::setup_rand_state(rng);
+        Integer::random_below(ceiling.clone(), &mut rng)
+    }
+
+    fn rand_rsa_modulus(rng: &mut impl CryptoRngCore) -> Self::Num {
+        let mut rng = Self::setup_rand_state(rng);
+        let p: Integer = Integer::random_bits(1024, &mut rng).into();
+        let q: Integer = Integer::random_bits(1024, &mut rng).into();
+        p * q
+    }
+
+    fn rand_prime_256bit(rng: &mut impl CryptoRngCore) -> Self::Num {
+        let i: Integer = Integer::random_bits(256, &mut Self::setup_rand_state(rng)).into();
+        let prime = i.next_prime();
+        debug_assert!(prime.is_positive());
+        prime
+    }
+}
+
+#[cfg(feature = "rug")]
+impl BigNumRug {
+    fn setup_rand_state(rng: &mut impl CryptoRngCore) -> RandState {
+        let mut seed = [0u8; 32];
+        rng.fill_bytes(&mut seed);
+        let seed = Integer::from_digits(&seed, Order::LsfLe);
+        let mut rng = RandState::new();
+        rng.seed(&seed);
+        rng
     }
 }

--- a/wnfs-nameaccumulator/src/traits.rs
+++ b/wnfs-nameaccumulator/src/traits.rs
@@ -1,0 +1,153 @@
+use std::{
+    fmt::{Debug, Display},
+    hash::Hash,
+    ops::{BitOr, BitOrAssign, Mul, MulAssign, Rem, RemAssign},
+    str::FromStr,
+};
+
+use num_bigint_dig::{prime::probably_prime, BigUint, ModInverse, RandBigInt, RandPrime};
+use num_integer::Integer;
+use num_traits::One;
+use rand_core::CryptoRngCore;
+use zeroize::Zeroize;
+
+use crate::uint256_serde_be::to_bytes_helper;
+
+/// Necessary implementations for the nameaccumulator backend that implements big integer math
+pub trait Big: Eq + Clone {
+    /// The big unsigned integer for this backend
+    type Num: Clone
+        + Debug
+        + Display
+        + PartialEq
+        + Eq
+        + Hash
+        + Ord
+        + Mul
+        + for<'a> MulAssign<&'a Self::Num>
+        + for<'a> RemAssign<&'a Self::Num>
+        + for<'a> Rem<&'a Self::Num, Output = Self::Num>
+        + One
+        + BitOr
+        + BitOrAssign
+        + From<u8>
+        + FromStr;
+
+    fn modpow_product<'a>(
+        base: &Self::Num,
+        exponents: impl Iterator<Item = Self::Num>,
+        modulus: &Self::Num,
+    ) -> Self::Num;
+
+    fn modpow(base: &Self::Num, exponent: &Self::Num, modulus: &Self::Num) -> Self::Num;
+
+    fn mod_inv(base: &Self::Num, modulus: &Self::Num) -> Option<Self::Num>;
+
+    fn squaremod(base: &Self::Num, modulus: &Self::Num) -> Self::Num;
+
+    fn quotrem_product(
+        factors: impl Iterator<Item = Self::Num>,
+        divisor: &Self::Num,
+    ) -> (Self::Num, Self::Num);
+
+    fn from_bytes_le(bytes: &[u8]) -> Self::Num;
+
+    fn to_bytes_le<const N: usize>(n: &Self::Num) -> [u8; N];
+
+    fn from_bytes_be(bytes: &[u8]) -> Self::Num;
+
+    fn to_256_bytes_be(n: &Self::Num) -> [u8; 256];
+
+    fn is_probably_prime(candidate: &Self::Num) -> bool;
+
+    fn rand_below(ceiling: &Self::Num, rng: &mut impl CryptoRngCore) -> Self::Num;
+
+    fn rand_rsa_modulus(rng: &mut impl CryptoRngCore) -> Self::Num;
+
+    fn rand_prime_256bit(rng: &mut impl CryptoRngCore) -> Self::Num;
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BigNumDig;
+
+impl Big for BigNumDig {
+    type Num = BigUint;
+
+    fn modpow_product<'a>(
+        base: &Self::Num,
+        exponents: impl Iterator<Item = Self::Num>,
+        modulus: &Self::Num,
+    ) -> Self::Num {
+        let mut product = BigUint::one();
+        for exponent in exponents {
+            product *= exponent;
+        }
+
+        base.modpow(&product, modulus)
+    }
+
+    fn modpow(base: &Self::Num, exponent: &Self::Num, modulus: &Self::Num) -> Self::Num {
+        base.modpow(exponent, modulus)
+    }
+
+    fn mod_inv(base: &Self::Num, modulus: &Self::Num) -> Option<Self::Num> {
+        base.mod_inverse(modulus)?.to_biguint()
+    }
+
+    fn squaremod(base: &Self::Num, modulus: &Self::Num) -> Self::Num {
+        base.modpow(&BigUint::from(2u8), modulus)
+    }
+
+    fn quotrem_product(
+        factors: impl Iterator<Item = Self::Num>,
+        divisor: &Self::Num,
+    ) -> (Self::Num, Self::Num) {
+        let mut product = BigUint::one();
+        for factor in factors {
+            product *= factor;
+        }
+
+        product.div_mod_floor(divisor)
+    }
+
+    fn from_bytes_le(bytes: &[u8]) -> Self::Num {
+        BigUint::from_bytes_le(bytes)
+    }
+
+    fn to_bytes_le<const N: usize>(n: &Self::Num) -> [u8; N] {
+        to_bytes_helper::<N>(n)
+    }
+
+    fn from_bytes_be(bytes: &[u8]) -> Self::Num {
+        BigUint::from_bytes_be(bytes)
+    }
+
+    fn to_256_bytes_be(n: &Self::Num) -> [u8; 256] {
+        to_bytes_helper(n)
+    }
+
+    fn is_probably_prime(candidate: &Self::Num) -> bool {
+        probably_prime(candidate, 20)
+    }
+
+    fn rand_below(ceiling: &Self::Num, rng: &mut impl CryptoRngCore) -> Self::Num {
+        rng.gen_biguint_below(ceiling)
+    }
+
+    fn rand_rsa_modulus(rng: &mut impl CryptoRngCore) -> Self::Num {
+        // This is a trusted setup.
+        // The prime factors are "toxic waste", they need to be
+        // disposed immediately.
+        let mut p = rng.gen_prime(1024);
+        let mut q = rng.gen_prime(1024);
+        let modulus = &p * &q;
+        // Make sure to delete toxic waste
+        p.zeroize();
+        q.zeroize();
+        modulus
+    }
+
+    fn rand_prime_256bit(rng: &mut impl CryptoRngCore) -> Self::Num {
+        rng.gen_prime(256)
+    }
+}

--- a/wnfs-nameaccumulator/src/uint256_serde_be.rs
+++ b/wnfs-nameaccumulator/src/uint256_serde_be.rs
@@ -1,19 +1,21 @@
 use num_bigint_dig::BigUint;
 use serde::{Deserializer, Serializer};
 
-pub(crate) fn deserialize<'de, D>(deserializer: D) -> Result<BigUint, D::Error>
+use crate::Big;
+
+pub(crate) fn deserialize<'de, B: Big, D>(deserializer: D) -> Result<B::Num, D::Error>
 where
     D: Deserializer<'de>,
 {
     let bytes: Vec<u8> = serde_bytes::deserialize(deserializer)?;
-    Ok(BigUint::from_bytes_be(&bytes))
+    Ok(B::from_bytes_be(&bytes))
 }
 
-pub(crate) fn serialize<S>(uint: &BigUint, serializer: S) -> Result<S::Ok, S::Error>
+pub(crate) fn serialize<B: Big, S>(uint: &B::Num, serializer: S) -> Result<S::Ok, S::Error>
 where
     S: Serializer,
 {
-    serde_bytes::serialize(to_bytes_helper::<256>(uint).as_ref(), serializer)
+    serde_bytes::serialize(B::to_256_bytes_be(uint).as_ref(), serializer)
 }
 
 pub(crate) fn to_bytes_helper<const N: usize>(state: &BigUint) -> [u8; N] {

--- a/wnfs-nameaccumulator/src/uint256_serde_be.rs
+++ b/wnfs-nameaccumulator/src/uint256_serde_be.rs
@@ -1,7 +1,5 @@
-use num_bigint_dig::BigUint;
-use serde::{Deserializer, Serializer};
-
 use crate::Big;
+use serde::{Deserializer, Serializer};
 
 pub(crate) fn deserialize<'de, B: Big, D>(deserializer: D) -> Result<B::Num, D::Error>
 where
@@ -16,12 +14,4 @@ where
     S: Serializer,
 {
     serde_bytes::serialize(B::to_256_bytes_be(uint).as_ref(), serializer)
-}
-
-pub(crate) fn to_bytes_helper<const N: usize>(state: &BigUint) -> [u8; N] {
-    let vec = state.to_bytes_be();
-    let mut bytes = [0u8; N];
-    let zero_bytes = N - vec.len();
-    bytes[zero_bytes..].copy_from_slice(&vec);
-    bytes
 }

--- a/wnfs/Cargo.toml
+++ b/wnfs/Cargo.toml
@@ -45,7 +45,7 @@ skip_ratchet = { version = "0.3", features = ["serde"] }
 thiserror = "1.0"
 wnfs-common = { path = "../wnfs-common", version = "=0.1.25" }
 wnfs-hamt = { path = "../wnfs-hamt", version = "=0.1.25" }
-wnfs-nameaccumulator = { path = "../wnfs-nameaccumulator", version = "=0.1.25" }
+wnfs-nameaccumulator = { path = "../wnfs-nameaccumulator", version = "=0.1.25", default-features = false, features = ["rug"] }
 
 [dev-dependencies]
 async-std = { version = "1.11", features = ["attributes"] }

--- a/wnfs/src/private/forest/snapshots/wnfs__private__forest__hamt__snapshot_tests__hamt.snap.new
+++ b/wnfs/src/private/forest/snapshots/wnfs__private__forest__hamt__snapshot_tests__hamt.snap.new
@@ -1,0 +1,75 @@
+---
+source: wnfs/src/private/forest/hamt.rs
+assertion_line: 569
+expression: store
+---
+{
+  "value": {
+    "accumulator": {
+      "generator": {
+        "/": {
+          "bytes": "DnwXmD/vORPcLzdf1evo7nGljNInOtYHpODrD3+82Nnpu0qfQPxFLKSB2dhylrLkh4UmTnLZtphq+jBbSjrWkqRf6C/qEToqzAhkAPtkF048lnLaI3UjBCXagQjJv8boXybWdaxiKxTFN2nu9B2vzNyUl1QqO9wXmNkzWM1P4T8lIm6FTjWSbHg/TVTXkpv8nTgQIUA1A0Kk7jEtjb/Vl8VdTZ2UgBywKE1Pvf8HbmXDc6Cjg0K5+XXC6SW1Bk71iLdLM174Mu8KWDjb3qotRpqrGGeSIv1KI1v1VWCI8ZuohkVe4zT5JvzyKIizsVDKcPTKGR60H6enSeQZgShFww"
+        }
+      },
+      "modulus": {
+        "/": {
+          "bytes": "x5cM7tzDsHVEkCAaeqYTzXOREIHHkPXxqHJvRjVQu1t/8NuOHqEYnscvk9FlABG9chrurMKs3jKgQQfwZIwoE6MfWwt3Zf+LRLS2/8kzhLZG6wnHz16FktQOozyAA581tPFKBLUfe/14G+TRZzFkuo65kcLE1zC7vjX1kr3vUkr36Nrv0mxm/ALEea+J1k03P0QnCUOd5mzrlV8+o31RWfYTWAn4UzS1yxgTrdyAzQVgnxCsapWtZYcskJUlva0yvHKVkmQpIPJMYdxbPDt5I+VrFqTZ03PYch8ko/wPGzEx9VYVFyhmvMww+VBUyCTnM6XraBf3vBY5nUjGNhzH5Q"
+        }
+      }
+    },
+    "root": [
+      {
+        "/": {
+          "bytes": "IgQ"
+        }
+      },
+      [
+        [
+          [
+            {
+              "/": {
+                "bytes": "WzUFTg2et93G6urhSL2Viqdf49sAgAv0vv8SE1SgzA2V80ukVHaZR6+PcbbkvJa7kqRzKbUJ8si3pckU/2L30Kmr+JVM38v6cQAT5N0y9KiTmXX6EyUIkQ5r+zfH8xybEhJ00mPJbRpB76OgZ24z9a1VLWQCcenR6GsrPWUkU94p3r8XBQtIBni/uHjKlpFvR/Csq+pmoBqK5qOYaDsgWn6nV8pgMIIRFifu6S7bw9SSMtRUrW/FFfcu1GjRHeq7UV71wyUGGB2gpC4Ekm8Y/tri1S3zHbLnh54ck+tjUZM0MMRSWnL+FvwXcYKaxfRmxooi0Jajw3zF+xGdW8hlnw"
+              }
+            },
+            [
+              {
+                "/": "baeaaaaa"
+              }
+            ]
+          ]
+        ],
+        [
+          [
+            {
+              "/": {
+                "bytes": "JpTYbHBVDGw5673kIA4lqeXDoKce4FWIcUzot6Dz7jlQu9P/oIsgyVqxOsyywQNdzwbCXdzscWCzafaoX46arhINT9o9aB2e88mQLJrs3Q19cVojT1MNS0ozckERxcmJdarrm3SQMX61pyRK796Su33+5bKZ2QfVQwlhpQ6zC6bFrsXNtcM+xk82MgpFkhNNg7vP+LRUVzmRgk8bdsnHypPQE0jAOS/tn93KMV4aA32KNeZdxDwvFDJ/BFqQ0X0uhs0NA1xQbNqlUOfLvfKa2ADlU+Gn+wilPLwjnelZbuQSu78e+Y1kGDuYJPYG5aCYKlNlYfjV/V2BqvTgY6Qt7w"
+              }
+            },
+            [
+              {
+                "/": "baeaaaaa"
+              }
+            ]
+          ]
+        ],
+        [
+          [
+            {
+              "/": {
+                "bytes": "PIhixhlMETh9BGn4lF0klTdOCHH3/JngF0bGUZZg3HO25Qqp4c5K3eOyAohQYWIhyxgbOhkvzeVtG5oDNSVLcgd+6lMULgXBEEhavSX6CFLnxVoKLFqvvt7dxh5dUVTSQ6adIIa0E7hzu1Jt9E8mZm3C1rNz8js9+eaQwWzYynyRi78O/ubhgK8W5K1lIKtDdKI6VnOTaUKn/kih2kYhR/exZGWAzk9vwmDlsRRIJLHrTYX3cxZuTlMa2MwFov5WDE5zYSh/qe3jVmIXEhp/ffnWzEjwlbkZi6RpC/cT2NStprki+vwJdV4klvKpSdA8+5Ma+cUZ8PjeEBqLjl10WA"
+              }
+            },
+            [
+              {
+                "/": "baeaaaaa"
+              }
+            ]
+          ]
+        ]
+      ]
+    ],
+    "structure": "hamt",
+    "version": "0.1.0"
+  },
+  "bytes": "pGRyb290gkIiBIOBglkBAFs1BU4Nnrfdxurq4Ui9lYqnX+PbAIAL9L7/EhNUoMwNlfNLpFR2mUevj3G25LyWu5Kkcym1CfLIt6XJFP9i99Cpq/iVTN/L+nEAE+TdMvSok5l1+hMlCJEOa/s3x/McmxISdNJjyW0aQe+joGduM/WtVS1kAnHp0ehrKz1lJFPeKd6/FwULSAZ4v7h4ypaRb0fwrKvqZqAaiuajmGg7IFp+p1fKYDCCERYn7uku28PUkjLUVK1vxRX3LtRo0R3qu1Fe9cMlBhgdoKQuBJJvGP7a4tUt8x2y54eeHJPrY1GTNDDEUlpy/hb8F3GCmsX0ZsaKItCWo8N8xfsRnVvIZZ+B2CpFAAEAAACBglkBACaU2GxwVQxsOeu95CAOJanlw6CnHuBViHFM6Leg8+45ULvT/6CLIMlasTrMssEDXc8Gwl3c7HFgs2n2qF+Omq4SDU/aPWgdnvPJkCya7N0NfXFaI09TDUtKM3JBEcXJiXWq65t0kDF+tackSu/ekrt9/uWymdkH1UMJYaUOswumxa7FzbXDPsZPNjIKRZITTYO7z/i0VFc5kYJPG3bJx8qT0BNIwDkv7Z/dyjFeGgN9ijXmXcQ8LxQyfwRakNF9LobNDQNcUGzapVDny73ymtgA5VPhp/sIpTy8I53pWW7kEru/HvmNZBg7mCT2BuWgmCpTZWH41f1dgar04GOkLe+B2CpFAAEAAACBglkBADyIYsYZTBE4fQRp+JRdJJU3Tghx9/yZ4BdGxlGWYNxztuUKqeHOSt3jsgKIUGFiIcsYGzoZL83lbRuaAzUlS3IHfupTFC4FwRBIWr0l+ghS58VaCixar77e3cYeXVFU0kOmnSCGtBO4c7tSbfRPJmZtwtazc/I7PfnmkMFs2Mp8kYu/Dv7m4YCvFuStZSCrQ3SiOlZzk2lCp/5IodpGIUf3sWRlgM5Pb8Jg5bEUSCSx602F93MWbk5TGtjMBaL+VgxOc2Eof6nt41ZiFxIaf3351sxI8JW5GYukaQv3E9jUraa5Ivr8CXVeJJbyqUnQPPuTGvnFGfD43hAai45ddFiB2CpFAAEAAABndmVyc2lvbmUwLjEuMGlzdHJ1Y3R1cmVkaGFtdGthY2N1bXVsYXRvcqJnbW9kdWx1c1kBAMeXDO7cw7B1RJAgGnqmE81zkRCBx5D18ahyb0Y1ULtbf/Dbjh6hGJ7HL5PRZQARvXIa7qzCrN4yoEEH8GSMKBOjH1sLd2X/i0S0tv/JM4S2RusJx89ehZLUDqM8gAOfNbTxSgS1H3v9eBvk0WcxZLqOuZHCxNcwu7419ZK971JK9+ja79JsZvwCxHmvidZNNz9EJwlDneZs65VfPqN9UVn2E1gJ+FM0tcsYE63cgM0FYJ8QrGqVrWWHLJCVJb2tMrxylZJkKSDyTGHcWzw7eSPlaxak2dNz2HIfJKP8DxsxMfVWFRcoZrzMMPlQVMgk5zOl62gX97wWOZ1IxjYcx+VpZ2VuZXJhdG9yWQEADnwXmD/vORPcLzdf1evo7nGljNInOtYHpODrD3+82Nnpu0qfQPxFLKSB2dhylrLkh4UmTnLZtphq+jBbSjrWkqRf6C/qEToqzAhkAPtkF048lnLaI3UjBCXagQjJv8boXybWdaxiKxTFN2nu9B2vzNyUl1QqO9wXmNkzWM1P4T8lIm6FTjWSbHg/TVTXkpv8nTgQIUA1A0Kk7jEtjb/Vl8VdTZ2UgBywKE1Pvf8HbmXDc6Cjg0K5+XXC6SW1Bk71iLdLM174Mu8KWDjb3qotRpqrGGeSIv1KI1v1VWCI8ZuohkVe4zT5JvzyKIizsVDKcPTKGR60H6enSeQZgShFww=="
+}

--- a/wnfs/src/private/snapshots/wnfs__private__directory__snapshot_tests__private_fs.snap.new
+++ b/wnfs/src/private/snapshots/wnfs__private__directory__snapshot_tests__private_fs.snap.new
@@ -1,0 +1,777 @@
+---
+source: wnfs/src/private/directory.rs
+assertion_line: 2265
+expression: values
+---
+{
+  "bafkr4iabb422gnp45fdjd4onr567olqprcl53oblnyima3oenyqvae3ifq": {
+    "value": {
+      "/": {
+        "bytes": "SGVsbG8gV29ybGQ"
+      }
+    },
+    "bytes": "2ARXvwnglXovkitY55ZG4ColKct8mePeDZ5fiwOGqsKPJKYCSecliCfU6Qosi0kfW8Cd"
+  },
+  "bafkr4iahkw3bjsjkkrx4carbnlqd7u3ajgwsr7uiwymkeyjijd3mxbgnkm": {
+    "value": {
+      "wnfs/priv/dir": {
+        "entries": {
+          "jazz": {
+            "contentCid": {
+              "/": "bafkr4ictjgvf6likl7mkpnrzb62d3ncrrychx6wbjvkkiaj5iaqpa3jo3i"
+            },
+            "label": {
+              "/": {
+                "bytes": "3FRcwKHFw7UsbFvuPJY92Ee1+SIXPWJSkiLT5+Q7x5U"
+              }
+            },
+            "snapshotKey": {
+              "/": {
+                "bytes": "wgoQtwsOrB+0hooUC/hIbIqrhOi2E1V0f6edZTMzNSE"
+              }
+            },
+            "temporalKey": {
+              "/": {
+                "bytes": "Z0lE6T/vSa4vXjn0BQe12aJGA3wkotPuNb0Yq7yx0TxhNatdy+iFxA"
+              }
+            }
+          }
+        },
+        "headerCid": {
+          "/": "bafkr4ibc7yjsk2mjyr2etnxbcfovouvnmhgeif24luew67kk4urog3elc4"
+        },
+        "metadata": {
+          "created": 0,
+          "modified": 0
+        },
+        "previous": [],
+        "version": "1.0.0"
+      }
+    },
+    "bytes": "L4pYG5OW5YyMbIdJgNTG207RdlwnC6q86F59KgR/7lfiinXMhTN+Ha0oFYEFrO54s3SILC33VEgft5uC/naB327csQxqlGMc7OtJrs6tFymdqlM76ZY1CLxs8wnyFUHIkSRUOXmzTfL/OV8U+QoP7f1falYng+o66D2c9Q9mQnSHCN+jnrACKykrYu2WNK0KhAyYP1dub5K/8HxVWcZcXypB5sdaPNjHHbRwPrJXoBMq5+qQJFZNbO2PsvlLYZyoHY1wH4RqB8b0d0boWaytKDl3kJcRhg7gjxSAiPruP294D+8g6C2kBWWhpp2o8BSAPSrQ6f1i0uzsNJJSQ4G1V8k06J1efzCJDq5b5ZYtYXBMVcceZ+HQuGOEvG6kewkfWx2/uDnv2W3FMiCg6R731Q95YjGmITOYA13yrffxWr7m2jP/EIvHv/VV80OGOYw3pTs8WkSUiCht4QXkX9xxDK684ScRIc2gFs3ymevTdA=="
+  },
+  "bafkr4ibc7yjsk2mjyr2etnxbcfovouvnmhgeif24luew67kk4urog3elc4": {
+    "value": {
+      "inumber": {
+        "/": {
+          "bytes": "AYFy45ycBLjA5BtArQL72ZWs3HMmhS6dwH7ybF6/nhc"
+        }
+      },
+      "name": {
+        "/": {
+          "bytes": "hJOiX+spJVS+B8BTf9AHnee8iNlFnZEaANNQeHtoucSOGgUoHkD+R4KQ45f9nOB96yiLFtNb1SqBFDenwt1kHozDfFSnfVoUMg59lbsuAzI8HwzRsoL37HDemdDaRWOYgGNEN6UUyMHTZUPN0XQvfYv8OmAvQMi3kj5xgcRmj9P/iDSm3ZT2SofpPE9YEMV9f161S6XeLcvDd2cu5Sxa2bOZEOWzNAzEFgUMgRH5ZoGrQsznv2O/0NTtcaFIcDl5+/t0huNdjen1a/SIBWkr5amN33cwXzSujvrXxy2bVUTguY/wSZOsrNnG2LBn/sblU7g4c/d+SzERp6LmzOEJ5w"
+        }
+      },
+      "ratchet": {
+        "large": {
+          "/": {
+            "bytes": "J9y/uUtzPtr2uMrizZhRSPKiYbj7mIZ5mhVGlY7QSUQ"
+          }
+        },
+        "medium": {
+          "/": {
+            "bytes": "N7+d0A5VZ5QcCMrARPPM7Lp6pwjRYolfbfSBPAuv4so"
+          }
+        },
+        "mediumCounter": 227,
+        "salt": {
+          "/": {
+            "bytes": "wJknDy/chixgR3PN4i/umUKgu9w/dBQkKPcc8bpPtwM"
+          }
+        },
+        "small": {
+          "/": {
+            "bytes": "0yP5KKkIA3gskFH3ElX5nv3Z7iRD1GQSee7S4+xMSYg"
+          }
+        },
+        "smallCounter": 253
+      }
+    },
+    "bytes": "jYY2RjN9BbKyqePXVVee/OIoc91msVjabYLTIEfKPjsB+RFW9L+KXrfSADfXl2ZQbOLoInzxYtVrox6CweoLDV2J6sp6OSFxtw/IWfBJw/DByBNMBtLPg1VahZNOhX8ujtp8E26Wbpj+3cDAzWkFozZAEutZKovNoFWq3DioEIyFf2C3hNSYaGny4eAI5gMfQGD51Aj9pfmT3nIVAk9Aej1BkXtOaNLqkMTSniDCuISIUNh8Q3UdoTO07iUvB836N6IorER8jb4YyWYTmaeBFlnOIAeoSd3n43Z2ce+N43jPcrRp1zUxzBEI781csAhU3Ub5tYdE/f+rHoAh5z4RjlkDD6fbg/g1Eoa9byhODka3o5xFThdkLqnRcenWQBMZI4A8EXRDzqENoftHK2sZSmhqEhqF4XNvcDtqPSfH53NnGODp5DFZhiM9FJZ85T3LSq2fzt37Y0jZ4l/KJzlizkZrbfMUhzFoOUkcFJWs0hQULmeF07gtctmFmphPHtm16xXHzt0pinknOj6rV1Qp7d4gfTiN2PIstc2vJfslltqQtbPrd0Wi7BJFeUIjiL172hmkTPQBYcfDN4mVcVGseggK/VzHi4cu9fjc1DExIu8H7bxzCZAvdNuk2fA8A2HpSQxwdalWUrdwr7VCsukIN0d8oOtyZcmxUsGxNQnjZNI/JitqhxzZBA=="
+  },
+  "bafkr4ibpzyie2yheabo4axf3mwr5mft5wnf7ut4xxqbt54mpz4rqu7tb6i": {
+    "value": {
+      "inumber": {
+        "/": {
+          "bytes": "W97A8DleWRdttNjFq/5zb6wolixPTrDubqDKDreenzY"
+        }
+      },
+      "name": {
+        "/": {
+          "bytes": "Ha6m9Qtvybi13t8xS6jCJVd8/4vIgb18hy+u3tewR1dSYw/YijfJhTE9SpO9WZWeMejVpHwVqNg37ieT5DogFfBBOo4eBlOaLUE1pUOZCvDHrXz5LXbw62decS+2XKNJMrF8k6T9nK05prowsfrIAOnGrvew2xCmmLoSiCVOrLghXPMNlvqMm8unic9k23fAg/vE4AEfKXGhCNy5zbeqK8vV5wOo0JBHPrWgNyP4IdR76IeiYa6Yrkxs3cPtDqY387JuyUsX8fyWdap4JXTP2ldNsr3X4G66mce1h6vkrVO1jfPvCswFevkdFOcqnoGZJsHuY9I1q0LDP2z3UI4jXg"
+        }
+      },
+      "ratchet": {
+        "large": {
+          "/": {
+            "bytes": "Gsgh612kLZy5xCAXrHmAIbVkuVTAaSKQAs061PVJ1Ag"
+          }
+        },
+        "medium": {
+          "/": {
+            "bytes": "o9OePElGO1DER+MHy5oABkbDIblbg+jUVNW7REa2Kyo"
+          }
+        },
+        "mediumCounter": 31,
+        "salt": {
+          "/": {
+            "bytes": "zoSIa/gNcNGdLwpk591zPxnRl46bR2NVMovEgpAY8KE"
+          }
+        },
+        "small": {
+          "/": {
+            "bytes": "A0L13AljldlXoBzDH6BVWBvbhZOQgPq8B0+xY00cMjk"
+          }
+        },
+        "smallCounter": 149
+      }
+    },
+    "bytes": "GeTn5Nf4+sRQFRNoqq2pSKxBtooTsPZFHzuMSUn3PdkMzakhmjvcVved4F2Qc29mMW1OeX1H9AlqehLawKCIdGmp2DkEpI4Q6u81KNV/TQN7zCm9jB9RA/txCximqHTJbQwoCnD1bFg279sxVyT+eAHX/GrC+dcPatEVKUcXMuPseUDqr74Uy5Ha/++a31CYvWTTHgZ3/JjpnBxlxuIidjaMdnpqkW8YEI6AscXsiJeURmuu61yP1PhYHRCC55LoWw+AEoUSJc+3dyhfgc/BJIyDNA+0l0y5uxqy7dR5uyMOpxyJPtPql/Dy6w4IuAow2pmWlaFO485E1eM3sr/DaxkVMC503xysIqfU6TX8pTVSWBYncBPpIiqVeftnmsW/twwxVxeJihQ8V1TJ6JcBOJMzEQZhv4eqbpyfNKrykMAXBreIkcwAgio8OkJcjZyu9O4iIHYfNeJBQ2JtECyrU9hOrLlUeaYxdVZHVAesu27xh9s+RKeyDo9jPr0PWFV0sfY/Y2Db1xHM6D9SwfdfpfElYvL/+1IMAUogTHWI4lxlQN8b3L6wzgXMZDSjR5ZALldqo2oooJarIdDoykAzveQIgMMp51eE49lYskdn8kOIjLE+cSq1wkhVsDaDixBqNue/dQyR65wF2foYxYZXhv6cu6bRVmQ2oNGK7Ae5WUbVhC9U6WQ4Ew=="
+  },
+  "bafkr4icard4qkcqguebyyia3issfinnfywggaohgq46cxvznv4lsrd67qq": {
+    "value": {
+      "inumber": {
+        "/": {
+          "bytes": "U1obi/Yf48JxIgbIdQMptUgaqubcTWtqIlYqk1q1d74"
+        }
+      },
+      "name": {
+        "/": {
+          "bytes": "ElVG2/MKo+xcz+1lm3nFkl2MpM/PoWElg2C1H5sPfQ0YBSQW9+nMJR1otJy+dm0bg5bImWHMUpenrCxZ+W+JPdb6fXPe59F7gTO9j3zRJOVceZF9z/pDjTR9Ub8wNcilyrAA3T0DYcmD+4PDJXzWMlhDpMaTyEb0Ktza8ohwPwqZ+l8dGyMYAqoL+tZ1EdZeTaj2vH8D0GZ0G3jETwv0Sei9rpsraQD/sYvTFn3EiGSvmFfJciXVXM3nQ1iVp/qydKwlDxyW+E2qpL2ZAE/MsZ19l5FfaS+ZICT24TZqXP04r8LXdH8OmTwwusDi/RupMQQcHDieCGMVbeu4ClPDrg"
+        }
+      },
+      "ratchet": {
+        "large": {
+          "/": {
+            "bytes": "fkQysCnE9+L5U6SI6r6TEjxAg9ypPYkILcyntk6i4MA"
+          }
+        },
+        "medium": {
+          "/": {
+            "bytes": "Qyo7Rw0IyXRu6eL805pN9Uxlb41DahrvEHbw3qib1Aw"
+          }
+        },
+        "mediumCounter": 18,
+        "salt": {
+          "/": {
+            "bytes": "/8FmnP2I6CnT0N6iXzyETzANlYRQeNrs9z+z/ClDPzQ"
+          }
+        },
+        "small": {
+          "/": {
+            "bytes": "pZ0fTz4FIqjw54lxpz8l0NEGPo5l2XYgFN9dmGeHlZg"
+          }
+        },
+        "smallCounter": 207
+      }
+    },
+    "bytes": "RWTWhVC1mzo1CpTOjae7kDrhmpRami7jWzi1//dc5cqlJA97T0LFzjdl+r9K6M390hyIhlouuSRUWp7icNkoYOjf8FLFLfh/HULCC0WGMhgmRJWML1SdwCxi7sx7hlguSOBqVjiHBKm5fe+lObrBqW29S+1zVv4x5kDdk1AHIHxivbLj8Br0gOO/wv4D7I5NGeAyxTvK5AnhdfyphmMv3TtSAQgkRD9nd/KNvrd8sF5ZfxlgdtgGsFeMW3rRRv1rir6H9VmZusOVkS2OJbXVJM9x5TCBEFz7hrFm9rLfRn6nVbVq5svMWR617LxjXyQA8nV+57l6BlvkisKr1mVeuvMW593ha4Wq647OH6ao8pJzF933Ka/WVeQjH0TNg2got1iMltzj7gbutuvajm0JoMKvVfc0NZaQwaSALk40V1DtFskRUwEBqxH32yqmgr+TjpV+vyUjlnxJQLGIr0nwXtv2fqdMDm/nFsp2s+LmilnxPjg0giy6cF/rKFb8PRASSDUm4g01oMcxqHl5ZsLrIRn2AdpduLTlW7TJvbyhWOJcfYRvCJZ3NzT9cuJBqgpFDCJU+R89isA7b+ooLMYxhN+vJzZdvuncAKK5y52ul+NpmMmiC346gJ79MGjWR1diwhyIqvAdfdugZIlp1/f3woZNKbhXyi6KpV+2+z5iYqTJCEEA2hMzuw=="
+  },
+  "bafkr4ictjgvf6likl7mkpnrzb62d3ncrrychx6wbjvkkiaj5iaqpa3jo3i": {
+    "value": {
+      "wnfs/priv/file": {
+        "content": {
+          "external": {
+            "baseName": {
+              "/": {
+                "bytes": "utu20BTQZ5cAdyP+CDHT2VKJGoWSBfrKhzRw9MnceDNg1sw2coP9s6tF9z2+uoSvxjc2YHdI0hFtFsMJO3wWP1PvvIr11bcOhZZKP1mtHuR2C0vGRr3UxtKc3P2+nPlQmOLuPxKLdOOE1CL3AvBm/FmSguurGz+wYmzWLmDHK0ssOSuHXQGJzGyhV6hTCNDiGtfeUZDRwVUIbRXwvTjDH7FcFhqCUalfRNYKgXcXbwc62vy6oXZ4ndzokTWEJNFPDEn6SU/aqLwQ7veQmWhQ12NN8hFpVoPfSOlGVUPimj1qkYjRrcslXoZMPGHny+g+S8yI0S7DbsvMCfpKSD095A"
+              }
+            },
+            "blockContentSize": 262104,
+            "blockCount": 1,
+            "key": {
+              "/": {
+                "bytes": "RTVvKoRFbRabxFk8iiPjWbiY2+UbTvYvEOuZ4hjFvoU"
+              }
+            }
+          }
+        },
+        "headerCid": {
+          "/": "bafkr4ifwpko4yw7isbtjanffydqmswecgfxnlappwxiaig2xwln5lvdtzu"
+        },
+        "metadata": {
+          "created": 0,
+          "modified": 0
+        },
+        "previous": [],
+        "version": "1.0.0"
+      }
+    },
+    "bytes": "UxsjWntevfOu6Qzk1fNZJm6/iIpgysHyUiqc0wcGJrkynPLYAp44wsfTpC4XZIwCHiiY6JDGSWeDZtwmW09XXdMYmSygNH646nDJB7/zNScVGIr6V6d8L+ct86AT2QyFzaA3d64Y3OeNg/ztfoR1LbzeZsX4mp5VgREP/yFPicpX68bVwmJmgaUepDzsRQM2UC+TNxklM3A9YH7kb6RDKHuhcM1yI+95s0UNgqm1iUmRRZGv+xWzdZQuvgGsCtbNbHirho40lfLbkXdHYQmFbFfoIOV8zSfl1EBMx5lqwtXqx1BTXnd9pjjz2t/ik5268bLRj7t4nz6dv+D2ngnov88p0U3svAaNyncZt3UbcUZfcYaDtbEA40b3+SaBGKRDS4NATk79lSHYvV5n6cIzyHn7LapG4PjGqDrTN+q4kEawh7qmTzTD6ND0hpYn9PI+3ktyuDSfg4ln6dXrzmmlai0hDJisc7Xo5dyuBURmzkzYUsJ7IOaj7DxnwwH0v7Dizr2SmRMjBq7Owb9n9bCTWJq4g8RxmwUJyEU8NmnYLuc4ryc6j/RqXje5YZHiJrn5ostWo/ghXMDdHuCpd3B900wRYVWx3vvBbtlq9JRYQizKRmv5F25joZw6m3IlfQBggXapL2I+ruBvn6Rz0aG6mtwMk6vDhWt9yGviN+v19LChY352IWddKQ=="
+  },
+  "bafkr4icvi4lg2wwglhr4ultusrny5iljt6bprow7c52fr5dynx2fr2gtja": {
+    "value": {
+      "wnfs/priv/file": {
+        "content": {
+          "external": {
+            "baseName": {
+              "/": {
+                "bytes": "JDOKXlqMuCcsTXOUB5ewFJ2uabTYH566tTt2CgNv7FIKUYpsk0DlYRdFdAVCRKfQW1dSWYQVeeMILQyCkggTkS3t7oa2ftE+8td94t1MJ0oELX+IlPuuaiWQItxIQRcmLtM6gd0vSghpTX2X4ulRXsPsUXYYSFxHy7DgV5FjzoQhKt+rOtpxK5yYSfKoOJ6Q0ZfaQrN1qtDFZXvA9hZxdaCmzqdpt6ZKNjAL76/nDaKQsumlQk45SWx/Qivf3qzzY5U1FPog+ZGVT5plHqPBQYEmzBRyVwvgKr9n3FVPpyXf0/SNtXDXXQXk+aV40ZWmhhOVmj1SFxc7LeCxGxfFrw"
+              }
+            },
+            "blockContentSize": 262104,
+            "blockCount": 1,
+            "key": {
+              "/": {
+                "bytes": "ZKCSuHlM49WxT+92lwlfNPM+XxOoFM2AjU5e4dCLQ6M"
+              }
+            }
+          }
+        },
+        "headerCid": {
+          "/": "bafkr4ibpzyie2yheabo4axf3mwr5mft5wnf7ut4xxqbt54mpz4rqu7tb6i"
+        },
+        "metadata": {
+          "created": 0,
+          "modified": 0
+        },
+        "previous": [],
+        "version": "1.0.0"
+      }
+    },
+    "bytes": "+IU4xTGhOAuWwYvbYU3qdgyjhSyIOYpWtVNE1j5IG0GoQ+52FKMYJeScXXH9fpG4WJWhGsZxChQ/icSVclEYRqlcy7Pw7YDB1QSEbXuiqtXga+QBmrT41b4ec+BLiEVYPRx2xUwA6odaKMTvgJpha6jbN65VpDSSt3GxJouzF19dRtQrmyqBrvepZ5Dp7Il2tOAGyWoe8IaUyxMLTdQYFcuP1r8NvEx4Wkg+TWwRAnyYSWbH9KL0ALhHp0bmDof7htt9PxyofoaV0lC/6xXC/nk5NQ/sMJXqAkeJKES8WfX/rdjRbQxij4p6mgwOdt/qAsG765XIR7S35I4Ht+9KmfVNIl8ytyUjXbZUgakh1p4MwNpIyV7ynMJQ8jpEDMF+zVWB1d3ljhs3bG7nDpx+YYRqs7ws43uUjgJweE3UdQO+tBPlxT0OMJCIxIuKrhlwE94nV11ovKY6HCUML7A82bd0H4aJYUKTdJG60o/XbwnTDkErPiNSh0pmHX95l3NxjbCPbBZEbpoOxfMh3KXzLWTchIiJzFr+PxKPi9WvqQw2l1EaSjcv1rR0ylWgYL+ZtAx7I265roajvvoz7fjwfFbXIzxKSDopRzddf3BVbFZxw5KagDPOAxLjeLr7X7Wb93upW0mp3f4B57v5iIbkBsSJsOk6Dj07wJxOaVusW0UK8HTA2E7SjQ=="
+  },
+  "bafkr4iczjy3vg4v3snxzouqcf7hos3gta5ewwrqh6sp6243kp6nlxv6axi": {
+    "value": {
+      "/": {
+        "bytes": "SGVsbG8gV29ybGQ"
+      }
+    },
+    "bytes": "VWB36mFajvViTP7DTRDQD6bINeHM4vYFrdw43P/I978t7cD4xwCQrnWrHHau8ViPU25T"
+  },
+  "bafkr4idauz6dybed5ke35r4smjlkp3rhne34kve7gn2b6c4sbk7qhdrhq4": {
+    "value": {
+      "inumber": {
+        "/": {
+          "bytes": "OYxZ7wt/y1W2z7yglpMk7OQIUhmGWaYCaseeIjE3lPY"
+        }
+      },
+      "name": {
+        "/": {
+          "bytes": "S/ls0kBalPwc+iDXWpahp3wQ2+WOOxYGreewh79e1lFl3+Z2zFkTn4eKu8/HP5/BZqLxy4DwZB4Y/eejZF9ID7+rUizD3kzM0YmGBgiTujuXiVpIPNk4//qJm7Fa9qdZrBYTciHY9aoXip0UJK88GtCP6nn6TWutcuf+7prysBkYjRlFxswEDMfqmAy4dpgUPLWilkdj7IyHrokqo1VT8QzROow9NMv+mPhWF+4M2lQpKKIvQGQ3DZc7C419p5dLUBzzOjS4w9AFrxzElEFGAhqytWoXEyqV5Lz/AtkIBjvb+oTVvFs1r/hpbEhmXURFnELqV+vHMSpa9NGzBosmDQ"
+        }
+      },
+      "ratchet": {
+        "large": {
+          "/": {
+            "bytes": "jplWEnfjcZTajnfsX7TYhbL2nB3LesG4Pj7uJd8cT2o"
+          }
+        },
+        "medium": {
+          "/": {
+            "bytes": "0Ja9S3VJOqUQXtJ0nFpa8R4vboY0eYAjXon9WM3ehqE"
+          }
+        },
+        "mediumCounter": 39,
+        "salt": {
+          "/": {
+            "bytes": "bt7le++zTEs5jkCzohJnSEiXJZ8uJSGUexDLp7zen2c"
+          }
+        },
+        "small": {
+          "/": {
+            "bytes": "hZBPNt3qnCpdcqWUqvX0SiwUVrdr7rq9l2HHefy4YO8"
+          }
+        },
+        "smallCounter": 224
+      }
+    },
+    "bytes": "MfQ/LZl/xT+7JFDIl5mT7/ES5u8Z6V3ey6fqiGZTM3OZuWnqH/GRuf5BE0tgM4BBa0EO9+mcur/Rm+Fgqj093NNA8BZQ2VzeihSqognRG371C6z8wRj4YsdF9q4AX59v7j+hwa7EwF19kS9sqmvB5Y8YPF5l9f0ck/mH1WOBpFjhNA6ypehcX8Fi2WRsLxcMSyuV+j5LQvFIIWzDFh0JmYUEp+TQWXzuLMJdAVCHqZMItJYn6EyJ50/8lYSkXKEF3T28T2y+F6xW4SKQAqtLE6fOI0oMUFr+fM5+oAJ0I2sETT+ucSZicXpTs52V0NYYqnpGeSVUT9mz+gUbEjXKIGm8I2tbcWbN8tbKoJDMIrSTyz1M78YjhjagL7aOpxifp/JP+r58JGy9d1iB1UQ5F3YI5AFvwn7DJfgC/0d25lX5vsKI/qlov+9C7BoDUVSP9h/QTQo9B8KOYvgekBl2luf+eSHqD8LlBOK7LNDCxkY1lKq0IxUmtHpzp0Q2EtMxk/JD6mB61yxNnOmhY2nvcDGJr6wcAfxHbTnSlM8nEB+NiI2/cDOb5s+I22UqgXPpuI784aLNaPxcWX2U0wiUi11VDUF1GtBj0ioUuMC+5atHgkV/qI5nocAg0ONrQFJqYT0ihoyXBFTDAX9i8Plyk0es0qWuNlJs9FdPu5/Se8YKGFB92pG/EQ=="
+  },
+  "bafkr4idfnx2wtvhgyjwixz4xv6bzbyqv3jaf5kw55ayi2zccrlhwqt4sva": {
+    "value": {
+      "wnfs/priv/dir": {
+        "entries": {
+          "anime": {
+            "contentCid": {
+              "/": "bafkr4ie3mpzembun2s56qmyyykhc6n7vigtahdgx2cx2wiozhshnvwp5ly"
+            },
+            "label": {
+              "/": {
+                "bytes": "HEHDoFCgwTUAp2fOeR5Mz7efw3ykWn4w4XdQrOOZtRM"
+              }
+            },
+            "snapshotKey": {
+              "/": {
+                "bytes": "NlzXezeSP3RAStijGSnUAoKOlGrEzqfMCphY424Jzww"
+              }
+            },
+            "temporalKey": {
+              "/": {
+                "bytes": "j1sB3oEoYLgh4K2F/oWn+JcYBs1n0f5dqxkYw5blUDz6vRn2PREmKQ"
+              }
+            }
+          }
+        },
+        "headerCid": {
+          "/": "bafkr4icard4qkcqguebyyia3issfinnfywggaohgq46cxvznv4lsrd67qq"
+        },
+        "metadata": {
+          "created": 0,
+          "modified": 0
+        },
+        "previous": [],
+        "version": "1.0.0"
+      }
+    },
+    "bytes": "T6EjSLJGR1Ckk85SRNTa+2HUBkjM3oPJWq8lThHbxO1NzlGPDx3qlR0J8XVUegpx27nsxDAzGVOUMSKDC5A/6NbfqNRbou56de2rMyeDc26hJb9c7Esq8y/vYMj80Q9EpEXsM+n/cs/sNQAYl6qWVzPbv3JYYd0UeIRt1Et2QsNXbw/CXz6IS8QnaiJG+WFldHk4iFBSJZFuzSel1jak/Sg4mYKm2IQ4QD/9D5S6jiZHwfsfpIte9w9I4iEFxa7uBrQiVt2TPK8u0F5ECUvdRmT1pirIykBEChWRVDQ9wR7COPRf0xuNJ/Jp26fFl5+TosmieSXjNsC5Oy6HY0T0yDRpkEz+72jhLg0ttBwiHYjAhlM7SQ/HCykEYjgwgJEW9rcFJ3+UAejaXpDTSmGTj2tMjCOlwXthu3WeSmQb3ZrImMOmxBMkfJ87T+IsAdHooQv4KXIzYHs0WI4eWEUCTo12e+4vdfv5NHgYUrJ+aoU="
+  },
+  "bafkr4ie3mpzembun2s56qmyyykhc6n7vigtahdgx2cx2wiozhshnvwp5ly": {
+    "value": {
+      "wnfs/priv/file": {
+        "content": {
+          "external": {
+            "baseName": {
+              "/": {
+                "bytes": "Qd/tl836RpyIeOFace+GDfivbUqfl/Y1Pta6tKt1S/64+8bLdsoGMoYRsELRpQLv50dv+Aou85wE14IQNeZGLJzeiNsi+ekkvMV4m7gr16ZAqR6bRgcUy8vI9Exyr/xQG1t2D5mlKDBMynAlktnB40vmJJUzGZfoDqAzpeyzocIDvX3gckdZL8EFRmgcp0LlAjjKSo+ajxZBzW8fxt9ICWQ0/njANPWEk+RdA8T9ItWydGrZdZWGvLJujXBilksMja4TVRii2oclpV7x5A4MhZvxRoXqb85q9jxX41f23xEM6Ue+6Xa3GeMydjpM+krSMPI4I61hyeg6rcrnRAbS+g"
+              }
+            },
+            "blockContentSize": 262104,
+            "blockCount": 1,
+            "key": {
+              "/": {
+                "bytes": "jVcwDN/TdjHv5AfNidTSi4YTVNCx+2xZGF9Z1+pTi88"
+              }
+            }
+          }
+        },
+        "headerCid": {
+          "/": "bafkr4ihv4pskefqdbao7ugf7gsmnks7r6k3pezkzkgtwi2qz7tgbrrv2pu"
+        },
+        "metadata": {
+          "created": 0,
+          "modified": 0
+        },
+        "previous": [],
+        "version": "1.0.0"
+      }
+    },
+    "bytes": "KNb/g8e03KQjyeUy9xeoZpgabhtQAkR7xRrY6QLQXuspUPs5yZ8aGFQ6m6z+ZCzEsIeDxnjojh7460X7McSYYxQo7sawTELaROCAqIOmMxG9du3jBBu4A0YWglTJHrIIFjyngmBQaGFxrwKeJbIAmpxAqI2b3WGBF3b00khLTQd8Q9KRpbtlMXeAP8bW2gRl4tR8w7DBU0q12S7g7FSvZQ77t+JwNPXwa8P9vr1Fpped+CzHU0dn23p8sk+Ex65nT2frBFrYv/+ZVyydi6l8SK0WzXoXuuDRNYNBORUgga2tYHlTH8yHalYTkjDHEWX3hB4EcTXGbhHmmKoImrU3iPdaQMN3TLAbhyCRa7IGdc8fiE9qO+SAhI/+zNaFedksNrsVEKNg3FLWqshKX3l+a1uizBaLXwZ1lRKUvv8CgWdevVIJmjAkTQZMTw9EInRqzqYwWRO8C9knCnNIdoLQnNrJwMNHK/UPbMvMe4jyqguDj2gQaA91ROHKdXssbFe4tFRS+NeRpI/eez7oUIFQYJWgycuTPBvM0hFNbksi9g+nVABLOlI90y8DoeorMTWJDaoryS4MFoANtX+XRYW3kSfYGXc8PAEqwVc0t+Mq3F/1trhKf8ghAaMnFlcXPQSJjXozo71EsGHh8pmDqrHKgdpJVWH4lWe/Vw3ZBSknvN0sog7dgbVDIA=="
+  },
+  "bafkr4ie545cdu4sbij7mlt5pcwkfd2m5fzekz6akcbs6tm63b45dl5mtba": {
+    "value": {
+      "inumber": {
+        "/": {
+          "bytes": "4QkplQ8Volxj2J/elrPvhNMbFEN2Mz5Axtn5uOQYMsE"
+        }
+      },
+      "name": {
+        "/": {
+          "bytes": "WzUFTg2et93G6urhSL2Viqdf49sAgAv0vv8SE1SgzA2V80ukVHaZR6+PcbbkvJa7kqRzKbUJ8si3pckU/2L30Kmr+JVM38v6cQAT5N0y9KiTmXX6EyUIkQ5r+zfH8xybEhJ00mPJbRpB76OgZ24z9a1VLWQCcenR6GsrPWUkU94p3r8XBQtIBni/uHjKlpFvR/Csq+pmoBqK5qOYaDsgWn6nV8pgMIIRFifu6S7bw9SSMtRUrW/FFfcu1GjRHeq7UV71wyUGGB2gpC4Ekm8Y/tri1S3zHbLnh54ck+tjUZM0MMRSWnL+FvwXcYKaxfRmxooi0Jajw3zF+xGdW8hlnw"
+        }
+      },
+      "ratchet": {
+        "large": {
+          "/": {
+            "bytes": "0Xcz7RLjVmm+AzcWeY2i2QLcclCjoJktNy65o58rQDw"
+          }
+        },
+        "medium": {
+          "/": {
+            "bytes": "Nk4K4fSXXGSIL1hQ0gHHVGKjY/xSLm4fcLv3z0IPI5U"
+          }
+        },
+        "mediumCounter": 187,
+        "salt": {
+          "/": {
+            "bytes": "ONa5zrgjyuV6QSBzqKdagXT6HqmDbOX6b0+TK6spVOw"
+          }
+        },
+        "small": {
+          "/": {
+            "bytes": "/L33L32w93i0T7oGYx8u0Yxb9QWBumanpcvXJWQQWHY"
+          }
+        },
+        "smallCounter": 183
+      }
+    },
+    "bytes": "/63JRABPVoZz6twxVvMopMgw3Jp/mWdKgxbspfLGAGA0Qev6TQIQ5yz0zfSLu/BK6gEEmoRFDBBNuV6Xj5W8hv9wyQR4nVLYm4y26j4OgESPdrsQn7Jl8cXVSKDoRUOpdVfzeuK1oNoiYh6FXoNNUv8fao4gQtqtNDVmKfNRqD5il5mvKglfFVfZGonxtJzV9mk7W5Sv6mWLeanHXF5OeY0uLs7eOYJRdr0Z36Phpdy8jPlhwlvnvUilIe61MLYrKc3ElpdwRv3gP/djIJh0XZMME9tB6pkpjUrNSWwSOvaCix5bVRXJjZlBh7IJXjSR9a9u9KT4zGB+tVb+7JW9gM3uYWrjkStUzbphJ4e6vVFvLkb7vHLosTfoMCvnoY8wHFCoVeBlGzaW/U4kqNBTVr35Qyvi6CftOCzs8nGcg8cphu17iU0WfOnH/5Dln0WFYU7vBUbxGh1rr5Vk9tJgJgXO5FV587aPF6MaHNrKJf3P2Sz/Nb/XNUWVgqJWVHfKU7v5yJFXr5rJKRep7fisj5Q3Wv7w8uw4z+/+WXm68LTg8ww+83rEZFoMLVnTFjcu0MMnC0dFGyxAd5eOhjPadJLg5yO9RGvZfIIQVXotFMt/aicdxHby9qZnJ7HxGQykuh6fYR5AQXv2Ln/FU5z+TQm2D81e0fJIlVgC41z5EB1n1zltdKnhKA=="
+  },
+  "bafkr4ieckqbufxfkufnr4i6yhbq2qklhm2mhdw4twu4iiutsy2hslcgf4e": {
+    "value": {
+      "wnfs/priv/dir": {
+        "entries": {
+          "movies": {
+            "contentCid": {
+              "/": "bafkr4idfnx2wtvhgyjwixz4xv6bzbyqv3jaf5kw55ayi2zccrlhwqt4sva"
+            },
+            "label": {
+              "/": {
+                "bytes": "5+BCpuH15Y7PRniJLDURNz+5HXI4q6ARWZTBqIoXb8w"
+              }
+            },
+            "snapshotKey": {
+              "/": {
+                "bytes": "xjVdETOZFxTc/3EYwdj6HaxAExeWR13hDrMvlJipxK0"
+              }
+            },
+            "temporalKey": {
+              "/": {
+                "bytes": "8EV+cWCG7lqz5IJseUnKe45Gghwlbhb2Y+hZNxvYUrIL6eEzWhcNYA"
+              }
+            }
+          }
+        },
+        "headerCid": {
+          "/": "bafkr4idauz6dybed5ke35r4smjlkp3rhne34kve7gn2b6c4sbk7qhdrhq4"
+        },
+        "metadata": {
+          "created": 0,
+          "modified": 0
+        },
+        "previous": [],
+        "version": "1.0.0"
+      }
+    },
+    "bytes": "Cza5T+uIf+6zBPzXJcYOTSgpGd8O8kMRKVEAGPlts5APSVvpUjmGAoIoaPPmWZv3Eeo6NeHfnK0916Dhh4MgXqhjbyoMBjvyaXjNe8paWK7qALGaiKzNa7oLLpuvw9vRYXicGCpx/GCGzLORDs3VVZqJ3dnZiD059Lxmm56qGnoQWYeT0R1K5iBwyJEyxR1HEHOuOEoZo3hRvF24mBQrbBU7ky9G4EvNA2wvMWuNcJ/63DcpMW3rbulLG+Ngfoe2DMY63j1UGfk/yHzHJHcJJ5ES7lxrTC4MVIfY3LHR/EwkgT2XyHObKuxX+tY8TN1hV/eiQr+sxmmd4EADAfw3KnY4UbQ/pIzZAHQgJr1No8Xakw/UyoYHNIw1LwHYWsTFEhxwc5ptE7L0NwXzil6J/sK4exITR7CbKTkq5/vDf+prfS+Id8YmkgDSf1W95Fo1V4g7DLPVjgJQQqT+n83OOEmKayjrP1mfN1OoMiQfSfCh"
+  },
+  "bafkr4ifwpko4yw7isbtjanffydqmswecgfxnlappwxiaig2xwln5lvdtzu": {
+    "value": {
+      "inumber": {
+        "/": {
+          "bytes": "QRni7HhhOb9OKJ/RnphwqkzYq1+eo7Qf4zwwIMeNhvI"
+        }
+      },
+      "name": {
+        "/": {
+          "bytes": "spIDAZGJKcmGiQzqOkSlfevPRmOkND7dmfxoKGSZn+L2U72swQgZWyqEGYFoBHkAOVfREN5puBpD39wif7cle1/NA6VmsEKTVVM2kOs9wWUj1ltUOjJdem6cIHGHKuuBfyT4cKkMeSlLIjO4G8plynMsnk2Wl06HATb9Z0OrarINH9Qja4dZ8LPIP7TqpKOjhmY4Uzh8VHb2/4J7LBKrTvu4uQAgZCEDixnZ0DlSCUtqEtVM7pz2E3esfx2EJtA8Jxu/wVwt1ca82sEpkZYKIqV8qxK1Mt6B7Zm91fjm4MhtN6UkHBNZyn0IflhZphLmbIxlfcViPHEQSBq8+Z1pXg"
+        }
+      },
+      "ratchet": {
+        "large": {
+          "/": {
+            "bytes": "b7PHfJFquImGboCHvDVUIuasqPla7vum7OVpZjvwltQ"
+          }
+        },
+        "medium": {
+          "/": {
+            "bytes": "7+aipcV8QxNDi5CI5u3xNERS/26h7l94ZtxVji53mNQ"
+          }
+        },
+        "mediumCounter": 213,
+        "salt": {
+          "/": {
+            "bytes": "MlXknXWqPUtUIQ70Pc20OmddXfgd2u4lHRFt7GuDGRo"
+          }
+        },
+        "small": {
+          "/": {
+            "bytes": "Bu9qjHcXjCr6W69E2B64PVPhOEfEmvGXYd8+LbJa1aY"
+          }
+        },
+        "smallCounter": 116
+      }
+    },
+    "bytes": "hgqgfwPJVXinv16d2DlH2QlvfdnhoMcDe6DA+Kj8llR8DSJXaKgUZntG36x1hILy7cv/J1XKIG/JMMFDcVSuFP9t2Ji4K8g0zEgh3VXru+lPjEqzwyAhW8SLPfB6ihmWewYzN5ywavp84rS8Gy9LVW7FkgeoDQeGppKTEwUNjL5G3HZ7hmVcVdgSqp6LYH0c0XzSu555XFRMcOEenJNdIRdMMaVwMaAr4LbWBfkwE2rCFUwI+D/NUg/ByDRH/ki7yVaK4OCFrAZOKeoJVsuSND52gH/fe5a6clujNdpQcLE4zdLcrnGe3DRFrizbBs9IUo/KOvO61ohC2teg/vV25k6o7WKISDor72QB+TUOuek1Y2cS48jnIYVfmOdAhheaC2zT7ooT7AJTifAbV98SpGrLzUUwv3i6K9KGRwE3nmqaLKNoOcu9VB2nAaFDF9oCIrO+rxf962u3VJXbXC460NtDYY0UOq4E3Brz6s2x1cbH2Z1m236Xh8GsI1JCNwy3Ca3bmtGh0Dkwjlmim33NRYWoI1c4LXqmm6iEt60FL6nt68n6L9XaQM8M1rG8RvZBLpOkz6FD/SX5PWMJrC8cQbQEi4VrkxIjFh9YfTeU9gGtxyjs/sKGtYjo6/m6403GJa2GDqA86MSmzvfPVQr3bEZ5DSv0ZqysW/NBzVLoURmaxdHfG4UQbQ=="
+  },
+  "bafkr4ig24orkcp75447hy2abpan36i3woaerfsg6bnu4z656d6xpa22jsu": {
+    "value": {
+      "/": {
+        "bytes": "SGVsbG8gV29ybGQ"
+      }
+    },
+    "bytes": "XfKFnyZ9B/oCShlpO5aJQzasQmcQIQpAbn63DLcIBTFdjX2mYM5HJkXCjt+et7E0+Aro"
+  },
+  "bafkr4ih5lxxbjlcpfp4ndcc4tr7d5thvzdppk6nt53zsyvpcbhl4hr425i": {
+    "value": {
+      "wnfs/priv/dir": {
+        "entries": {
+          "music": {
+            "contentCid": {
+              "/": "bafkr4iahkw3bjsjkkrx4carbnlqd7u3ajgwsr7uiwymkeyjijd3mxbgnkm"
+            },
+            "label": {
+              "/": {
+                "bytes": "aGWX0GpZvcnxqd7q2cUqQegdZp27yUr2swAdgaPWzVo"
+              }
+            },
+            "snapshotKey": {
+              "/": {
+                "bytes": "5X7tyBMCXzOlkKCsXIbFLWcXexyUQj0hZUIKtp4Wxz8"
+              }
+            },
+            "temporalKey": {
+              "/": {
+                "bytes": "F46+nL5NLAa7hPDhWqejs7sWL42jPBbnr+ERUXGAyjmOPchbLDIdJA"
+              }
+            }
+          },
+          "text.txt": {
+            "contentCid": {
+              "/": "bafkr4icvi4lg2wwglhr4ultusrny5iljt6bprow7c52fr5dynx2fr2gtja"
+            },
+            "label": {
+              "/": {
+                "bytes": "JG9ZrFxGFpui2wPLVOBmJsoo5/wI22ojfHiR9y/bhpM"
+              }
+            },
+            "snapshotKey": {
+              "/": {
+                "bytes": "P0JI2br1vLOnHBj+FvdhqShwftCZmMbk4ev+kVeU8oo"
+              }
+            },
+            "temporalKey": {
+              "/": {
+                "bytes": "0mdxowC9s8LBOHOWL/H/yL8IOqpGn9jtLO8kjKeLFoiiJp33clLz3g"
+              }
+            }
+          },
+          "videos": {
+            "contentCid": {
+              "/": "bafkr4ieckqbufxfkufnr4i6yhbq2qklhm2mhdw4twu4iiutsy2hslcgf4e"
+            },
+            "label": {
+              "/": {
+                "bytes": "2F1+dbdM+WJO7gekBFL3IKV7PxHHEep2BY8OC3FVQrQ"
+              }
+            },
+            "snapshotKey": {
+              "/": {
+                "bytes": "ncNrAzuzVnDzGUSeEtE4x+3ahIoEflbc7y3KcTYfnic"
+              }
+            },
+            "temporalKey": {
+              "/": {
+                "bytes": "D8R7Iuad+1HW+9NI4pbFRQuAHbqTPCKB+Ipjyee8MApkjeh3zEFf5A"
+              }
+            }
+          }
+        },
+        "headerCid": {
+          "/": "bafkr4ie545cdu4sbij7mlt5pcwkfd2m5fzekz6akcbs6tm63b45dl5mtba"
+        },
+        "metadata": {
+          "created": 0,
+          "modified": 0
+        },
+        "previous": [],
+        "version": "1.0.0"
+      }
+    },
+    "bytes": "2dCKfxMwtLYKoHGOWQffL7tjJ8bbRdU7a0x5374pwy5cjcGVt56PntkCqWbSJDh72nnN58BI2myQOfp18zbvAgkjLXGao99wr4qR8ihsuUpWO8u5lnmQIAlGd0psgOJUvnSHZAcSQNs8QBGzQG5fzeduVL5atpjy0pxqGT4Ma/2k8Ov5otfOEuOF2UHFjol57tyLaRtIitIUdUsHg2TFa1C6dX4001xXv3wRDLq3BuwIoL1rlXZIYshRt0/1XWRjtyiFngfZGHulk0Z3TH9own31WsXHThcxNFGtyu+b4eaPyvP0D8kC6k3bVd6+QDL7mB2f0SixhfZwZzyRUrXt+STc1GG9as/LQbOZDAdJQtW+8SNtC+G083XPn7wY8kNSoK4iarXOLYNpwWmam9yhW2leKQWPAyJR/A7c6587dCwqfn6S7APae6A6+GgXs8V8z7IBBCqbwPfA8aMTYowdbeY89kOEtjOlDovbaIGcyFbMLxht0xug0spt25UMefcc/VZrgD8zL9L6GmBpTIUkle3RfWuiW0hnMCXk1rv+D5311g/3oNowA7CTGKRaevg/9ajPnJjGLVAkIjmv0jl9AnkwQ2TMc/cav4VW9BrHpmSCA8L+Z8IrC9Ik737+VSBdY1TRZXavnKdJslr1z6SWIEm2K05b8TMJi6lNbteazNcTbHzGkxDeJyf4BJdwjrRYzvw/1B+umA0TY9u0O3+GW3uLJcGR0v4TNQz3YHkrETMkFpZ/Ul6Npux6eqJrtANxMnog++U4ZaPfcCYY5bo5D32HniWmyOAVjzo/Qdh7WQ9iX4PJM6aFNH9M9Rt9a1K7teOE4zLp/90wapMru47CC+A8tjTYUFvcAcRGGfDCfqCArju4ZB6xwe0Nr3J+1F91ixdjVW3/f6KHX6nPUlWNSfrTIUZt5XGVDiGu5VVw+wiLyYwSREqnL/pzkwfTkPerxbJXHFurh13rc3svb0WMYespJJOsh+ggfEtoiKbDLRsA7dD2qucFAMz/CA3hgsDELcQ="
+  },
+  "bafkr4ihv4pskefqdbao7ugf7gsmnks7r6k3pezkzkgtwi2qz7tgbrrv2pu": {
+    "value": {
+      "inumber": {
+        "/": {
+          "bytes": "1dSdp4eriRvkC3nrEaXnGw/bSS10IsOKfNJEaxLTuts"
+        }
+      },
+      "name": {
+        "/": {
+          "bytes": "tUCUwv43o9ajn84gq0Gkow6PtTAIDe+uuViNVctIs4XNTnM6fi3Hk+X9eNJnIr5o7lvZr9Gf0DiENsQ/p4Vm9rtLP3KS2Hw1EBs/lLgqazbbK4At5GGgBhUL+NSvKJ1r2pX7urxx4iQy1Ag8i1zII143TuzFBe5nuN8jMLGMbLzAEuDwUTRL9bOCFdjJHvzbslyvMj6S60qqoNzxO+fgbvj0bRWaPaZvKCvdj/gTlaIcVOJ+jzR3ULoofORvPvcnGaC6XDqVL6wIShN/f7QgFRi05r0FcmIEP3ekAuA76KtA+ubULRMQg+JUMIi8srkckPaYlo3a+KvQ5TWroIXwdQ"
+        }
+      },
+      "ratchet": {
+        "large": {
+          "/": {
+            "bytes": "GJqV9EMwaCbW8We2glA8bmgKkW5fv/bad0Ur8b+fvkI"
+          }
+        },
+        "medium": {
+          "/": {
+            "bytes": "ZK2XGLHMoU5tLdTlXGYR9T+/nCf6h8iLKoJORu9qC/Y"
+          }
+        },
+        "mediumCounter": 225,
+        "salt": {
+          "/": {
+            "bytes": "YuR9jMoolPnCxP1IUZDVuuXjvducRLiIJHWGwoB9VAw"
+          }
+        },
+        "small": {
+          "/": {
+            "bytes": "CTVUMi4+gZVMOAECcB2vCDYflrCxctMqOcFuKpV7j7A"
+          }
+        },
+        "smallCounter": 233
+      }
+    },
+    "bytes": "ZlEKh2O7d8LUfX5+2QuuB5whRET4Jyn3Voe/AbRBjWh+gTPiYDUrI0ABvy1tiw291mtslGNHd8OS4a6PPR+xBQb7yBRiZEqnhIZ+8Hg9RYNgqhH8/e+N4G04k6AJkLyqaQpot9xlP6kYPVRZAwIaIpy1ylg6q2+MUb3GEydpYHR9vmq70VXnPU6fccFl7A9Dqo7K6rZYKy6OvNFG/q0tCUivNLfM4varGfBys9F8qX25pEdoqox3pgwvFUbLVEeQhtYOv4wKreYl5zF89n+YehSbUuTjCy5aJkKPHZZdEBQEMGH5Og73z7W2LrUZVyUtjwXY9Bu+SPPUieOSMy4D/xK8nbQ7DjxnJpLnb6ADCktl9A9rHoVZLWlWpndI+T76AZ8GNYPWlaIa0W1U4oPS5JZntAxoVA5YQexRetl90v3f5yAODDJUaV8Uumhx1b6umFNU/SMQxcubUsm83Wasu7+8o6yxpdWPmxh59SVXKD+5jCIyO+fy+PJyVI9h5VmLQsBL2TZ+NGR4IWHn+aD/+VjfdyxGuq2henESHMfvODLWVrmYA7wGMugby5UyzfgCQCWnNPhzdQahKT9HUmvY+IXxo0vrHFzqw0GAVLfBD2Qz9efpinODCR2HUJZHxQwtPI7Vl+ZCcBxszI3ktmLd8GS19zDj4KMaVdU4GNq402+9wUJYwFSdQA=="
+  },
+  "bafyr4ieueemmhjoepyzkqzg4c7fuxtmavbvpfm7rhirqtwzm5fatt5e2s4": {
+    "value": {
+      "accumulator": {
+        "generator": {
+          "/": {
+            "bytes": "DnwXmD/vORPcLzdf1evo7nGljNInOtYHpODrD3+82Nnpu0qfQPxFLKSB2dhylrLkh4UmTnLZtphq+jBbSjrWkqRf6C/qEToqzAhkAPtkF048lnLaI3UjBCXagQjJv8boXybWdaxiKxTFN2nu9B2vzNyUl1QqO9wXmNkzWM1P4T8lIm6FTjWSbHg/TVTXkpv8nTgQIUA1A0Kk7jEtjb/Vl8VdTZ2UgBywKE1Pvf8HbmXDc6Cjg0K5+XXC6SW1Bk71iLdLM174Mu8KWDjb3qotRpqrGGeSIv1KI1v1VWCI8ZuohkVe4zT5JvzyKIizsVDKcPTKGR60H6enSeQZgShFww"
+          }
+        },
+        "modulus": {
+          "/": {
+            "bytes": "x5cM7tzDsHVEkCAaeqYTzXOREIHHkPXxqHJvRjVQu1t/8NuOHqEYnscvk9FlABG9chrurMKs3jKgQQfwZIwoE6MfWwt3Zf+LRLS2/8kzhLZG6wnHz16FktQOozyAA581tPFKBLUfe/14G+TRZzFkuo65kcLE1zC7vjX1kr3vUkr36Nrv0mxm/ALEea+J1k03P0QnCUOd5mzrlV8+o31RWfYTWAn4UzS1yxgTrdyAzQVgnxCsapWtZYcskJUlva0yvHKVkmQpIPJMYdxbPDt5I+VrFqTZ03PYch8ko/wPGzEx9VYVFyhmvMww+VBUyCTnM6XraBf3vBY5nUjGNhzH5Q"
+          }
+        }
+      },
+      "root": [
+        {
+          "/": {
+            "bytes": "VnE"
+          }
+        },
+        [
+          [
+            [
+              {
+                "/": {
+                  "bytes": "uE7mETpW3d42MqZL8pokFoXyEZ97lWi7crrah6Q7xITXZr6SnB3aiZPS7W7naVN0mcBeu0j6BpNA356AfdGnkzWTlhSxB8JMKN9BsoKCeftBoMIUdn4OVnyBHMFHDIcjjN/rzJ4KMQ5dunwmFlnXkiA9GD7lQ4f075+VC2QHKZxFGgn8cDzPjiekpvvI7uZBfcG9i3PnbXNdYwFu7zfKsk8vuqOpHy1P/3KHx/Rn7D+chPkjhuqAmMPpWe/Ykm7saULCN+cvrx30+5d+jkoNr2fDzEtRr2df80mKjIjF8xHcmbtKjgoDyrheIV0kIRTcpQlo0Mq3wyti2UBHrqXhcg"
+                }
+              },
+              [
+                {
+                  "/": "bafkr4ie3mpzembun2s56qmyyykhc6n7vigtahdgx2cx2wiozhshnvwp5ly"
+                },
+                {
+                  "/": "bafkr4ihv4pskefqdbao7ugf7gsmnks7r6k3pezkzkgtwi2qz7tgbrrv2pu"
+                }
+              ]
+            ]
+          ],
+          [
+            [
+              {
+                "/": {
+                  "bytes": "RJsvCmbJRpJcTNr1lk76weDT5vFYaD0Y+q90sMk2Jsjg+Fk0mTIISrUIuQ2WoHvsMCbp8WU2Uc0eqjtjWcTgO6pIpjkQgsE4OqPZGYobDcxQ1WKmNjlzedO3jBe34RQe0cl5QhXy+sNiRIZtgclwn9ehVgFvDTMZL9KRLyNzPUQhtnE5ACqb0o6DumysDwOr47YuDaBeffu1jRgLllmIuBcYQlZaYiV4dR5Jm1ICv3Og6tRNjsjKre3bHycL9JLADFjS5hMMD2x7uBJv8ekDpprGFtbQ2adLVcRnQweZQDrbSuGQ77XCbCHJuXaNEGvo3FEVDmuCwHiGjDVVffShtw"
+                }
+              },
+              [
+                {
+                  "/": "bafkr4ibpzyie2yheabo4axf3mwr5mft5wnf7ut4xxqbt54mpz4rqu7tb6i"
+                },
+                {
+                  "/": "bafkr4icvi4lg2wwglhr4ultusrny5iljt6bprow7c52fr5dynx2fr2gtja"
+                }
+              ]
+            ]
+          ],
+          [
+            [
+              {
+                "/": {
+                  "bytes": "VVdhKfEGHezv4/sqZw3tpoWOfftXkXLvSOuA7J58NU1+zC79Zr3eLvuSRGU9K8kwbmtP8FkFjwzwmAzMZn5eKwZJqdlkhLcQZXNUFsj2LZEXlBRc6mN+Pfop8Qt4R6z1tUgY0anqfONTny3tCVZ6/3HXm7ioUFedzGNvR65gA3Ky9BPMlXRypmepgdvj6PKzkmZLROF+65sDdVKdyci546h+x6idYK5UsSZtRmI+dixTvPoahoszXTYv/EP5Jj4fIYrlo6sRmNojc+KjDIV3S1aMm41S2rZKVb5pTESNvbUHY8okn2sXBhwCq/+x5F1LhQTvMYDz1ewEgR9nuDex3A"
+                }
+              },
+              [
+                {
+                  "/": "bafkr4iczjy3vg4v3snxzouqcf7hos3gta5ewwrqh6sp6243kp6nlxv6axi"
+                }
+              ]
+            ]
+          ],
+          [
+            [
+              {
+                "/": {
+                  "bytes": "UisykGslFxwF2WKF9DBoOycmcXq/1fya/MtwnDytGb+hNqmpOHS5LI/oNIxJgz15b8d+ALkbCw0JkMOVkhL7xtEWBqYQ2DitmfT4ffVajUYgO9VcbPjusQdgw279Q1iMXpxdH1Po2Vr0//oRU7paZuGlXD2xEdK4ZDRB2KZyYVyTxpZyEXOn9N8m9hMZFNLZn626ZpVyVuox5d+iGyzRPiGcQkFgRDd4vlA1C7beyDNnpC/Jnke8pe5v0NnVNrwhTsdtgpe7+x/kkBT4X9a7PY3zvZdBeZxXU5PQisycQ9UrCdtbMuOmM9Y5YQtVcXHl0RDNAKuUc1ah2HcksCS1Ow"
+                }
+              },
+              [
+                {
+                  "/": "bafkr4iahkw3bjsjkkrx4carbnlqd7u3ajgwsr7uiwymkeyjijd3mxbgnkm"
+                },
+                {
+                  "/": "bafkr4ibc7yjsk2mjyr2etnxbcfovouvnmhgeif24luew67kk4urog3elc4"
+                }
+              ]
+            ]
+          ],
+          [
+            [
+              {
+                "/": {
+                  "bytes": "h68NEmBBszWXhvh1Hb8i28Me90g9/VpBVtkUZ/+XHlOqB6qNY7Eyp9eK/2ieoKbxLw5RGlysQi+GNcM+l3mQWIZSE2H5qGfBbsghr+BUdjrnMCs+AMUQVPwMOwY0WSiYfomsnkSpznDzbus0nxXca9vUxHPuIiIUGM4iiolooFxq200MK1hUqk9P/De/KSyzlr5F5OIqm8Z3zMoeUU97ugJ9t3hzS/MSeLHkmkqBBjgnA4en8jWxa8d+Nrcpjyb2osNfzIGfoRNLpTPH3GdngD2jZv8Z1dLzipKAsyQCzsP/aTSBrQgYEJ00NM4uqgyn3/OJBkl41rjUur9V6X62tQ"
+                }
+              },
+              [
+                {
+                  "/": "bafkr4iabb422gnp45fdjd4onr567olqprcl53oblnyima3oenyqvae3ifq"
+                }
+              ]
+            ],
+            [
+              {
+                "/": {
+                  "bytes": "fxga5w2tdc2rDyh+yOnXXsnCxaUYUplBPPqB9s9jYCp9F1Ji9zfgRBTWvBa8Nn1OeE2iYEkH0hi1FQnyznuut6Fuu9/LvE57F3oYmgCbu1UPVsexQU5mNlKgI7IhU1E4swV0HnAJWl/JbxLmXi0fvYzK1sRMOFGTil1tkMLZiWiDnbxAsyaiqoKyWUxhGX6836+atRUZcM0mDvc1rMQE3gadxf17ogD+qMCmtMWNiKxcq2Ju4x/9xNpE48m4r2AxyB3+jtO7IKVTytUYJc5u2lSG/tOF72Psqz0Ogog6onPcSCxSFX2iCEk4yjjttbqqLUEDlqG8r6EBhqdbF3rBdA"
+                }
+              },
+              [
+                {
+                  "/": "bafkr4ie545cdu4sbij7mlt5pcwkfd2m5fzekz6akcbs6tm63b45dl5mtba"
+                },
+                {
+                  "/": "bafkr4ih5lxxbjlcpfp4ndcc4tr7d5thvzdppk6nt53zsyvpcbhl4hr425i"
+                }
+              ]
+            ]
+          ],
+          [
+            [
+              {
+                "/": {
+                  "bytes": "XQo1Fvfc0JTU+MyYeTNmWqZPu2VtK7XmN6EZglIIpczYAvr9KYbG9yT2yX8EeZXKVsK6e4P+LKf3LxhO1lMr1yh4q41FqpyOqUNE6h+Ai+VDSE/pdLeNQOveGc8S3gswhNMg50qDuBv2SrbQvUsVdq32e6hOJkgOyGhqRlcQJv8Bq5phquH6/st38NruapLN8BupS6sLfoO8inQDibJe1bjvNlJFYTIWcBLKYvtx0odEryUz+snQ/DRVPhsuKUAWh8QUNuusc3dCeR5pZbB6WFfuShZ+fHU38uqToxoJ6Ye9JHmuzHOV+6cybtvdg9X9vbKWj9rLyENleyLsDeSX+A"
+                }
+              },
+              [
+                {
+                  "/": "bafkr4ig24orkcp75447hy2abpan36i3woaerfsg6bnu4z656d6xpa22jsu"
+                }
+              ]
+            ]
+          ],
+          [
+            [
+              {
+                "/": {
+                  "bytes": "go3eRDE/zMYW/7rtRG9un5GFfgkpNikrt8YUmdUTxsYHdoNIlzhGHpOo4y+v0ua12Uq3hjOXnqm+VNgwB3MhaMW4Nj2jsS4HTlOMV0tcOO4v0gpY/R81R4ZJYSr+rV7XbCH22km+3sX/A3wPS+OursCpIgyFKpOehEkxxRlqBVB9NVHhCCPz01A4NvZSrso+QgHrB6KgI1n0GzKVo7t/oGJfJHfJ3rrrFHw7XItFkna166hQ8Jra6AQ9pPXpMBW8eIRjZ2IBk1mmuSkTmABtb0LoRo2ekTsy6Kk7nZXOfr13iHqjSpCWXtGSpY8MmNTiBxjzVyD7CYGPxifysNL8sA"
+                }
+              },
+              [
+                {
+                  "/": "bafkr4idauz6dybed5ke35r4smjlkp3rhne34kve7gn2b6c4sbk7qhdrhq4"
+                },
+                {
+                  "/": "bafkr4ieckqbufxfkufnr4i6yhbq2qklhm2mhdw4twu4iiutsy2hslcgf4e"
+                }
+              ]
+            ],
+            [
+              {
+                "/": {
+                  "bytes": "YFDfWTiHewo15PZE2qQurtlH5ym1s4CSTSJPpCBNReDQo3TunurbYZsmImXBWPcG6ayH2wx2Ye9EyIDowxTs40FSX9Vv9nQpUPSTvXLqxNmcaMj0l06fgUUwzRi24QzdN65W3tlqdyJaLXLUWmXn4jqX6++yJGhAjAP7uQY6PKefiz5pcSYzvAnLBPbeips6n5DQX22lwbrypGW3svTT9RJY4wOwQzmC/YtuoVcjOjRc41UD6oSjeAaYQYLlGdhfLrZwwuIY6lBkJokWbUcCHm9NAt3Um5SBGNtkS9tFf7lEqBAJkAXFpxxfevE3mV+yhREKjv1yYt/3Pq0B4RN4OQ"
+                }
+              },
+              [
+                {
+                  "/": "bafkr4ictjgvf6likl7mkpnrzb62d3ncrrychx6wbjvkkiaj5iaqpa3jo3i"
+                },
+                {
+                  "/": "bafkr4ifwpko4yw7isbtjanffydqmswecgfxnlappwxiaig2xwln5lvdtzu"
+                }
+              ]
+            ]
+          ],
+          [
+            [
+              {
+                "/": {
+                  "bytes": "SREHCF/L8i73hPyLMceTbgIVy+esJIMtVbvURjZpRqzU+wlnwc89qS6UMjw/MUMcNEK7+xt4mCvcYvLzU1ydWynudx3+RI+3tLpSPJNLFcu7KblIlXrtgkGGSoZnwju8icrSBVWMCGHTES0Emg9xaAT5GfQEjO9OMpGPShzi92K0aJ3uj4ab5Fwq9NXCWZi/VWhEe+UGB8a6n4TTooIcUzsM3H3MOXlKPkeBC4LMZZkZeGqPEWshtcMbV6cCgXf+XREiYHd9D92HFjHNCZietqAQ1M9UHZP6tv3BJKJVSu1Zw6hXZWSV1dXTshPL5C89Qe3PdNa7S7ZJU5KOwrF9YA"
+                }
+              },
+              [
+                {
+                  "/": "bafkr4icard4qkcqguebyyia3issfinnfywggaohgq46cxvznv4lsrd67qq"
+                },
+                {
+                  "/": "bafkr4idfnx2wtvhgyjwixz4xv6bzbyqv3jaf5kw55ayi2zccrlhwqt4sva"
+                }
+              ]
+            ]
+          ]
+        ]
+      ],
+      "structure": "hamt",
+      "version": "0.1.0"
+    },
+    "bytes": "pGRyb290gkJWcYiBglkBALhO5hE6Vt3eNjKmS/KaJBaF8hGfe5Vou3K62oekO8SE12a+kpwd2omT0u1u52lTdJnAXrtI+gaTQN+egH3Rp5M1k5YUsQfCTCjfQbKCgnn7QaDCFHZ+DlZ8gRzBRwyHI4zf68yeCjEOXbp8JhZZ15IgPRg+5UOH9O+flQtkBymcRRoJ/HA8z44npKb7yO7mQX3BvYtz521zXWMBbu83yrJPL7qjqR8tT/9yh8f0Z+w/nIT5I4bqgJjD6Vnv2JJu7GlCwjfnL68d9PuXfo5KDa9nw8xLUa9nX/NJioyIxfMR3Jm7So4KA8q4XiFdJCEU3KUJaNDKt8MrYtlAR66l4XKC2CpYJQABVR4gm2PyRgaN1LvoMxjCji839UGmA4zX0K+rIdk8jtrZ/V7YKlglAAFVHiD14+SiFgMIHfoYvzSY1Uvx8rbyZVlRp2RqGfzMGMa6fYGCWQEARJsvCmbJRpJcTNr1lk76weDT5vFYaD0Y+q90sMk2Jsjg+Fk0mTIISrUIuQ2WoHvsMCbp8WU2Uc0eqjtjWcTgO6pIpjkQgsE4OqPZGYobDcxQ1WKmNjlzedO3jBe34RQe0cl5QhXy+sNiRIZtgclwn9ehVgFvDTMZL9KRLyNzPUQhtnE5ACqb0o6DumysDwOr47YuDaBeffu1jRgLllmIuBcYQlZaYiV4dR5Jm1ICv3Og6tRNjsjKre3bHycL9JLADFjS5hMMD2x7uBJv8ekDpprGFtbQ2adLVcRnQweZQDrbSuGQ77XCbCHJuXaNEGvo3FEVDmuCwHiGjDVVffSht4LYKlglAAFVHiAvzhBNYOQAXcBcu2Wj1hZ9s0v6T5e8Az7xj88jCn5h8tgqWCUAAVUeIFVHFm1axlnjyi50lFuOoWmfgvi63xd0WPR4bfRY6NNIgYJZAQBVV2Ep8QYd7O/j+ypnDe2mhY59+1eRcu9I64Dsnnw1TX7MLv1mvd4u+5JEZT0ryTBua0/wWQWPDPCYDMxmfl4rBkmp2WSEtxBlc1QWyPYtkReUFFzqY349+inxC3hHrPW1SBjRqep841OfLe0JVnr/cdebuKhQV53MY29HrmADcrL0E8yVdHKmZ6mB2+Po8rOSZktE4X7rmwN1Up3JyLnjqH7HqJ1grlSxJm1GYj52LFO8+hqGizNdNi/8Q/kmPh8hiuWjqxGY2iNz4qMMhXdLVoybjVLatkpVvmlMRI29tQdjyiSfaxcGHAKr/7HkXUuFBO8xgPPV7ASBH2e4N7HcgdgqWCUAAVUeIFlON1Nyu5Nvl1ICL87pbNMHSWtGB/Sf7XNqf5q718C6gYJZAQBSKzKQayUXHAXZYoX0MGg7JyZxer/V/Jr8y3CcPK0Zv6E2qak4dLksj+g0jEmDPXlvx34AuRsLDQmQw5WSEvvG0RYGphDYOK2Z9Ph99VqNRiA71Vxs+O6xB2DDbv1DWIxenF0fU+jZWvT/+hFTulpm4aVcPbER0rhkNEHYpnJhXJPGlnIRc6f03yb2ExkU0tmfrbpmlXJW6jHl36IbLNE+IZxCQWBEN3i+UDULtt7IM2ekL8meR7yl7m/Q2dU2vCFOx22Cl7v7H+SQFPhf1rs9jfO9l0F5nFdTk9CKzJxD1SsJ21sy46Yz1jlhC1VxceXREM0Aq5RzVqHYdySwJLU7gtgqWCUAAVUeIAdVthTJKlRvwQIhauA/02BJrSj+iLYYomEoSPbLhM1T2CpYJQABVR4gIv4TJWmJxHRJtuERXVdSrWHMRBdcXQlvfUrlIuNsixeCglkBAIevDRJgQbM1l4b4dR2/ItvDHvdIPf1aQVbZFGf/lx5TqgeqjWOxMqfXiv9onqCm8S8OURpcrEIvhjXDPpd5kFiGUhNh+ahnwW7IIa/gVHY65zArPgDFEFT8DDsGNFkomH6JrJ5Eqc5w827rNJ8V3Gvb1MRz7iIiFBjOIoqJaKBcattNDCtYVKpPT/w3vykss5a+ReTiKpvGd8zKHlFPe7oCfbd4c0vzEnix5JpKgQY4JwOHp/I1sWvHfja3KY8m9qLDX8yBn6ETS6Uzx9xnZ4A9o2b/GdXS84qSgLMkAs7D/2k0ga0IGBCdNDTOLqoMp9/ziQZJeNa41Lq/Vel+trWB2CpYJQABVR4gAQ81ozX86UaR8c2PffcuD4iX3bgrbhDAbcRuIVATaCyCWQEAfxga5w2tdc2rDyh+yOnXXsnCxaUYUplBPPqB9s9jYCp9F1Ji9zfgRBTWvBa8Nn1OeE2iYEkH0hi1FQnyznuut6Fuu9/LvE57F3oYmgCbu1UPVsexQU5mNlKgI7IhU1E4swV0HnAJWl/JbxLmXi0fvYzK1sRMOFGTil1tkMLZiWiDnbxAsyaiqoKyWUxhGX6836+atRUZcM0mDvc1rMQE3gadxf17ogD+qMCmtMWNiKxcq2Ju4x/9xNpE48m4r2AxyB3+jtO7IKVTytUYJc5u2lSG/tOF72Psqz0Ogog6onPcSCxSFX2iCEk4yjjttbqqLUEDlqG8r6EBhqdbF3rBdILYKlglAAFVHiCd50Q6ckFCfsXPrxWUUemdLkis+AoQZemz2w86NfWTCNgqWCUAAVUeIP1d7hSsTyv40YhcnH4+zPXI3vV5s+7zLFXiCdfDx5rqgYJZAQBdCjUW99zQlNT4zJh5M2Zapk+7ZW0rteY3oRmCUgilzNgC+v0phsb3JPbJfwR5lcpWwrp7g/4sp/cvGE7WUyvXKHirjUWqnI6pQ0TqH4CL5UNIT+l0t41A694ZzxLeCzCE0yDnSoO4G/ZKttC9SxV2rfZ7qE4mSA7IaGpGVxAm/wGrmmGq4fr+y3fw2u5qks3wG6lLqwt+g7yKdAOJsl7VuO82UkVhMhZwEspi+3HSh0SvJTP6ydD8NFU+Gy4pQBaHxBQ266xzd0J5HmllsHpYV+5KFn58dTfy6pOjGgnph70kea7Mc5X7pzJu292D1f29spaP2svIQ2V7IuwN5Jf4gdgqWCUAAVUeINrjoqE//ec+fGgBeBu/I3ZwCRLI3gtpzPu+H67wa0mVgoJZAQCCjd5EMT/Mxhb/uu1Eb26fkYV+CSk2KSu3xhSZ1RPGxgd2g0iXOEYek6jjL6/S5rXZSreGM5eeqb5U2DAHcyFoxbg2PaOxLgdOU4xXS1w47i/SClj9HzVHhklhKv6tXtdsIfbaSb7exf8DfA9L466uwKkiDIUqk56ESTHFGWoFUH01UeEII/PTUDg29lKuyj5CAesHoqAjWfQbMpWju3+gYl8kd8neuusUfDtci0WSdrXrqFDwmtroBD2k9ekwFbx4hGNnYgGTWaa5KROYAG1vQuhGjZ6ROzLoqTudlc5+vXeIeqNKkJZe0ZKljwyY1OIHGPNXIPsJgY/GJ/Kw0vywgtgqWCUAAVUeIGCmfDwEg+qJvseSYlan7idpN8VUnzN0HwuSCr8DjieH2CpYJQABVR4gglQDQtyqoVseI9g4YagpZ2aYcduTtTiEUnLGjyWIxeGCWQEAYFDfWTiHewo15PZE2qQurtlH5ym1s4CSTSJPpCBNReDQo3TunurbYZsmImXBWPcG6ayH2wx2Ye9EyIDowxTs40FSX9Vv9nQpUPSTvXLqxNmcaMj0l06fgUUwzRi24QzdN65W3tlqdyJaLXLUWmXn4jqX6++yJGhAjAP7uQY6PKefiz5pcSYzvAnLBPbeips6n5DQX22lwbrypGW3svTT9RJY4wOwQzmC/YtuoVcjOjRc41UD6oSjeAaYQYLlGdhfLrZwwuIY6lBkJokWbUcCHm9NAt3Um5SBGNtkS9tFf7lEqBAJkAXFpxxfevE3mV+yhREKjv1yYt/3Pq0B4RN4OYLYKlglAAFVHiBTSapfLQpf2Ke2OQ+0PbRRjgR7+sFNVKQBPUAg8G0u2tgqWCUAAVUeILZ6ncxb6JBmkDSlwODJWIIxbtWB77XQBBtXstvV1HPNgYJZAQBJEQcIX8vyLveE/Isxx5NuAhXL56wkgy1Vu9RGNmlGrNT7CWfBzz2pLpQyPD8xQxw0Qrv7G3iYK9xi8vNTXJ1bKe53Hf5Ej7e0ulI8k0sVy7spuUiVeu2CQYZKhmfCO7yJytIFVYwIYdMRLQSaD3FoBPkZ9ASM704ykY9KHOL3YrRone6PhpvkXCr01cJZmL9VaER75QYHxrqfhNOighxTOwzcfcw5eUo+R4ELgsxlmRl4ao8RayG1wxtXpwKBd/5dESJgd30P3YcWMc0JmJ62oBDUz1Qdk/q2/cEkolVK7VnDqFdlZJXV1dOyE8vkLz1B7c901rtLtklTko7CsX1ggtgqWCUAAVUeIECI+QUKBqEDjCAbRKRUNaXFjGA45oc8K9ctrxcoj9+E2CpYJQABVR4gZW31adTmwmyL55evg5DiFdpAXqrd6DCNZEKKz2hPkqhndmVyc2lvbmUwLjEuMGlzdHJ1Y3R1cmVkaGFtdGthY2N1bXVsYXRvcqJnbW9kdWx1c1kBAMeXDO7cw7B1RJAgGnqmE81zkRCBx5D18ahyb0Y1ULtbf/Dbjh6hGJ7HL5PRZQARvXIa7qzCrN4yoEEH8GSMKBOjH1sLd2X/i0S0tv/JM4S2RusJx89ehZLUDqM8gAOfNbTxSgS1H3v9eBvk0WcxZLqOuZHCxNcwu7419ZK971JK9+ja79JsZvwCxHmvidZNNz9EJwlDneZs65VfPqN9UVn2E1gJ+FM0tcsYE63cgM0FYJ8QrGqVrWWHLJCVJb2tMrxylZJkKSDyTGHcWzw7eSPlaxak2dNz2HIfJKP8DxsxMfVWFRcoZrzMMPlQVMgk5zOl62gX97wWOZ1IxjYcx+VpZ2VuZXJhdG9yWQEADnwXmD/vORPcLzdf1evo7nGljNInOtYHpODrD3+82Nnpu0qfQPxFLKSB2dhylrLkh4UmTnLZtphq+jBbSjrWkqRf6C/qEToqzAhkAPtkF048lnLaI3UjBCXagQjJv8boXybWdaxiKxTFN2nu9B2vzNyUl1QqO9wXmNkzWM1P4T8lIm6FTjWSbHg/TVTXkpv8nTgQIUA1A0Kk7jEtjb/Vl8VdTZ2UgBywKE1Pvf8HbmXDc6Cjg0K5+XXC6SW1Bk71iLdLM174Mu8KWDjb3qotRpqrGGeSIv1KI1v1VWCI8ZuohkVe4zT5JvzyKIizsVDKcPTKGR60H6enSeQZgShFww=="
+  }
+}

--- a/wnfs/src/snapshots/wnfs__root_tree__snapshot_tests__root_filesystems.snap.new
+++ b/wnfs/src/snapshots/wnfs__root_tree__snapshot_tests__root_filesystems.snap.new
@@ -1,0 +1,310 @@
+---
+source: wnfs/src/root_tree.rs
+assertion_line: 479
+expression: values
+---
+{
+  "bafkr4ialmvnmzmxxdw2bmichtupuohprsguaz27yw6zymk2oz6dd5reaca": {
+    "value": {
+      "/": {
+        "bytes": "KureFvu0kYp5e6Es9dauanzuUZVOnWFnWrXiDSrMN67FsZndLhfNsXRhGwwM8iUVm7sSAWvdMUkegIuRHDVvwhSrnZLONfSVljQ6XZOzpRBOLONt5YWKxe9op6IB8gPI9YKjzExL6zTuXPiobdz4BR9PVm5GQq/hY+rH51T/FLNOe/gO2RzAftu2z7rY97ftW87oANjNihyphZdljWzcrMwte2I9P3NiHA"
+      }
+    },
+    "bytes": "KureFvu0kYp5e6Es9dauanzuUZVOnWFnWrXiDSrMN67FsZndLhfNsXRhGwwM8iUVm7sSAWvdMUkegIuRHDVvwhSrnZLONfSVljQ6XZOzpRBOLONt5YWKxe9op6IB8gPI9YKjzExL6zTuXPiobdz4BR9PVm5GQq/hY+rH51T/FLNOe/gO2RzAftu2z7rY97ftW87oANjNihyphZdljWzcrMwte2I9P3NiHA=="
+  },
+  "bafkr4ib74rijhbp57g7dzkzcwkdoiv7e6ljbj55n2kluczgrcmrhzrfj7u": {
+    "value": {
+      "wnfs/priv/dir": {
+        "entries": {
+          "videos": {
+            "contentCid": {
+              "/": "bafkr4ifrt6o4xyjjivkfm43p5obpejrori4gfy4itkkrlhpstz2sqoqafi"
+            },
+            "label": {
+              "/": {
+                "bytes": "/utq/bjqBVKjDOyd4uoJYyiJUi+9udotQlWu1llBkvE"
+              }
+            },
+            "snapshotKey": {
+              "/": {
+                "bytes": "VLvB1/9ylAKfYDf0mHbyi9z4Lqm1ZccFZkDrAFvXsqE"
+              }
+            },
+            "temporalKey": {
+              "/": {
+                "bytes": "nTHPSaNnSW4u+wFakpIA4mlJmFjXbdmiLAzKn+DqVkWbjzg0qqMPHw"
+              }
+            }
+          }
+        },
+        "headerCid": {
+          "/": "bafkr4ibw46mmphjyyulwem6eofhjuuigt6o5gtwxxa4v2zurk52oogab34"
+        },
+        "metadata": {
+          "created": 0,
+          "modified": 0
+        },
+        "previous": [
+          [
+            1,
+            {
+              "/": {
+                "bytes": "KYJtvolOJtOn6zauh0CnwcihQWaXTZ21aRW1opLGt8LvxzG61LumZA14syfWaYNKstB7a4sVnrY"
+              }
+            }
+          ]
+        ],
+        "version": "1.0.0"
+      }
+    },
+    "bytes": "6isyNxx0srLIYzICld/UOoGiOZiAmQpJ6Dto2pz79VKRKVfYs++1t5DD2/qGiqpXFzewaV7rn2Iox7yrIs6PVgLkITyj0F1d7AK/PLbsHeweUCoW5tCmofUfJEL/S97SFaCF2f8DTNsKymXUo/x6AsF/ROaR6R75NtsEvw9EpL22vpf+jLXTS/clyjj2EsMZMbjSI0zqpuw2ggjPkounjg/6Xxe+qm4tSFYehLw9di1gaR4UFQ9WR8mI2EgyH7T7vTC3dok+vLS+AgsQ7z6imRMOVolXKBE/JsNSknhF0ga+VeeD4i1uijR6sLG7FZ3vftf+j6hAATvcuziwH5uniuGuwyVmuJlDTdhWybuodGdaap0/qMQsR7eQ8WZRKBO3hWJWni8cdJadbtz0TvwQmDKEK/8Q/9/X741Sd/dY8DL5vmdyEcAgjwRXg64VUZOBx1fSlpxG2vTAeVl7EXSrkEjhGMsOwiRdzjqKcUpTMbI2/B+XTvVf3HzP+vQoM8ZgFzHgZM0cLPqymBzplGXFtb2e+LgXTfyDThncQYCh6iwUYYDWRaHyNToFHORO"
+  },
+  "bafkr4ibnb7eh3y7k6iwpkhurjf5vb7awlz47h4iahjkmzltoc2ackni5m4": {
+    "value": {
+      "inumber": {
+        "/": {
+          "bytes": "1w7eB3rz9RFfjvjbVhYFfAiL4EObojRS1UPu6BPuM9M"
+        }
+      },
+      "name": {
+        "/": {
+          "bytes": "KIgXpOcthnIqZ2P8yKngSMdwP/CQCCXILxHK7cOYsN9rABXcYXU3XlvP9H69jN7jFRw60e1boXkdEZdqdA/bvCvKQPM0jq36Xct1Cv+AScR0dXb96o3WfUEQYdkD1dYGYD6qGUWH8lxn1nIcBjxwFuvEbCTZCrgg7Gk6yp1iPJ4UXVvOXppyqb+285ZYSdineLavZedj5atCdREy88RJ6V5lKkt4xsUoNBQPMc+i8BYWNUAwKoMpMNnR+3+U7Q4YhLjZSiZolWCnhIARfvtwgJUI25s3gCH5p69Qxpjz/Frd18ihov333N3BFyUzoP5M+8QExJy/BiDu1xJAC/2Xpg"
+        }
+      },
+      "ratchet": {
+        "large": {
+          "/": {
+            "bytes": "Vb1tWV9AhqWIYE1ICnHiWANgCwFwKKRuMUIP0OnP0pc"
+          }
+        },
+        "medium": {
+          "/": {
+            "bytes": "DuTEIA4KyE7IfgNvlKxIS7sCpQoab6QToceNd3qnFKo"
+          }
+        },
+        "mediumCounter": 26,
+        "salt": {
+          "/": {
+            "bytes": "SYZOkP3tc7/xlW1UPTvOJNRpGQEc6Cw+GBtGOMWUuqM"
+          }
+        },
+        "small": {
+          "/": {
+            "bytes": "qp6S8dJY5yA23lcZgxPM7uwGGbAjya4b6EXHuAUlDgk"
+          }
+        },
+        "smallCounter": 139
+      }
+    },
+    "bytes": "6ai0C1GSK+VD5Vqq5QunWOGG2J0uPinInjbj4CxW58yMWvkAqzaWxRyMoOd+JdePS/GruNyMwg5rumsBqgwQx/PBLMH1qj88maT6ZjuuuMCbEE0Gct6eVkfwXllcZ9atHrsFYerJyXJPZ/G35GlhPEYiKNrw3zbGr0OX+b9sWijf/C5AmaUAXVxfWDfnQvpDt5UkkTNdCTN8hqZKfFcx3FSacOBe2gsj0v+m2A1AGPhZBgidJ5gD816Thu0dvIebcO7M6fR3qHgwUrPDtL+O7wlYn9fq6YGtyR/9Tpe4j6hg/ChaU6JuIvtgkA6SJhtrreBUO9qKBo8vcin9uPmWWuifTiVe5Q7D09mhlLxNtC6DQc2Tcqtr1pQA6C+nxJiVgIxgscHyzkB9ZdJioQSoc8jicVPVrmvbNA+I0/zDWtybL8iDbUKIookhlgBvioATH6d4SCLgbguS2wVAe4JRUcRo155z91v9Z4ENht7N30F88zFg2C8hqLF1AgsOZbuxM4dTOdSScRYMyf46QqpuMwGVa4TCQcaupGhnB2YvShv8YzRT7+dmmlXZsulPiWe/J9eZQo2AGIEBduHljSoj2J9P5kOK2ysJjp9Qt0478/EBql9BqWKH9kpfUu+QTqtPaWP0yVszPjBjxWTRyeOO+DkU3eYUJKS4CX0YdxFgadKtYSg0tP2Y8A=="
+  },
+  "bafkr4ibw46mmphjyyulwem6eofhjuuigt6o5gtwxxa4v2zurk52oogab34": {
+    "value": {
+      "inumber": {
+        "/": {
+          "bytes": "aXOZfUYNJHjQJRqg6GYILn2Q1OpVYOIn4IWeONqvNPk"
+        }
+      },
+      "name": {
+        "/": {
+          "bytes": "dobIKL6WvlAGN4ZEQRtRphUMtQSIlLQTc2lxc2Je7kKkNq9ooldHWcd1NG55AEAWqCOGbH+Vf3AgX6hNtrutFa6e7KJ/rSF4pTS7uuk6r2G/zOQ1leVnIvVeW+CYE3lcWNPB1yA6WSbMgfia8UIS46rgtOrfsYkMSdRxpkltthEiWmyQ7ahaWZaRXelLksMTYfwLVks+XI+WqG4Bzinvr9cV8eE7uGtIFeK7n2IGyfEv8fpE4jyjlNc51A+j85+VAT21EvT4DNaQwLVQ5PYdSZ/7qHvJOJzDCiluIcmX6TKsQ+XHqNzI4f0oJdzYFCKBG+C5Tjte9T0JyEABfxdvjg"
+        }
+      },
+      "ratchet": {
+        "large": {
+          "/": {
+            "bytes": "9ywQE1NYvFOxpnkYyimeZLlHdo/JPfhWQ8ARmvR7f+I"
+          }
+        },
+        "medium": {
+          "/": {
+            "bytes": "yvO1gGRmolMO5jeGE7tjY26HiIbjJe8zu8b6OHf9Xio"
+          }
+        },
+        "mediumCounter": 20,
+        "salt": {
+          "/": {
+            "bytes": "J6dQrLG9Do1fdEEl6bBBBp3gASVKF4GyoRoIkB5mT2g"
+          }
+        },
+        "small": {
+          "/": {
+            "bytes": "blxep4f4qhR48Wqyr7uuGQh7cdqdWtXm2cjXLef36GY"
+          }
+        },
+        "smallCounter": 40
+      }
+    },
+    "bytes": "q45OIbkymHPMPk7FAdPkSvEcryVW9H2V82sYHaDmrLEPK3r6gT7DcNlhmjmUTFMjO0035ZGvr19ickkbNfUUuM7fcQg6pUoAo2pZDY15zuC0seXIEWsQfshRFS1cvjFA9Dtn5P9zDOnDsJrYKUTmqJJWnLbWYwPToJOpKjIA13viYPV8hMVTxHIP4sOoW6GYdqw4hAUXFm5uPBZlZ6zuIil5S8jtotYWjqryvb6UnrPBivRy6oeLUbJQSSrIRAL5ZD+wP4fXmle/FEnBwUBbVj+UJTElU7n8SVTCpAbOH48wh5n3ms8NLH047wnZe0RQAxbBAV+Iqxq8g/bxQtNgLDAA8in+y8MEzPWGrE4TCaWowPJrwKYp2SAIdRR8+wjbnZxuxqK3YC+rJ0dDQ93z4vJFs3NzOwr9XDFmNqzPb1f0J/nBas02NR3iwsGwPqpSeY4BFu6VXO2USj7nM4avHflXmZyqoT/6qYtHC38vEFTjWTtZDWtT/P2oIebe7pyR8kZ52eJRJAo9opPI4m4JE6i21cE4uXovn0XnBoawK21vyXQga+ioMk8rVBi8WbcmPXlUZ8zndE/DYl7fcGPTzbhoLdsiFpSBCdeNrsmv/Iu6QACM+EwGOzMwS+/MJwYw2s9qkNPvJdMBlwlDkP/4ueQLZMHH+J8h1LgNJun9jk69N2rlh83AIg=="
+  },
+  "bafkr4ifrt6o4xyjjivkfm43p5obpejrori4gfy4itkkrlhpstz2sqoqafi": {
+    "value": {
+      "wnfs/priv/file": {
+        "content": {
+          "external": {
+            "baseName": {
+              "/": {
+                "bytes": "DUUMhrPcVxAOHt2QgZNZz2qYQk5ni08z/fRelGwDBGzh+tmTfwKZgAki047508dETfAOpwbi/cv9zJEvZPW1HBI7kYimDMkQy4y0s5O9Xtzn6rP6Ei2Cd4Wmiz/NWJj31ZyylIYa9ualtbSfRVdi/mSjZvHYB+DjBhfSCDx8G6wk+cKnYE0uxhLRDaXKnkm1GG0nrtlg6URTnEfYKWAidkat6zEAPlZENHPoYIFuWHEBB5iQ7a0LJ8KPcOCoaBOvY+NXeGqGS79yA2dADvUZ7xAaaAc3yNB2fKX0hE8JjQXJJ0Uz0YeD81Kx1gzzoSNtiZMydTzl7a5zxv9GxjykwQ"
+              }
+            },
+            "blockContentSize": 262104,
+            "blockCount": 1,
+            "key": {
+              "/": {
+                "bytes": "jPTfK7QN20PpuP+PiA/Xx7ByqHW6bYcq7O/3vwNXMC4"
+              }
+            }
+          }
+        },
+        "headerCid": {
+          "/": "bafkr4ibnb7eh3y7k6iwpkhurjf5vb7awlz47h4iahjkmzltoc2ackni5m4"
+        },
+        "metadata": {
+          "created": 0,
+          "modified": 0
+        },
+        "previous": [],
+        "version": "1.0.0"
+      }
+    },
+    "bytes": "mSnOvap3kHBnNt95vtCKWncBu/HIGmawJhKrcM5Zozbld+VdONjH4NDq8Js19zHjyLFEA33Wg27IFR4wiJvIJWuFnda4bvm8U1k+5AB3A9l2LL5wWD2eFoIPjZwAHRAbeu9LO+VF28iHb1F2ZonbOMtBRfTZufHSBGyPkpW14kPIyuBMWV35riWwpqvQIc6HObDNHZZWdh+iJtNwrHBhldql6mrubij2dURLHoZlZqm2DdZX43nU2DTYLjJtX5cBQu83NzhsdHfANha5aX2sRldjxVUdLD9u5tdsvL9WY+XyWYlM0DDrYKjewwCny0oW1qH++u1IbT3qKbHQ/8YyQ5RephmYKYJRYk2Otimas2tieNpvMngfRd2xDpiBbmLrX7KalxhB0tXXxo3CGB9py6HUJSZkHpdMC/VMcV/pfjviVZYD7MQ/i24X6S3Y29ib2Ma0DfbTEnSgEuTXL8uTz4PyJVKdOljDGhNrVxCddt/viV4SybjHjjIg3i1nIdvmsrzLKz5AAtL/E4G4odbT6g/b4Exz9UWPgLFkw2tRYdiS79dkKou7s7zreqPIWczIYI5v+ldWvR1OKKDuiThkRuy5JOLI2Ugt93HS0doLkzI1h7Csp667boeRTnrDaxnoeD5jR/A4ZN4d5572XA/+kFpmzDbKJNIUuasDbNboKpP9US76tOMH1A=="
+  },
+  "bafkr4ihicyuqqoaiorr2ger3323vm6lprkxfeubscfpozezepvfmnq7dri": {
+    "value": {
+      "/": {
+        "bytes": "aGVsbG8gd29ybGQ"
+      }
+    },
+    "bytes": "JtzBivNEvSIfnxKEEOl2Hi7pfMQAvf0HY3HYYF58iFHxFuoe3pCvJlRsRag9snel5oCR"
+  },
+  "bafkr4ihruy753dol37cpmw5sbawmn4ij2u76baa7s2ducxnmvvl7zx3ata": {
+    "value": {
+      "/": {
+        "bytes": "eygQUuEPYTrWO3vtWZHxCAL5+1kwLw+TVQ+AGDAuPg9abT9TVMTvQID/P7Bi8J/9ZjDheWczkcLMfBE/xYydA4mPDBsI2A/RjVWNwv79FHR8rAaY6Tu/tXj4p/8t8SCMvBGpbCHswfQpehlXOliV/DTUgjetLlHH1eem5AAaJdA9l8mtozfL8Q342aEd0l2ekloPk3+CCOqYtzoBP4QQ5aDdzqWTCKCYO6DQxTA3yqemK6h9+dA+X9g3t+w6S+UHqGiIejdwdnXGfktmViLIo4WCTjKUeTpGqoFm7IrRZdrtvdPvokUYSVN16JHP8xC684RTL1iXHR6ST6OqGOsJHi+nXQQc394FqMZ8fgqorOl8L/aly7KuQ2V54IieFfim8H9yRVqupJ+pVc7+Mouix5HQdMs+uY7Bti4fxRFqVBTbBcBcrOhlbGU5K1y6ww/KcWMeUwxPixIOFjYeTbgIF/vSD5CFJO9voiUiaXk1CIkJkA4Cw0I5Dn7v9sw7X8CqeyFHRMkPpqOjy2EmOUhnDusG9QRlEU3YhT9hbcER9j/n0BP0OHw+YAQt5PGk79e1t3NblYbhyWqzFbYlMy8wkHkEJjlpTf3OZYCmArDwbs2vcYnlXt/DDcDtLQvYs+Pr74xMxOE3zW5OR/u0NO3y2QOYkKUEj7xUd8qW/BzbJLxRV2zy/01h/Q"
+      }
+    },
+    "bytes": "eygQUuEPYTrWO3vtWZHxCAL5+1kwLw+TVQ+AGDAuPg9abT9TVMTvQID/P7Bi8J/9ZjDheWczkcLMfBE/xYydA4mPDBsI2A/RjVWNwv79FHR8rAaY6Tu/tXj4p/8t8SCMvBGpbCHswfQpehlXOliV/DTUgjetLlHH1eem5AAaJdA9l8mtozfL8Q342aEd0l2ekloPk3+CCOqYtzoBP4QQ5aDdzqWTCKCYO6DQxTA3yqemK6h9+dA+X9g3t+w6S+UHqGiIejdwdnXGfktmViLIo4WCTjKUeTpGqoFm7IrRZdrtvdPvokUYSVN16JHP8xC684RTL1iXHR6ST6OqGOsJHi+nXQQc394FqMZ8fgqorOl8L/aly7KuQ2V54IieFfim8H9yRVqupJ+pVc7+Mouix5HQdMs+uY7Bti4fxRFqVBTbBcBcrOhlbGU5K1y6ww/KcWMeUwxPixIOFjYeTbgIF/vSD5CFJO9voiUiaXk1CIkJkA4Cw0I5Dn7v9sw7X8CqeyFHRMkPpqOjy2EmOUhnDusG9QRlEU3YhT9hbcER9j/n0BP0OHw+YAQt5PGk79e1t3NblYbhyWqzFbYlMy8wkHkEJjlpTf3OZYCmArDwbs2vcYnlXt/DDcDtLQvYs+Pr74xMxOE3zW5OR/u0NO3y2QOYkKUEj7xUd8qW/BzbJLxRV2zy/01h/Q=="
+  },
+  "bafyr4icm6t3ewfsg6z37y5da2oxwxtnwmrrg4dfetvrlkr3zqxpw55ptyi": {
+    "value": {
+      "accumulator": {
+        "generator": {
+          "/": {
+            "bytes": "SxhAYVIS6TcgcK8rZ2LEY9siAPMu12U94+xW09MjqxR22cX+Jb2eeq3ykgWbIo+buUs0tfCxU7TiuFZo6oP5H+7DPbR1vkPAntUel8GJVL97bl2CYlK0UNfkhxGR0jfrbNAkhYCc1A0M4aR6IUCZhMxDhSMKtXnPSd8us+pTpyTuL+SoxAdj+hU8mcsbPg85CPHx/y5H/BFfWjb5BPLtaR2jN4hnOC4kcMkuxa/akWJk4zrPWKPWrX8XvfjkwTyixE5G21eG7c5h99FglAb0glDVptIbaULH2aDkuQnbqp8G6ZPuZvQrT3iOXZxRbj+O3hKOET631tQFVr66eR9ayQ"
+          }
+        },
+        "modulus": {
+          "/": {
+            "bytes": "tfJY9Ns02diq4Acy25Bps3PVn1BcdwzIwM/p2D8axaFaUKZNoFepJLk0spm3XlPcQxPoJhn5Fl8Z9+7Ldb3nz5WrgGykTaRWBdRfw6frLPJA1KCVZ6svaaavJJw8bADgbgZJR5UjWbSORMbsQzeaO9EO5zkxO/Bz9C6hYoK+sSB9WPUd9ecRT9OEVVdzZLrs2wmDYwB9UD/Cn8gdK1gxLoFggxVNTxJVHlOcGJ8yOxAVpKmj8eHjqVMSVIYZQcZPKAppESw6yfFwZ8m0obszFtQDMEukgHEe/sUfktjYnqJEaFN/5U6DOuHCuPPXwRSZj+bbDAkr/Z583TJOWGJR2Q"
+          }
+        }
+      },
+      "root": [
+        {
+          "/": {
+            "bytes": "NIA"
+          }
+        },
+        [
+          [
+            [
+              {
+                "/": {
+                  "bytes": "PfjGTXoUJKdi2jSyFoPY3aAlEqiVi+BwqYSLe+DxQPCgVwxdSTUZQv6nVJtt/NRb/+nT9UbXQfOY3qHpCyiWQW6DkHBof89sLi855MPr/mA/ZIjcv956Xu1TRnKhJ2axp6pAqrBHPLUexrcN2QAAT7YgzM7pDUW5OYQNm9HrBrqeB54fUSDpgnhGtHTSVRELkBgskdD4tCGBB6ccpIMm4c124VeZXF5uZhey71WtENhAGNIA8jF4GRwPdblzLACmsga5BBiYT3pABcIDe2pcWWcRVxxm2XrT1+wBvkK33wqUQVOOg23t109ZHVwl/RFHWNoGn9Gp4iTz2fqTgZwpSg"
+                }
+              },
+              [
+                {
+                  "/": "bafkr4ialmvnmzmxxdw2bmichtupuohprsguaz27yw6zymk2oz6dd5reaca"
+                },
+                {
+                  "/": "bafkr4ihruy753dol37cpmw5sbawmn4ij2u76baa7s2ducxnmvvl7zx3ata"
+                }
+              ]
+            ]
+          ],
+          [
+            [
+              {
+                "/": {
+                  "bytes": "oFRKVnLhRiA24SFH9unmkPw401RB+tRYqW+c5JRg8x2SYVbhjrCKfXmG8tM5x8b3Vp6BBuWnXHO9a6UZ+/HVmgMzT1VB1lA0fViuHXBPQafHetehZLOUP9jgSyvjgC11fFU+tgSA4Nax0TCuRYt664sL2OfoSBAe56iSEZMJxmdRy23+xzTpHWic6e8qJUW5OCoYQWtwA8CwcY5BOo0H9gcJ9jfoOuQPbeRISGJ4lA085VSPQCxd9stHioUcDRsYW0YDuYaxV0ax9Qr3316fDJ/Ynbpi81bo+5dKPwqmJ8IupcCy9eBOQS9NatFCpBA+KxmQWwuQ9cV2S13VsJUxKQ"
+                }
+              },
+              [
+                {
+                  "/": "bafkr4ibw46mmphjyyulwem6eofhjuuigt6o5gtwxxa4v2zurk52oogab34"
+                },
+                {
+                  "/": "bafkr4ib74rijhbp57g7dzkzcwkdoiv7e6ljbj55n2kluczgrcmrhzrfj7u"
+                }
+              ]
+            ]
+          ],
+          [
+            [
+              {
+                "/": {
+                  "bytes": "Qr2ZI+cZd1gPOv4QpAslhNanVZITJ5N+oAkmtxtySyaVupeWsTxYSRiwelVDJEnGDkO/1Iu8WzI/a6lL3lfOImC3ZaSlDBAIHOHZdeh7T74pty233wR8V2CL0X/JG78YGECKczEaCcY/oc3K+nYgna6tx9cRe03aE9XP/SnoKGRvYpS34lNec6fg0jAA0t4JqZM1BJe9y4/pnhEtxd07sCIBbvJIYOThLOIgvkbPj3uKhUYiiZNBhsydl/klMo4XhuksW87bkjjYFwnUnVDzO2M3K8J2EMdMzyu5lsmvlMT8Xd/FB5jJK2LGSb1ShMANhsSiIyJwPTADKBdzCioUbQ"
+                }
+              },
+              [
+                {
+                  "/": "bafkr4ihicyuqqoaiorr2ger3323vm6lprkxfeubscfpozezepvfmnq7dri"
+                }
+              ]
+            ]
+          ],
+          [
+            [
+              {
+                "/": {
+                  "bytes": "mDoQjcWDa6hu3spPu3D/NOaRiXNA8z/CPHQsMn6n25dX+NnA22uDihzaPfWk+pgk6pxp1XMZ8ewttANgcnWvdhhLnyIkZe0614UmFXPFw8A4ywObAUYjCGbNJb+/Py9N+qqYg1/XTh5Ci50qkCWb1B4YnOxAkUOTA0GYpHRcLbXwL61kkuMnv1N5S0VYJfq3Bu/tvJun3nsOgtJx0yPxo5k1fRwzVluE9vuXlKOIXIkCLdlrCVtXMWReTS940PMONioT4MuColdghYRBY9c3ABZGzN9BqoVyY2B/7vH+K9KKQ5I3h5B3kkBBTPaa5aFwYM1uFUL+1lQrpaFgFK0dRg"
+                }
+              },
+              [
+                {
+                  "/": "bafkr4ibnb7eh3y7k6iwpkhurjf5vb7awlz47h4iahjkmzltoc2ackni5m4"
+                },
+                {
+                  "/": "bafkr4ifrt6o4xyjjivkfm43p5obpejrori4gfy4itkkrlhpstz2sqoqafi"
+                }
+              ]
+            ]
+          ]
+        ]
+      ],
+      "structure": "hamt",
+      "version": "0.1.0"
+    },
+    "bytes": "pGRyb290gkI0gISBglkBAD34xk16FCSnYto0shaD2N2gJRKolYvgcKmEi3vg8UDwoFcMXUk1GUL+p1SbbfzUW//p0/VG10HzmN6h6QsolkFug5BwaH/PbC4vOeTD6/5gP2SI3L/eel7tU0ZyoSdmsaeqQKqwRzy1Hsa3DdkAAE+2IMzO6Q1FuTmEDZvR6wa6ngeeH1Eg6YJ4RrR00lURC5AYLJHQ+LQhgQenHKSDJuHNduFXmVxebmYXsu9VrRDYQBjSAPIxeBkcD3W5cywAprIGuQQYmE96QAXCA3tqXFlnEVccZtl609fsAb5Ct98KlEFTjoNt7ddPWR1cJf0RR1jaBp/RqeIk89n6k4GcKUqC2CpYJQABVR4gC2VazLL3HbQWIEedH0cd8ZGoDOv4t7OGK07Phj7EgBDYKlglAAFVHiDxpj/djcvfxPZbsggsxvEJ1T/ggB+Wh0FdrK1X/N9gmIGCWQEAoFRKVnLhRiA24SFH9unmkPw401RB+tRYqW+c5JRg8x2SYVbhjrCKfXmG8tM5x8b3Vp6BBuWnXHO9a6UZ+/HVmgMzT1VB1lA0fViuHXBPQafHetehZLOUP9jgSyvjgC11fFU+tgSA4Nax0TCuRYt664sL2OfoSBAe56iSEZMJxmdRy23+xzTpHWic6e8qJUW5OCoYQWtwA8CwcY5BOo0H9gcJ9jfoOuQPbeRISGJ4lA085VSPQCxd9stHioUcDRsYW0YDuYaxV0ax9Qr3316fDJ/Ynbpi81bo+5dKPwqmJ8IupcCy9eBOQS9NatFCpBA+KxmQWwuQ9cV2S13VsJUxKYLYKlglAAFVHiA255jHnTjFF2IzxHFOmlEGn53TTte4OV1mkVd05xgB39gqWCUAAVUeID/kUJOF/fm+PKsisobkV+Ty0hT3rdKXQWTREyJ8xKn9gYJZAQBCvZkj5xl3WA86/hCkCyWE1qdVkhMnk36gCSa3G3JLJpW6l5axPFhJGLB6VUMkScYOQ7/Ui7xbMj9rqUveV84iYLdlpKUMEAgc4dl16HtPvim3LbffBHxXYIvRf8kbvxgYQIpzMRoJxj+hzcr6diCdrq3H1xF7TdoT1c/9KegoZG9ilLfiU15zp+DSMADS3gmpkzUEl73Lj+meES3F3TuwIgFu8khg5OEs4iC+Rs+Pe4qFRiKJk0GGzJ2X+SUyjheG6SxbztuSONgXCdSdUPM7YzcrwnYQx0zPK7mWya+UxPxd38UHmMkrYsZJvVKEwA2GxKIjInA9MAMoF3MKKhRtgdgqWCUAAVUeIOgWKQg4CHRjoxI73rdWeW+KrlJQMhFe7JMkfUrGw+OKgYJZAQCYOhCNxYNrqG7eyk+7cP805pGJc0DzP8I8dCwyfqfbl1f42cDba4OKHNo99aT6mCTqnGnVcxnx7C20A2Byda92GEufIiRl7TrXhSYVc8XDwDjLA5sBRiMIZs0lv78/L036qpiDX9dOHkKLnSqQJZvUHhic7ECRQ5MDQZikdFwttfAvrWSS4ye/U3lLRVgl+rcG7+28m6feew6C0nHTI/GjmTV9HDNWW4T2+5eUo4hciQIt2WsJW1cxZF5NL3jQ8w42KhPgy4KiV2CFhEFj1zcAFkbM30GqhXJjYH/u8f4r0opDkjeHkHeSQEFM9prloXBgzW4VQv7WVCuloWAUrR1GgtgqWCUAAVUeIC0PyH3j6vIs9R6RSXtQ/BZeefPxADpUzK5uFoAlNR1n2CpYJQABVR4gsZ+dy+EpRVRWc2/rgvImLoo4YuOImpUVnfKedSg6ACpndmVyc2lvbmUwLjEuMGlzdHJ1Y3R1cmVkaGFtdGthY2N1bXVsYXRvcqJnbW9kdWx1c1kBALXyWPTbNNnYquAHMtuQabNz1Z9QXHcMyMDP6dg/GsWhWlCmTaBXqSS5NLKZt15T3EMT6CYZ+RZfGffuy3W958+Vq4BspE2kVgXUX8On6yzyQNSglWerL2mmryScPGwA4G4GSUeVI1m0jkTG7EM3mjvRDuc5MTvwc/QuoWKCvrEgfVj1HfXnEU/ThFVXc2S67NsJg2MAfVA/wp/IHStYMS6BYIMVTU8SVR5TnBifMjsQFaSpo/Hh46lTElSGGUHGTygKaREsOsnxcGfJtKG7MxbUAzBLpIBxHv7FH5LY2J6iRGhTf+VOgzrhwrjz18EUmY/m2wwJK/2efN0yTlhiUdlpZ2VuZXJhdG9yWQEASxhAYVIS6TcgcK8rZ2LEY9siAPMu12U94+xW09MjqxR22cX+Jb2eeq3ykgWbIo+buUs0tfCxU7TiuFZo6oP5H+7DPbR1vkPAntUel8GJVL97bl2CYlK0UNfkhxGR0jfrbNAkhYCc1A0M4aR6IUCZhMxDhSMKtXnPSd8us+pTpyTuL+SoxAdj+hU8mcsbPg85CPHx/y5H/BFfWjb5BPLtaR2jN4hnOC4kcMkuxa/akWJk4zrPWKPWrX8XvfjkwTyixE5G21eG7c5h99FglAb0glDVptIbaULH2aDkuQnbqp8G6ZPuZvQrT3iOXZxRbj+O3hKOET631tQFVr66eR9ayQ=="
+  },
+  "bafyr4ifwzerohxg745kxssx6zjh4ntk4ajvjxd45eceo7xyyhhhhun2fhq": {
+    "value": {
+      "exchange": {
+        "/": "bafyr4ih3k2ipwwqryrlmtmwtolma4t772gknmx7pxqu5opjwsrr2nc27qq"
+      },
+      "forest": {
+        "/": "bafyr4icm6t3ewfsg6z37y5da2oxwxtnwmrrg4dfetvrlkr3zqxpw55ptyi"
+      },
+      "public": {
+        "/": "bafyr4ih3k2ipwwqryrlmtmwtolma4t772gknmx7pxqu5opjwsrr2nc27qq"
+      },
+      "version": "1.0.0"
+    },
+    "bytes": "pGZmb3Jlc3TYKlglAAFxHiBM9PZLFkb2d/x0YNOva822ZGJuDKSdYrVHeYXfbvXzwmZwdWJsaWPYKlglAAFxHiD7VpD7WhHEVsmy03LYDk//0ZTWX++8Kdc9NpRjpotfhGd2ZXJzaW9uZTEuMC4waGV4Y2hhbmdl2CpYJQABcR4g+1aQ+1oRxFbJstNy2A5P/9GU1l/vvCnXPTaUY6aLX4Q="
+  },
+  "bafyr4ih3k2ipwwqryrlmtmwtolma4t772gknmx7pxqu5opjwsrr2nc27qq": {
+    "value": {
+      "wnfs/pub/dir": {
+        "metadata": {
+          "created": 0,
+          "modified": 0
+        },
+        "previous": [],
+        "userland": {},
+        "version": "1.0.0"
+      }
+    },
+    "bytes": "oWx3bmZzL3B1Yi9kaXKkZ3ZlcnNpb25lMS4wLjBobWV0YWRhdGGiZ2NyZWF0ZWQAaG1vZGlmaWVkAGhwcmV2aW91c4BodXNlcmxhbmSg"
+  }
+}


### PR DESCRIPTION
This introduces the `Big` trait in the `wnfs-nameaccumulator` crate which abstracts the type & functions needed from the bigint library to support name accumulators.
This allows us to experiment with different backends.
I've implemented a `rug` based backend and tested it against the `num-bigint-dig` backend, it improves name accumulator performance by roughly 2x:

<details>
<summary>Benchmark output</summary>
<pre>
[philipp@nixos:~/program/work/rs-wnfs]$ cargo bench -p wnfs-bench --bench nameaccumulator
   Compiling wnfs-nameaccumulator v0.1.25 (/home/philipp/program/work/rs-wnfs/wnfs-nameaccumulator)
   Compiling wnfs-bench v0.1.25 (/home/philipp/program/work/rs-wnfs/wnfs-bench)
    Finished bench [optimized] target(s) in 2.05s
     Running nameaccumulator.rs (target/release/deps/nameaccumulator-969d61c944503e93)
Benchmarking NameSegment::<BigNumDig>::new_hashed: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 7.1s, enable flat sampling, or reduce sample count to 50.
Benchmarking NameSegment::<BigNumDig>::new_hashed: Collecting 100 samples in estima
NameSegment::<BigNumDig>::new_hashed
                        time:   [1.4227 ms 1.4422 ms 1.4615 ms]
Found 3 outliers among 100 measurements (3.00%)
  1 (1.00%) low severe
  1 (1.00%) low mild
  1 (1.00%) high severe

Benchmarking NameSegment::<BigNumRug>::new_hashed: Collecting 100 samples in estima
NameSegment::<BigNumRug>::new_hashed
                        time:   [247.75 µs 250.97 µs 254.11 µs]
Found 2 outliers among 100 measurements (2.00%)
  1 (1.00%) low mild
  1 (1.00%) high mild

Benchmarking NameSegment::<BigNumDig>::new(rng): Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 6.9s, enable flat sampling, or reduce sample count to 50.
Benchmarking NameSegment::<BigNumDig>::new(rng): Collecting 100 samples in estimate
NameSegment::<BigNumDig>::new(rng)
                        time:   [1.3551 ms 1.3711 ms 1.3873 ms]
Found 10 outliers among 100 measurements (10.00%)
  1 (1.00%) low severe
  2 (2.00%) low mild
  6 (6.00%) high mild
  1 (1.00%) high severe

Benchmarking NameSegment::<BigNumRug>::new(rng): Collecting 100 samples in estimate
NameSegment::<BigNumRug>::new(rng)
                        time:   [460.11 µs 461.60 µs 463.13 µs]
Found 4 outliers among 100 measurements (4.00%)
  1 (1.00%) low severe
  1 (1.00%) low mild
  1 (1.00%) high mild
  1 (1.00%) high severe

Benchmarking NameAccumulator::<BigNumDig>::add: Collecting 100 samples in estimated
NameAccumulator::<BigNumDig>::add
                        time:   [1.3226 ms 1.3311 ms 1.3398 ms]
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high mild

Benchmarking NameAccumulator::<BigNumRug>::add: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 5.9s, enable flat sampling, or reduce sample count to 60.
Benchmarking NameAccumulator::<BigNumRug>::add: Collecting 100 samples in estimated
NameAccumulator::<BigNumRug>::add
                        time:   [735.55 µs 739.12 µs 742.85 µs]
Found 6 outliers among 100 measurements (6.00%)
  1 (1.00%) low severe
  3 (3.00%) low mild
  2 (2.00%) high mild

Benchmarking NameAccumulator::<BigNumDig> serialization: Collecting 100 samples in 
NameAccumulator::<BigNumDig> serialization
                        time:   [986.84 ns 1.0084 µs 1.0381 µs]
Found 7 outliers among 100 measurements (7.00%)
  2 (2.00%) high mild
  5 (5.00%) high severe

Benchmarking NameAccumulator::<BigNumRug> serialization: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 6.0s, enable flat sampling, or reduce sample count to 60.
Benchmarking NameAccumulator::<BigNumRug> serialization: Collecting 100 samples in 
NameAccumulator::<BigNumRug> serialization
                        time:   [597.78 ns 608.67 ns 622.15 ns]
Found 9 outliers among 100 measurements (9.00%)
  7 (7.00%) high mild
  2 (2.00%) high severe
</pre>
</details>

The downside of the `rug` backend is that you need to have the [`gmp`](https://gmplib.org/) libraries installed locally.

Currently WIP because:
- [ ] Needs cleanup of the `Big` trait. There's some weirdness to it. Function names and stuff.
- [ ] Consider splitting the `Big::Num` type into `Big::U2048` and `Big::U256`, or `Big::GroupElem` and `Big::Exponent`, or whatever is needed to support a `crypto-bigint` backend.
- [ ] Figure out what to is going on with snapshot tests (why isn't the num-bigint-dig backend generating exactly the same data?).
- [ ] Decide whether backends must use e.g. the same pseudo-random prime derivation algorithms.