### PR TITLE
feat: Bytes-based public file writing API

### DIFF
--- a/wnfs-common/src/async_serialize.rs
+++ b/wnfs-common/src/async_serialize.rs
@@ -48,6 +48,7 @@ pub trait AsyncSerialize {
     async fn async_serialize<S, B>(&self, serializer: S, store: &B) -> Result<S::Ok, S::Error>
     where
         S: Serializer + CondSend,
+        S::Error: CondSend,
         B: BlockStore + ?Sized;
 
     /// Serialize with an IPLD serializer.
@@ -69,6 +70,7 @@ impl<T: AsyncSerialize + CondSync> AsyncSerialize for Arc<T> {
     async fn async_serialize<S, B>(&self, serializer: S, store: &B) -> Result<S::Ok, S::Error>
     where
         S: Serializer + CondSend,
+        S::Error: CondSend,
         B: BlockStore + ?Sized,
     {
         self.as_ref().async_serialize(serializer, store).await

--- a/wnfs-common/src/utils/send_sync_poly.rs
+++ b/wnfs-common/src/utils/send_sync_poly.rs
@@ -59,3 +59,31 @@ impl<S> CondSync for S where S: Send + Sync {}
 
 #[cfg(target_arch = "wasm32")]
 impl<S> CondSync for S {}
+
+#[cfg(not(target_arch = "wasm32"))]
+pub fn boxed_fut<'a, T>(
+    fut: impl futures::future::Future<Output = T> + Sized + CondSend + 'a,
+) -> BoxFuture<'a, T> {
+    futures::future::FutureExt::boxed(fut)
+}
+
+#[cfg(target_arch = "wasm32")]
+pub fn boxed_fut<'a, T>(
+    fut: impl futures::future::Future<Output = T> + Sized + CondSend + 'a,
+) -> BoxFuture<'a, T> {
+    futures::future::FutureExt::boxed_local(fut)
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+pub fn boxed_stream<'a, T>(
+    stream: impl futures::stream::Stream<Item = T> + Sized + CondSend + 'a,
+) -> BoxStream<'a, T> {
+    futures::stream::StreamExt::boxed(stream)
+}
+
+#[cfg(target_arch = "wasm32")]
+pub fn boxed_stream<'a, T>(
+    stream: impl futures::stream::Stream<Item = T> + Sized + CondSend + 'a,
+) -> BoxStream<'a, T> {
+    futures::stream::StreamExt::boxed_local(stream)
+}

--- a/wnfs-unixfs-file/src/balanced_tree.rs
+++ b/wnfs-unixfs-file/src/balanced_tree.rs
@@ -10,7 +10,7 @@ use bytes::Bytes;
 use futures::{Stream, StreamExt};
 use libipld::Cid;
 use std::collections::VecDeque;
-use wnfs_common::BlockStore;
+use wnfs_common::{utils::CondSend, BlockStore};
 
 /// Default degree number for balanced tree, taken from unixfs specs
 /// <https://github.com/ipfs/specs/blob/main/UNIXFS.md#layout>
@@ -35,7 +35,7 @@ impl TreeBuilder {
 
     pub fn stream_tree<'a>(
         &self,
-        chunks: impl Stream<Item = std::io::Result<Bytes>> + Send + 'a,
+        chunks: impl Stream<Item = std::io::Result<Bytes>> + CondSend + 'a,
         store: &'a impl BlockStore,
     ) -> impl Stream<Item = Result<(Cid, Block)>> + 'a {
         match self {
@@ -51,7 +51,7 @@ struct LinkInfo {
 }
 
 fn stream_balanced_tree<'a>(
-    in_stream: impl Stream<Item = std::io::Result<Bytes>> + Send + 'a,
+    in_stream: impl Stream<Item = std::io::Result<Bytes>> + CondSend + 'a,
     degree: usize,
     store: &'a impl BlockStore,
 ) -> impl Stream<Item = Result<(Cid, Block)>> + 'a {

--- a/wnfs-unixfs-file/src/chunker.rs
+++ b/wnfs-unixfs-file/src/chunker.rs
@@ -1,6 +1,6 @@
 use anyhow::{anyhow, Context};
 use bytes::Bytes;
-use futures::{stream::BoxStream, Stream};
+use futures::Stream;
 use std::{
     fmt::{Debug, Display},
     io,
@@ -9,6 +9,7 @@ use std::{
     task,
 };
 use tokio::io::AsyncRead;
+use wnfs_common::utils::{BoxStream, CondSend};
 
 mod fixed;
 mod rabin;
@@ -126,7 +127,7 @@ impl<'a> Stream for ChunkerStream<'a> {
 }
 
 impl Chunker {
-    pub fn chunks<'a, R: AsyncRead + Unpin + Send + 'a>(self, source: R) -> ChunkerStream<'a> {
+    pub fn chunks<'a, R: AsyncRead + Unpin + CondSend + 'a>(self, source: R) -> ChunkerStream<'a> {
         match self {
             Self::Fixed(chunker) => ChunkerStream::Fixed(chunker.chunks(source)),
             Self::Rabin(chunker) => ChunkerStream::Rabin(chunker.chunks(source)),

--- a/wnfs-unixfs-file/src/types.rs
+++ b/wnfs-unixfs-file/src/types.rs
@@ -2,7 +2,8 @@ use crate::{codecs::Codec, parse_links, protobufs};
 use anyhow::{anyhow, Result};
 use bytes::Bytes;
 use libipld::Cid;
-use std::io::Cursor;
+use std::{io::Cursor, pin::Pin};
+use tokio::io::AsyncRead;
 use wnfs_common::BlockStore;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -161,3 +162,9 @@ impl<'a> Iterator for PbLinks<'a> {
         (self.outer.links.len(), Some(self.outer.links.len()))
     }
 }
+
+#[cfg(not(target_arch = "wasm32"))]
+pub type BoxAsyncRead<'a> = Pin<Box<dyn AsyncRead + Send + 'a>>;
+
+#[cfg(target_arch = "wasm32")]
+pub type BoxAsyncRead<'a> = Pin<Box<dyn AsyncRead + 'a>>;

--- a/wnfs-wasm/src/fs/public/directory.rs
+++ b/wnfs-wasm/src/fs/public/directory.rs
@@ -85,7 +85,7 @@ impl PublicDirectory {
                 .await
                 .map_err(error("Cannot add to store"))?;
 
-            let cid_u8array = Uint8Array::from(&cid.to_bytes()[..]);
+            let cid_u8array = Uint8Array::from(cid.to_bytes().as_ref());
 
             Ok(value!(cid_u8array))
         }))
@@ -118,9 +118,9 @@ impl PublicDirectory {
                 .await
                 .map_err(error("Cannot read from directory"))?;
 
-            let result = Uint8Array::from(&result.to_bytes()[..]);
+            let u8array = Uint8Array::from(result.as_ref());
 
-            Ok(value!(result))
+            Ok(value!(u8array))
         }))
     }
 
@@ -165,20 +165,19 @@ impl PublicDirectory {
     pub fn write(
         &self,
         path_segments: &Array,
-        content_cid: Vec<u8>,
+        content: Vec<u8>,
         time: &Date,
         store: BlockStore,
     ) -> JsResult<Promise> {
         let mut directory = Rc::clone(&self.0);
         let store = ForeignBlockStore(store);
 
-        let cid = Cid::try_from(content_cid).map_err(error("Invalid CID"))?;
         let time = DateTime::<Utc>::from(time);
         let path_segments = utils::convert_path_segments(path_segments)?;
 
         Ok(future_to_promise(async move {
             (&mut directory)
-                .write(&path_segments, cid, time, &store)
+                .write(&path_segments, content, time, &store)
                 .await
                 .map_err(error("Cannot write to directory"))?;
 

--- a/wnfs-wasm/tests/mock.ts
+++ b/wnfs-wasm/tests/mock.ts
@@ -171,11 +171,10 @@ const createRecipientExchangeRoot = async (
 ): Promise<[PrivateKey, PublicDirectory]> => {
   const key = await PrivateKey.generate();
   const exchangeKey = await key.getPublicKey().getPublicKeyModulus();
-  const exchangeKeyCid = await store.putBlock(exchangeKey, 0x55);
 
   const { rootDir } = await new PublicDirectory(new Date()).write(
     ["device1", "v1.exchange_key"],
-    exchangeKeyCid,
+    exchangeKey,
     new Date(),
     store
   );

--- a/wnfs/Cargo.toml
+++ b/wnfs/Cargo.toml
@@ -43,9 +43,12 @@ serde_ipld_dagcbor = "0.4"
 sha3 = "0.10"
 skip_ratchet = { version = "0.3", features = ["serde"] }
 thiserror = "1.0"
+tokio = { version = "1.34", features = ["io-util"] }
+tokio-util = { version = "0.7.10", features = ["compat"] }
 wnfs-common = { path = "../wnfs-common", version = "=0.1.25" }
 wnfs-hamt = { path = "../wnfs-hamt", version = "=0.1.25" }
 wnfs-nameaccumulator = { path = "../wnfs-nameaccumulator", version = "=0.1.25" }
+wnfs-unixfs-file = { path = "../wnfs-unixfs-file", version = "=0.1.25" }
 
 [dev-dependencies]
 async-std = { version = "1.11", features = ["attributes"] }
@@ -61,6 +64,7 @@ serde_json = "1.0.103"
 sha2 = "0.10"
 test-log = "0.2"
 test-strategy = "0.3"
+testresult = "0.3.0"
 tiny-bip39 = "1.0"
 wnfs-common = { path = "../wnfs-common", features = ["test_utils"] }
 

--- a/wnfs/examples/public.rs
+++ b/wnfs/examples/public.rs
@@ -3,7 +3,6 @@
 
 use anyhow::Result;
 use chrono::Utc;
-use libipld_core::cid::Cid;
 use wnfs::{common::MemoryBlockStore, public::PublicDirectory};
 
 #[async_std::main]
@@ -23,7 +22,7 @@ async fn main() -> Result<()> {
     root_dir
         .write(
             &["pictures".into(), "dogs".into(), "billie.jpeg".into()],
-            Cid::default(),
+            b"Hello, world!".to_vec(),
             Utc::now(),
             &store,
         )

--- a/wnfs/src/private/directory.rs
+++ b/wnfs/src/private/directory.rs
@@ -1265,7 +1265,7 @@ impl PrivateDirectory {
             .into_private_ref(content_cid))
     }
 
-    /// Creates a  new [`PrivateDirectory`] from a [`PrivateDirectoryContentSerializable`].
+    /// Creates a new [`PrivateDirectory`] from a [`PrivateDirectoryContentSerializable`].
     pub(crate) async fn from_serializable(
         serializable: PrivateDirectoryContentSerializable,
         temporal_key: &TemporalKey,

--- a/wnfs/src/public/directory.rs
+++ b/wnfs/src/public/directory.rs
@@ -283,7 +283,7 @@ impl PublicDirectory {
     /// };
     /// use std::sync::Arc;
     /// use chrono::Utc;
-    /// use wnfs_common::libipld::{Ipld, Cid};
+    /// use wnfs_common::libipld::Ipld;
     ///
     /// #[async_std::main]
     /// async fn main() -> Result<()> {
@@ -292,8 +292,7 @@ impl PublicDirectory {
     ///
     ///     // Gain a mutable file reference
     ///     let path = &["Documents".into(), "Notes.md".into()];
-    ///     let initial_content = Cid::default();
-    ///     let file = dir.open_file_mut(path, initial_content, Utc::now(), store).await?;
+    ///     let file = dir.open_file_mut(path, Utc::now(), store).await?;
     ///
     ///     let metadata = Ipld::String("Hello Metadata!".into());
     ///     file.get_metadata_mut().put("custom-metadata", metadata.clone());
@@ -309,18 +308,20 @@ impl PublicDirectory {
     pub async fn open_file_mut<'a>(
         self: &'a mut Arc<Self>,
         path_segments: &[String],
-        initial_content: Cid,
         time: DateTime<Utc>,
         store: &'a impl BlockStore,
     ) -> Result<&'a mut PublicFile> {
         let (path, filename) = utils::split_last(path_segments)?;
 
+        // Resolve the path to an entry
         let file_ref = self
             .get_or_create_leaf_dir_mut(path, time, store)
             .await?
             .userland
             .entry(filename.clone())
-            .or_insert_with(|| PublicLink::with_file(PublicFile::new(time, initial_content)))
+            // Create a file, if it doesn't exist yet
+            .or_insert_with(|| PublicLink::with_file(PublicFile::new(time)))
+            // Get a mutable ref out of the directory entry
             .resolve_value_mut(store)
             .await?
             .as_file_mut()?
@@ -390,19 +391,18 @@ impl PublicDirectory {
     ///     public::PublicDirectory,
     ///     common::MemoryBlockStore
     /// };
-    /// use libipld_core::cid::Cid;
     /// use chrono::Utc;
     ///
     /// #[async_std::main]
     /// async fn main() {
     ///     let dir = &mut PublicDirectory::new_rc(Utc::now());
     ///     let store = &MemoryBlockStore::default();
-    ///     let cid = Cid::default();
+    ///     let content = b"Hello, World!".to_vec();
     ///
     ///     dir
     ///         .write(
     ///             &["pictures".into(), "cats".into(), "tabby.png".into()],
-    ///             cid,
+    ///             content.clone(),
     ///             Utc::now(),
     ///             store
     ///         )
@@ -414,14 +414,14 @@ impl PublicDirectory {
     ///         .await
     ///         .unwrap();
     ///
-    ///     assert_eq!(result, cid);
+    ///     assert_eq!(result, content);
     /// }
     /// ```
-    pub async fn read(&self, path_segments: &[String], store: &impl BlockStore) -> Result<Cid> {
+    pub async fn read(&self, path_segments: &[String], store: &impl BlockStore) -> Result<Vec<u8>> {
         let (path, filename) = utils::split_last(path_segments)?;
         match self.get_leaf_dir(path, store).await? {
             SearchResult::Found(dir) => match dir.lookup_node(filename, store).await? {
-                Some(PublicNode::File(file)) => Ok(file.userland),
+                Some(PublicNode::File(file)) => Ok(file.read_at(0, None, store).await?),
                 Some(_) => error(FsError::NotAFile),
                 None => error(FsError::NotFound),
             },
@@ -438,29 +438,30 @@ impl PublicDirectory {
     ///     public::PublicDirectory,
     ///     common::MemoryBlockStore
     /// };
-    /// use libipld_core::cid::Cid;
     /// use chrono::Utc;
+    /// use anyhow::Result;
     ///
     /// #[async_std::main]
-    /// async fn main() {
+    /// async fn main() -> Result<()> {
     ///     let dir = &mut PublicDirectory::new_rc(Utc::now());
-    ///     let store = &MemoryBlockStore::default();
+    ///     let store = &MemoryBlockStore::new();
     ///
     ///     dir
     ///         .write(
     ///             &["pictures".into(), "cats".into(), "tabby.png".into()],
-    ///             Cid::default(),
+    ///             b"Hello, World!".to_vec(),
     ///             Utc::now(),
     ///             store
     ///         )
-    ///         .await
-    ///         .unwrap();
+    ///         .await?;
+    ///
+    ///     Ok(())
     /// }
     /// ```
     pub async fn write(
         self: &mut Arc<Self>,
         path_segments: &[String],
-        content_cid: Cid,
+        content: Vec<u8>,
         time: DateTime<Utc>,
         store: &impl BlockStore,
     ) -> Result<()> {
@@ -468,12 +469,12 @@ impl PublicDirectory {
         let dir = self.get_or_create_leaf_dir_mut(path, time, store).await?;
 
         match dir.lookup_node_mut(filename, store).await? {
-            Some(PublicNode::File(file)) => file.write(time, content_cid),
+            Some(PublicNode::File(file)) => file.set_content(time, content, store).await?,
             Some(PublicNode::Dir(_)) => bail!(FsError::DirectoryAlreadyExists),
             None => {
                 dir.userland.insert(
                     filename.to_string(),
-                    PublicLink::with_file(PublicFile::new(time, content_cid)),
+                    PublicLink::with_file(PublicFile::with_content(time, content, store).await?),
                 );
             }
         }
@@ -547,7 +548,7 @@ impl PublicDirectory {
     ///     dir
     ///         .write(
     ///             &["pictures".into(), "cats".into(), "tabby.png".into()],
-    ///             Cid::default(),
+    ///             b"Hello, world!".to_vec(),
     ///             Utc::now(),
     ///             &store
     ///         )
@@ -597,42 +598,40 @@ impl PublicDirectory {
     ///     public::PublicDirectory,
     ///     common::MemoryBlockStore
     /// };
-    /// use libipld_core::cid::Cid;
     /// use chrono::Utc;
+    /// use anyhow::Result;
     ///
     /// #[async_std::main]
-    /// async fn main() {
+    /// async fn main() -> Result<()> {
     ///     let dir = &mut PublicDirectory::new_rc(Utc::now());
-    ///     let store = MemoryBlockStore::default();
+    ///     let store = &MemoryBlockStore::new();
     ///
     ///     dir
     ///         .write(
     ///             &["pictures".into(), "cats".into(), "tabby.png".into()],
-    ///             Cid::default(),
+    ///             b"Hello, World!".to_vec(),
     ///             Utc::now(),
-    ///             &store
+    ///             store
     ///         )
-    ///         .await
-    ///         .unwrap();
+    ///         .await?;
     ///
     ///     let result = dir
-    ///         .ls(&["pictures".into()], &store)
-    ///         .await
-    ///         .unwrap();
+    ///         .ls(&["pictures".into()], store)
+    ///         .await?;
     ///
     ///     assert_eq!(result.len(), 1);
     ///
     ///     dir
-    ///         .rm(&["pictures".into(), "cats".into()], &store)
-    ///         .await
-    ///         .unwrap();
+    ///         .rm(&["pictures".into(), "cats".into()], store)
+    ///         .await?;
     ///
     ///     let result = dir
-    ///         .ls(&["pictures".into()], &store)
-    ///         .await
-    ///         .unwrap();
+    ///         .ls(&["pictures".into()], store)
+    ///         .await?;
     ///
     ///     assert_eq!(result.len(), 0);
+    ///
+    ///     Ok(())
     /// }
     /// ```
     pub async fn rm(
@@ -676,7 +675,7 @@ impl PublicDirectory {
     ///     dir
     ///         .write(
     ///             &["pictures".into(), "cats".into(), "tabby.png".into()],
-    ///             Cid::default(),
+    ///             b"Hello, World!".to_vec(),
     ///             Utc::now(),
     ///             &store
     ///         )
@@ -749,7 +748,7 @@ impl PublicDirectory {
     ///     dir
     ///         .write(
     ///             &["code".into(), "python".into(), "hello.py".into()],
-    ///             Cid::default(),
+    ///             b"Hello, world!".to_vec(),
     ///             Utc::now(),
     ///             store
     ///         )
@@ -948,28 +947,29 @@ mod tests {
     use super::*;
     use chrono::Utc;
     use libipld_core::ipld::Ipld;
+    use testresult::TestResult;
     use wnfs_common::MemoryBlockStore;
 
     #[async_std::test]
-    async fn look_up_can_fetch_file_added_to_directory() {
+    async fn look_up_can_fetch_file_added_to_directory() -> TestResult {
         let root_dir = &mut PublicDirectory::new_rc(Utc::now());
-        let store = MemoryBlockStore::default();
-        let content_cid = Cid::default();
+        let store = &MemoryBlockStore::new();
         let time = Utc::now();
 
         root_dir
-            .write(&["text.txt".into()], content_cid, time, &store)
-            .await
-            .unwrap();
+            .write(&["text.txt".into()], b"Hello World!".to_vec(), time, store)
+            .await?;
 
-        let node = root_dir.lookup_node("text.txt", &store).await.unwrap();
-
-        assert!(node.is_some());
+        let node = root_dir.lookup_node("text.txt", store).await?;
 
         assert_eq!(
             node,
-            Some(&PublicNode::File(PublicFile::new_rc(time, content_cid)))
+            Some(&PublicNode::File(
+                PublicFile::with_content_rc(time, b"Hello World!".to_vec(), store).await?
+            ))
         );
+
+        Ok(())
     }
 
     #[async_std::test]
@@ -985,233 +985,223 @@ mod tests {
     }
 
     #[async_std::test]
-    async fn get_node_can_fetch_node_from_root_dir() {
+    async fn get_node_can_fetch_node_from_root_dir() -> TestResult {
         let time = Utc::now();
-        let store = MemoryBlockStore::default();
+        let store = &MemoryBlockStore::new();
         let root_dir = &mut PublicDirectory::new_rc(time);
 
         root_dir
-            .mkdir(&["pictures".into(), "dogs".into()], time, &store)
-            .await
-            .unwrap();
+            .mkdir(&["pictures".into(), "dogs".into()], time, store)
+            .await?;
 
         root_dir
             .write(
                 &["pictures".into(), "cats".into(), "tabby.jpg".into()],
-                Cid::default(),
+                b"Hello".to_vec(),
                 time,
-                &store,
+                store,
             )
-            .await
-            .unwrap();
+            .await?;
 
         assert!(root_dir
             .get_node(
                 &["pictures".into(), "cats".into(), "tabby.jpg".into()],
-                &store
+                store
             )
-            .await
-            .unwrap()
+            .await?
             .is_some());
 
         assert!(root_dir
             .get_node(
                 &["pictures".into(), "cats".into(), "tabby.jpeg".into()],
-                &store
+                store
             )
-            .await
-            .unwrap()
+            .await?
             .is_none());
 
         assert!(root_dir
             .get_node(
                 &["images".into(), "parrots".into(), "coco.png".into()],
-                &store
+                store
             )
-            .await
-            .unwrap()
+            .await?
             .is_none());
 
         assert!(root_dir
             .get_node(
                 &["pictures".into(), "dogs".into(), "bingo.jpg".into()],
-                &store
+                store
             )
-            .await
-            .unwrap()
+            .await?
             .is_none());
+
+        Ok(())
     }
 
     #[async_std::test]
-    async fn mkdir_can_create_new_directory() {
+    async fn mkdir_can_create_new_directory() -> TestResult {
         let time = Utc::now();
-        let store = MemoryBlockStore::default();
+        let store = &MemoryBlockStore::new();
         let root_dir = &mut PublicDirectory::new_rc(time);
 
         root_dir
-            .mkdir(&["tamedun".into(), "pictures".into()], time, &store)
-            .await
-            .unwrap();
+            .mkdir(&["tamedun".into(), "pictures".into()], time, store)
+            .await?;
 
         let result = root_dir
-            .get_node(&["tamedun".into(), "pictures".into()], &store)
-            .await
-            .unwrap();
+            .get_node(&["tamedun".into(), "pictures".into()], store)
+            .await?;
 
         assert!(result.is_some());
+
+        Ok(())
     }
 
     #[async_std::test]
-    async fn ls_can_list_children_under_directory() {
+    async fn ls_can_list_children_under_directory() -> TestResult {
         let time = Utc::now();
-        let store = MemoryBlockStore::default();
+        let store = &MemoryBlockStore::new();
         let root_dir = &mut PublicDirectory::new_rc(time);
 
         root_dir
-            .mkdir(&["tamedun".into(), "pictures".into()], time, &store)
-            .await
-            .unwrap();
+            .mkdir(&["tamedun".into(), "pictures".into()], time, store)
+            .await?;
 
         root_dir
             .write(
                 &["tamedun".into(), "pictures".into(), "puppy.jpg".into()],
-                Cid::default(),
+                b"Hello".to_vec(),
                 time,
-                &store,
+                store,
             )
-            .await
-            .unwrap();
+            .await?;
 
         root_dir
             .mkdir(
                 &["tamedun".into(), "pictures".into(), "cats".into()],
                 time,
-                &store,
+                store,
             )
-            .await
-            .unwrap();
+            .await?;
 
         let result = root_dir
-            .ls(&["tamedun".into(), "pictures".into()], &store)
-            .await
-            .unwrap();
+            .ls(&["tamedun".into(), "pictures".into()], store)
+            .await?;
 
         assert_eq!(result.len(), 2);
 
         assert_eq!(result[0].0, String::from("cats"));
 
         assert_eq!(result[1].0, String::from("puppy.jpg"));
+
+        Ok(())
     }
 
     #[async_std::test]
-    async fn rm_can_remove_children_from_directory() {
+    async fn rm_can_remove_children_from_directory() -> TestResult {
         let time = Utc::now();
-        let store = MemoryBlockStore::default();
+        let store = &MemoryBlockStore::new();
         let mut root_dir = PublicDirectory::new_rc(time);
 
         root_dir
-            .mkdir(&["tamedun".into(), "pictures".into()], time, &store)
-            .await
-            .unwrap();
+            .mkdir(&["tamedun".into(), "pictures".into()], time, store)
+            .await?;
 
         root_dir
             .write(
                 &["tamedun".into(), "pictures".into(), "puppy.jpg".into()],
-                Cid::default(),
+                b"Hello".to_vec(),
                 time,
-                &store,
+                store,
             )
-            .await
-            .unwrap();
+            .await?;
 
         root_dir
             .mkdir(
                 &["tamedun".into(), "pictures".into(), "cats".into()],
                 time,
-                &store,
+                store,
             )
-            .await
-            .unwrap();
+            .await?;
 
         let result = root_dir
-            .rm(&["tamedun".into(), "pictures".into()], &store)
+            .rm(&["tamedun".into(), "pictures".into()], store)
             .await;
 
         assert!(result.is_ok());
 
         let result = root_dir
-            .rm(&["tamedun".into(), "pictures".into()], &store)
+            .rm(&["tamedun".into(), "pictures".into()], store)
             .await;
 
         assert!(result.is_err());
+
+        Ok(())
     }
 
     #[async_std::test]
-    async fn read_can_fetch_userland_of_file_added_to_directory() {
-        let store = MemoryBlockStore::default();
-        let content_cid = Cid::default();
+    async fn read_can_fetch_userland_of_file_added_to_directory() -> TestResult {
+        let store = &MemoryBlockStore::new();
         let time = Utc::now();
+        let content = b"Hello".to_vec();
         let mut root_dir = PublicDirectory::new_rc(time);
 
         root_dir
-            .write(&["text.txt".into()], content_cid, time, &store)
-            .await
-            .unwrap();
+            .write(&["text.txt".into()], content.clone(), time, store)
+            .await?;
 
-        let result = root_dir.read(&["text.txt".into()], &store).await.unwrap();
+        let result = root_dir.read(&["text.txt".into()], store).await?;
 
-        assert_eq!(result, content_cid);
+        assert_eq!(result, content);
+
+        Ok(())
     }
 
     #[async_std::test]
-    async fn mv_can_move_sub_directory_to_another_valid_location() {
+    async fn mv_can_move_sub_directory_to_another_valid_location() -> TestResult {
         let time = Utc::now();
-        let store = MemoryBlockStore::default();
+        let store = &MemoryBlockStore::new();
         let mut root_dir = PublicDirectory::new_rc(time);
 
         root_dir
             .write(
                 &["pictures".into(), "cats".into(), "tabby.jpg".into()],
-                Cid::default(),
+                b"Hello".to_vec(),
                 time,
-                &store,
+                store,
             )
-            .await
-            .unwrap();
+            .await?;
 
         root_dir
             .write(
                 &["pictures".into(), "cats".into(), "luna.png".into()],
-                Cid::default(),
+                b"Hello".to_vec(),
                 time,
-                &store,
+                store,
             )
-            .await
-            .unwrap();
+            .await?;
 
-        root_dir
-            .mkdir(&["images".into()], time, &store)
-            .await
-            .unwrap();
+        root_dir.mkdir(&["images".into()], time, store).await?;
 
         root_dir
             .basic_mv(
                 &["pictures".into(), "cats".into()],
                 &["images".into(), "cats".into()],
                 Utc::now(),
-                &store,
+                store,
             )
-            .await
-            .unwrap();
+            .await?;
 
-        let result = root_dir.ls(&["images".into()], &store).await.unwrap();
+        let result = root_dir.ls(&["images".into()], store).await?;
 
         assert_eq!(result.len(), 1);
         assert_eq!(result[0].0, String::from("cats"));
 
-        let result = root_dir.ls(&["pictures".into()], &store).await.unwrap();
+        let result = root_dir.ls(&["pictures".into()], store).await?;
 
         assert_eq!(result.len(), 0);
+
+        Ok(())
     }
 
     #[async_std::test]
@@ -1247,60 +1237,57 @@ mod tests {
     }
 
     #[async_std::test]
-    async fn mv_can_rename_directories() {
+    async fn mv_can_rename_directories() -> TestResult {
         let time = Utc::now();
-        let store = MemoryBlockStore::default();
+        let store = &MemoryBlockStore::new();
         let root_dir = &mut PublicDirectory::new_rc(time);
 
         root_dir
-            .write(&["file.txt".into()], Cid::default(), time, &store)
-            .await
-            .unwrap();
+            .write(&["file.txt".into()], b"Hello".to_vec(), time, store)
+            .await?;
 
         root_dir
             .basic_mv(
                 &["file.txt".into()],
                 &["renamed.txt".into()],
                 Utc::now(),
-                &store,
+                store,
             )
-            .await
-            .unwrap();
+            .await?;
 
-        let result = root_dir
-            .read(&["renamed.txt".into()], &store)
-            .await
-            .unwrap();
+        let result = root_dir.read(&["renamed.txt".into()], store).await?;
 
-        assert!(result == Cid::default());
+        assert_eq!(result, b"Hello".to_vec());
+
+        Ok(())
     }
 
     #[async_std::test]
-    async fn mv_fails_moving_directories_to_files() {
+    async fn mv_fails_moving_directories_to_files() -> TestResult {
         let time = Utc::now();
-        let store = MemoryBlockStore::default();
+        let store = &MemoryBlockStore::new();
         let root_dir = &mut PublicDirectory::new_rc(time);
 
         root_dir
-            .mkdir(&["movies".into(), "ghibli".into()], time, &store)
-            .await
-            .unwrap();
+            .mkdir(&["movies".into(), "ghibli".into()], time, store)
+            .await?;
 
         root_dir
-            .write(&["file.txt".into()], Cid::default(), time, &store)
-            .await
-            .unwrap();
+            .write(&["file.txt".into()], b"Hello".to_vec(), time, store)
+            .await?;
 
         let result = root_dir
             .basic_mv(
                 &["movies".into(), "ghibli".into()],
                 &["file.txt".into()],
                 Utc::now(),
-                &store,
+                store,
             )
             .await;
 
         assert!(result.is_err());
+
+        Ok(())
     }
 
     #[async_std::test]
@@ -1378,7 +1365,7 @@ mod snapshot_tests {
 
         for path in paths.iter() {
             root_dir
-                .write(path, Cid::default(), time, store)
+                .write(path, b"Hello".to_vec(), time, store)
                 .await
                 .unwrap();
         }
@@ -1405,7 +1392,7 @@ mod snapshot_tests {
 
         for path in paths.iter() {
             root_dir
-                .write(path, Cid::default(), time, store)
+                .write(path, b"Hello".to_vec(), time, store)
                 .await
                 .unwrap();
         }

--- a/wnfs/src/public/file.rs
+++ b/wnfs/src/public/file.rs
@@ -4,11 +4,21 @@ use super::{PublicFileSerializable, PublicNodeSerializable};
 use crate::{error::FsError, is_readable_wnfs_version, traits::Id, WNFS_VERSION};
 use anyhow::{bail, Result};
 use async_once_cell::OnceCell;
+use async_trait::async_trait;
 use chrono::{DateTime, Utc};
+use futures::{AsyncRead, AsyncReadExt};
 use libipld_core::cid::Cid;
-use serde::{de::Error as DeError, Deserialize, Deserializer, Serialize, Serializer};
-use std::collections::BTreeSet;
-use wnfs_common::{utils::Arc, BlockStore, Metadata, RemembersCid};
+use serde::{
+    de::Error as DeError, ser::Error as SerError, Deserialize, Deserializer, Serialize, Serializer,
+};
+use std::{collections::BTreeSet, io::SeekFrom};
+use tokio::io::AsyncSeekExt;
+use tokio_util::compat::{FuturesAsyncReadCompatExt, TokioAsyncReadCompatExt};
+use wnfs_common::{
+    utils::{Arc, CondSend},
+    AsyncSerialize, BlockStore, Metadata, RemembersCid,
+};
+use wnfs_unixfs_file::{builder::FileBuilder, unixfs::UnixFsFile};
 
 /// A file in the WNFS public file system.
 ///
@@ -17,9 +27,8 @@ use wnfs_common::{utils::Arc, BlockStore, Metadata, RemembersCid};
 /// ```
 /// use wnfs::public::PublicFile;
 /// use chrono::Utc;
-/// use libipld_core::cid::Cid;
 ///
-/// let file = PublicFile::new(Utc::now(), Cid::default());
+/// let file = PublicFile::new(Utc::now());
 ///
 /// println!("File: {:?}", file);
 /// ```
@@ -27,8 +36,14 @@ use wnfs_common::{utils::Arc, BlockStore, Metadata, RemembersCid};
 pub struct PublicFile {
     persisted_as: OnceCell<Cid>,
     pub metadata: Metadata,
-    pub userland: Cid,
+    userland: FileUserland,
     pub previous: BTreeSet<Cid>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+enum FileUserland {
+    Loaded(UnixFsFile),
+    Stored(Cid),
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -36,43 +51,141 @@ pub struct PublicFile {
 //--------------------------------------------------------------------------------------------------
 
 impl PublicFile {
-    /// Creates a new file with provided content CID.
+    /// Creates a new, empty file.
     ///
     /// # Examples
     ///
     /// ```
-    /// use wnfs::public::PublicFile;
+    /// use wnfs::{public::PublicFile, common::MemoryBlockStore};
     /// use chrono::Utc;
-    /// use libipld_core::cid::Cid;
     ///
-    /// let file = PublicFile::new(Utc::now(), Cid::default());
+    /// let file = PublicFile::new(Utc::now());
     ///
     /// println!("File: {:?}", file);
     /// ```
-    pub fn new(time: DateTime<Utc>, content_cid: Cid) -> Self {
+    pub fn new(time: DateTime<Utc>) -> Self {
         Self {
             persisted_as: OnceCell::new(),
             metadata: Metadata::new(time),
-            userland: content_cid,
+            userland: FileUserland::Loaded(UnixFsFile::empty()),
             previous: BTreeSet::new(),
         }
     }
 
-    /// Creates an `Arc` wrapped file.
+    /// Creates an `Arc` wrapped empty file, a shorthand wrapper around `PublicFile::new`.
+    pub fn new_rc(time: DateTime<Utc>) -> Arc<Self> {
+        Arc::new(Self::new(time))
+    }
+
+    /// Creates a file with given content bytes.
     ///
     /// # Examples
     ///
     /// ```
-    /// use wnfs::public::PublicFile;
+    /// use anyhow::Result;
+    /// use wnfs::{public::PublicFile, common::MemoryBlockStore};
     /// use chrono::Utc;
-    /// use libipld_core::cid::Cid;
     ///
-    /// let file = PublicFile::new(Utc::now(), Cid::default());
+    /// #[async_std::main]
+    /// async fn main() -> Result<()> {
+    ///     let store = &MemoryBlockStore::new();
+    ///     let content = b"Hello, World!".to_vec();
+    ///     let file = PublicFile::with_content(Utc::now(), content, store).await?;
     ///
-    /// println!("File: {:?}", file);
+    ///     println!("File: {:?}", file);
+    ///
+    ///     Ok(())
+    /// }
     /// ```
-    pub fn new_rc(time: DateTime<Utc>, content_cid: Cid) -> Arc<Self> {
-        Arc::new(Self::new(time, content_cid))
+    pub async fn with_content(
+        time: DateTime<Utc>,
+        content: Vec<u8>,
+        store: &impl BlockStore,
+    ) -> Result<Self> {
+        let content_cid = FileBuilder::new()
+            .content_bytes(content)
+            .build()?
+            .store(store)
+            .await?;
+        Ok(Self {
+            persisted_as: OnceCell::new(),
+            metadata: Metadata::new(time),
+            userland: FileUserland::Loaded(UnixFsFile::load(&content_cid, store).await?),
+            previous: BTreeSet::new(),
+        })
+    }
+
+    pub async fn with_content_rc(
+        time: DateTime<Utc>,
+        content: Vec<u8>,
+        store: &impl BlockStore,
+    ) -> Result<Arc<Self>> {
+        Ok(Arc::new(Self::with_content(time, content, store).await?))
+    }
+
+    pub async fn with_content_streaming<'a>(
+        time: DateTime<Utc>,
+        content: impl AsyncRead + Send + 'a,
+        store: &'a impl BlockStore,
+    ) -> Result<Self> {
+        let content_cid = FileBuilder::new()
+            .content_reader(FuturesAsyncReadCompatExt::compat(content))
+            .build()?
+            .store(store)
+            .await?;
+        Ok(Self {
+            persisted_as: OnceCell::new(),
+            metadata: Metadata::new(time),
+            userland: FileUserland::Loaded(UnixFsFile::load(&content_cid, store).await?),
+            previous: BTreeSet::new(),
+        })
+    }
+
+    pub async fn with_content_streaming_rc<'a>(
+        time: DateTime<Utc>,
+        content: impl AsyncRead + Send + 'a,
+        store: &'a impl BlockStore,
+    ) -> Result<Arc<Self>> {
+        Ok(Arc::new(
+            Self::with_content_streaming(time, content, store).await?,
+        ))
+    }
+
+    pub fn copy_content_from(&mut self, other: &Self, time: DateTime<Utc>) {
+        self.metadata.upsert_mtime(time);
+        self.userland = other.userland.clone();
+    }
+
+    pub async fn stream_content<'a>(
+        &'a self,
+        byte_offset: u64,
+        store: &'a impl BlockStore,
+    ) -> Result<impl AsyncRead + Send + 'a> {
+        let mut reader = self
+            .userland
+            .get_cloned(store)
+            .await?
+            .into_content_reader(store, None)?;
+        reader.seek(SeekFrom::Start(byte_offset)).await?;
+        Ok(TokioAsyncReadCompatExt::compat(reader))
+    }
+
+    pub async fn read_at<'a>(
+        &'a self,
+        byte_offset: u64,
+        len_limit: Option<usize>,
+        store: &'a impl BlockStore,
+    ) -> Result<Vec<u8>> {
+        let mut reader = self.stream_content(byte_offset, store).await?;
+        if let Some(len) = len_limit {
+            let mut buffer = vec![0; len];
+            reader.read_exact(&mut buffer).await?;
+            Ok(buffer)
+        } else {
+            let mut buffer = Vec::new();
+            reader.read_to_end(&mut buffer).await?;
+            Ok(buffer)
+        }
     }
 
     /// Takes care of creating previous links, in case the current
@@ -93,10 +206,24 @@ impl PublicFile {
 
     /// Writes a new content cid to the file.
     /// This will create a new revision of the file.
-    pub(crate) fn write(self: &mut Arc<Self>, time: DateTime<Utc>, content_cid: Cid) {
+    pub async fn set_content(
+        self: &mut Arc<Self>,
+        time: DateTime<Utc>,
+        content: Vec<u8>,
+        store: &impl BlockStore,
+    ) -> Result<()> {
+        let content_cid = FileBuilder::new()
+            .content_bytes(content)
+            .build()?
+            .store(store)
+            .await?;
+        let userland = UnixFsFile::load(&content_cid, store).await?;
+
         let file = self.prepare_next_revision();
-        file.userland = content_cid;
         file.metadata.upsert_mtime(time);
+        file.userland = FileUserland::Loaded(userland);
+
+        Ok(())
     }
 
     /// Gets the previous value of the file.
@@ -130,11 +257,6 @@ impl PublicFile {
         self.prepare_next_revision().get_metadata_mut()
     }
 
-    /// Gets the content cid of a file
-    pub fn get_content_cid(&self) -> &Cid {
-        &self.userland
-    }
-
     /// Stores file in provided block store.
     ///
     /// # Examples
@@ -150,16 +272,16 @@ impl PublicFile {
     ///
     /// #[async_std::main]
     /// async fn main() {
-    ///     let mut store = MemoryBlockStore::default();
-    ///     let file = PublicFile::new(Utc::now(), Cid::default());
+    ///     let store = &MemoryBlockStore::new();
+    ///     let file = PublicFile::new(Utc::now());
     ///
-    ///     file.store(&mut store).await.unwrap();
+    ///     file.store(store).await.unwrap();
     /// }
     /// ```
     pub async fn store(&self, store: &impl BlockStore) -> Result<Cid> {
         Ok(*self
             .persisted_as
-            .get_or_try_init(store.put_serializable(self))
+            .get_or_try_init(store.put_async_serializable(self))
             .await?)
     }
 
@@ -172,21 +294,31 @@ impl PublicFile {
         Ok(Self {
             persisted_as: OnceCell::new(),
             metadata: serializable.metadata,
-            userland: serializable.userland,
+            userland: FileUserland::Stored(serializable.userland),
             previous: serializable.previous.iter().cloned().collect(),
         })
     }
 }
 
-impl Serialize for PublicFile {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+impl AsyncSerialize for PublicFile {
+    async fn async_serialize<S, B>(&self, serializer: S, store: &B) -> Result<S::Ok, S::Error>
     where
-        S: Serializer,
+        S: Serializer + CondSend,
+        S::Error: CondSend,
+        B: BlockStore,
     {
+        let userland = self
+            .userland
+            .get_stored(store)
+            .await
+            .map_err(SerError::custom)?;
+
         PublicNodeSerializable::File(PublicFileSerializable {
             version: WNFS_VERSION,
             metadata: self.metadata.clone(),
-            userland: self.userland,
+            userland,
             previous: self.previous.iter().cloned().collect(),
         })
         .serialize(serializer)
@@ -233,7 +365,7 @@ impl Clone for PublicFile {
                 .map(OnceCell::new_with)
                 .unwrap_or_default(),
             metadata: self.metadata.clone(),
-            userland: self.userland,
+            userland: self.userland.clone(),
             previous: self.previous.clone(),
         }
     }
@@ -245,6 +377,22 @@ impl RemembersCid for PublicFile {
     }
 }
 
+impl FileUserland {
+    async fn get_cloned(&self, store: &impl BlockStore) -> Result<UnixFsFile> {
+        match self {
+            Self::Loaded(file) => Ok(file.clone()),
+            Self::Stored(cid) => UnixFsFile::load(cid, store).await,
+        }
+    }
+
+    async fn get_stored(&self, store: &impl BlockStore) -> Result<Cid> {
+        match self {
+            Self::Loaded(file) => file.encode()?.store(store).await,
+            Self::Stored(cid) => Ok(*cid),
+        }
+    }
+}
+
 //--------------------------------------------------------------------------------------------------
 // Tests
 //--------------------------------------------------------------------------------------------------
@@ -253,19 +401,14 @@ impl RemembersCid for PublicFile {
 mod tests {
     use super::*;
     use chrono::Utc;
-    use wnfs_common::{MemoryBlockStore, CODEC_RAW};
+    use wnfs_common::MemoryBlockStore;
 
     #[async_std::test]
     async fn previous_links_get_set() {
         let time = Utc::now();
         let store = &MemoryBlockStore::default();
 
-        let content_cid = store
-            .put_block(b"Hello World".to_vec(), CODEC_RAW)
-            .await
-            .unwrap();
-
-        let file = &mut PublicFile::new_rc(time, content_cid);
+        let file = &mut PublicFile::new_rc(time);
         let previous_cid = &file.store(store).await.unwrap();
         let next_file = file.prepare_next_revision();
 
@@ -279,12 +422,8 @@ mod tests {
     async fn prepare_next_revision_shortcuts_if_possible() {
         let time = Utc::now();
         let store = &MemoryBlockStore::default();
-        let content_cid = store
-            .put_block(b"Hello World".to_vec(), CODEC_RAW)
-            .await
-            .unwrap();
 
-        let file = &mut PublicFile::new_rc(time, content_cid);
+        let file = &mut PublicFile::new_rc(time);
         let previous_cid = &file.store(store).await.unwrap();
         let next_file = file.prepare_next_revision();
         let next_file_clone = &mut Arc::new(next_file.clone());
@@ -301,34 +440,40 @@ mod tests {
 mod snapshot_tests {
     use super::*;
     use chrono::TimeZone;
+    use testresult::TestResult;
     use wnfs_common::utils::SnapshotBlockStore;
 
     #[async_std::test]
-    async fn test_simple_file() {
+    async fn test_simple_file() -> TestResult {
         let store = &SnapshotBlockStore::default();
         let time = Utc.with_ymd_and_hms(1970, 1, 1, 0, 0, 0).unwrap();
 
-        let file = &mut PublicFile::new_rc(time, Cid::default());
-        let cid = file.store(store).await.unwrap();
+        let file = &mut PublicFile::new_rc(time);
+        let cid = file.store(store).await?;
 
-        let file = store.get_block_snapshot(&cid).await.unwrap();
+        let file = store.get_block_snapshot(&cid).await?;
 
         insta::assert_json_snapshot!(file);
+
+        Ok(())
     }
 
     #[async_std::test]
-    async fn test_file_with_previous_links() {
+    async fn test_file_with_previous_links() -> TestResult {
         let store = &SnapshotBlockStore::default();
         let time = Utc.with_ymd_and_hms(1970, 1, 1, 0, 0, 0).unwrap();
 
-        let file = &mut PublicFile::new_rc(time, Cid::default());
-        let _ = file.store(store).await.unwrap();
+        let file = &mut PublicFile::new_rc(time);
+        let _ = file.store(store).await?;
 
-        file.write(time, Cid::default());
-        let cid = file.store(store).await.unwrap();
+        file.set_content(time, b"Hello, World!".to_vec(), store)
+            .await?;
+        let cid = file.store(store).await?;
 
-        let file = store.get_block_snapshot(&cid).await.unwrap();
+        let file = store.get_block_snapshot(&cid).await?;
 
         insta::assert_json_snapshot!(file);
+
+        Ok(())
     }
 }

--- a/wnfs/src/public/file.rs
+++ b/wnfs/src/public/file.rs
@@ -125,7 +125,7 @@ impl PublicFile {
 
     pub async fn with_content_streaming<'a>(
         time: DateTime<Utc>,
-        content: impl AsyncRead + Send + 'a,
+        content: impl AsyncRead + CondSend + 'a,
         store: &'a impl BlockStore,
     ) -> Result<Self> {
         let content_cid = FileBuilder::new()
@@ -143,7 +143,7 @@ impl PublicFile {
 
     pub async fn with_content_streaming_rc<'a>(
         time: DateTime<Utc>,
-        content: impl AsyncRead + Send + 'a,
+        content: impl AsyncRead + CondSend + 'a,
         store: &'a impl BlockStore,
     ) -> Result<Arc<Self>> {
         Ok(Arc::new(
@@ -160,7 +160,7 @@ impl PublicFile {
         &'a self,
         byte_offset: u64,
         store: &'a impl BlockStore,
-    ) -> Result<impl AsyncRead + Send + 'a> {
+    ) -> Result<impl AsyncRead + CondSend + 'a> {
         let mut reader = self
             .userland
             .get_cloned(store)

--- a/wnfs/src/public/node/snapshots/wnfs__public__node__node__snapshot_tests__public_file_and_directory_nodes-2.snap
+++ b/wnfs/src/public/node/snapshots/wnfs__public__node__node__snapshot_tests__public_file_and_directory_nodes-2.snap
@@ -11,10 +11,10 @@ expression: file
       },
       "previous": [],
       "userland": {
-        "/": "baeaaaaa"
+        "/": "bafkr4ifpcne3t5pzugtkaqcn5i3nzskjtpfslsnnyejlpte2spfoihzsmi"
       },
       "version": "1.0.0"
     }
   },
-  "bytes": "oW13bmZzL3B1Yi9maWxlpGd2ZXJzaW9uZTEuMC4waG1ldGFkYXRhomdjcmVhdGVkAGhtb2RpZmllZABocHJldmlvdXOAaHVzZXJsYW5k2CpFAAEAAAA="
+  "bytes": "oW13bmZzL3B1Yi9maWxlpGd2ZXJzaW9uZTEuMC4waG1ldGFkYXRhomdjcmVhdGVkAGhtb2RpZmllZABocHJldmlvdXOAaHVzZXJsYW5k2CpYJQABVR4grxNJufX5oaagQE3qNtzJSZvLJcmtwRK3zJqTyuQfMmI="
 }

--- a/wnfs/src/public/node/snapshots/wnfs__public__node__node__snapshot_tests__public_fs.snap
+++ b/wnfs/src/public/node/snapshots/wnfs__public__node__node__snapshot_tests__public_fs.snap
@@ -3,7 +3,69 @@ source: wnfs/src/public/node/node.rs
 expression: values
 ---
 {
-  "bafyr4ic4bdlnowxtowfynamfdwgetbetifmdgahjun3sdbjfmaq3o7tvpi": {
+  "bafkr4ibirkdkphzauplnztoko4j35lwrpb4yffv57j4rh6rkmlmxe67y7a": {
+    "value": {
+      "/": {
+        "bytes": "SGVsbG8sIFdvcmxkIQ"
+      }
+    },
+    "bytes": "SGVsbG8sIFdvcmxkIQ=="
+  },
+  "bafyr4icjyr6bcipvqzguj3gctaihetpeqxgine3zw7zkw4eyzrn2ojxwhe": {
+    "value": {
+      "wnfs/pub/dir": {
+        "metadata": {
+          "created": 0,
+          "modified": 0
+        },
+        "previous": [],
+        "userland": {
+          "anime": {
+            "/": "bafyr4ihsg6l6g5tw45a3zh2dilphrtafnb6pyc7dpdxbuncgekjycqchnu"
+          }
+        },
+        "version": "1.0.0"
+      }
+    },
+    "bytes": "oWx3bmZzL3B1Yi9kaXKkZ3ZlcnNpb25lMS4wLjBobWV0YWRhdGGiZ2NyZWF0ZWQAaG1vZGlmaWVkAGhwcmV2aW91c4BodXNlcmxhbmShZWFuaW1l2CpYJQABcR4g8jeX43Z250G8n0NC3njMBWh8/AvjeO4aNEYik4FAR20="
+  },
+  "bafyr4ieu4jffr7sjcakgzk6jr4w5gbbmjs6oe7q2trrutjqcugr4orvmuu": {
+    "value": {
+      "wnfs/pub/dir": {
+        "metadata": {
+          "created": 0,
+          "modified": 0
+        },
+        "previous": [],
+        "userland": {
+          "jazz": {
+            "/": "bafyr4ihsg6l6g5tw45a3zh2dilphrtafnb6pyc7dpdxbuncgekjycqchnu"
+          }
+        },
+        "version": "1.0.0"
+      }
+    },
+    "bytes": "oWx3bmZzL3B1Yi9kaXKkZ3ZlcnNpb25lMS4wLjBobWV0YWRhdGGiZ2NyZWF0ZWQAaG1vZGlmaWVkAGhwcmV2aW91c4BodXNlcmxhbmShZGphenrYKlglAAFxHiDyN5fjdnbnQbyfQ0LeeMwFaHz8C+N47ho0RiKTgUBHbQ=="
+  },
+  "bafyr4ifobgzwli26fibfladmtouh32okhnmhc7jpy5dvmocz5dgg3wqrnq": {
+    "value": {
+      "wnfs/pub/dir": {
+        "metadata": {
+          "created": 0,
+          "modified": 0
+        },
+        "previous": [],
+        "userland": {
+          "movies": {
+            "/": "bafyr4icjyr6bcipvqzguj3gctaihetpeqxgine3zw7zkw4eyzrn2ojxwhe"
+          }
+        },
+        "version": "1.0.0"
+      }
+    },
+    "bytes": "oWx3bmZzL3B1Yi9kaXKkZ3ZlcnNpb25lMS4wLjBobWV0YWRhdGGiZ2NyZWF0ZWQAaG1vZGlmaWVkAGhwcmV2aW91c4BodXNlcmxhbmShZm1vdmllc9gqWCUAAXEeIEnEfBEh9YZNROzCmBByTeSFzIaTebfyq3CYzFunJvY5"
+  },
+  "bafyr4igcgvnnbd6xh7waotpqdopqcesi4wfmfcl2u42gyspjfc3djzt6wa": {
     "value": {
       "wnfs/pub/dir": {
         "metadata": {
@@ -17,89 +79,19 @@ expression: values
         ],
         "userland": {
           "music": {
-            "/": "bafyr4ietl6u7ligzk3sxfwqvycd2vhd4ohw3rxn5qv7ajrlzommvzk5la4"
+            "/": "bafyr4ieu4jffr7sjcakgzk6jr4w5gbbmjs6oe7q2trrutjqcugr4orvmuu"
           },
           "text.txt": {
-            "/": "bafyr4ie5jfvlj66jxhhvggxjltfj4ljfhjyirnngts23e33ugezjpc6xaq"
+            "/": "bafyr4ihsg6l6g5tw45a3zh2dilphrtafnb6pyc7dpdxbuncgekjycqchnu"
           },
           "videos": {
-            "/": "bafyr4ifmlt3hmgb5kdaprkhqqg774bcgyra54sli273iceddse25d7xkbe"
+            "/": "bafyr4ifobgzwli26fibfladmtouh32okhnmhc7jpy5dvmocz5dgg3wqrnq"
           }
         },
         "version": "1.0.0"
       }
     },
-    "bytes": "oWx3bmZzL3B1Yi9kaXKkZ3ZlcnNpb25lMS4wLjBobWV0YWRhdGGiZ2NyZWF0ZWQAaG1vZGlmaWVkAGhwcmV2aW91c4HYKlglAAFxHiD7VpD7WhHEVsmy03LYDk//0ZTWX++8Kdc9NpRjpotfhGh1c2VybGFuZKNlbXVzaWPYKlglAAFxHiCTX6n1oNlW5XLaFcCHqpx8ce243b2FfgTFeXMZXKurB2Z2aWRlb3PYKlglAAFxHiCsXPZ2GD1QwPio8IG//gRGxEHeSWjX9oEQY5E10f7qCWh0ZXh0LnR4dNgqWCUAAXEeIJ1JarT7ybnPUxrpXMqeLSU6cIi1ppy1sm90MTKXi9cE"
-  },
-  "bafyr4ie5jfvlj66jxhhvggxjltfj4ljfhjyirnngts23e33ugezjpc6xaq": {
-    "value": {
-      "wnfs/pub/file": {
-        "metadata": {
-          "created": 0,
-          "modified": 0
-        },
-        "previous": [],
-        "userland": {
-          "/": "baeaaaaa"
-        },
-        "version": "1.0.0"
-      }
-    },
-    "bytes": "oW13bmZzL3B1Yi9maWxlpGd2ZXJzaW9uZTEuMC4waG1ldGFkYXRhomdjcmVhdGVkAGhtb2RpZmllZABocHJldmlvdXOAaHVzZXJsYW5k2CpFAAEAAAA="
-  },
-  "bafyr4ielvme7szwdjuhhmiy2h27dqi7ayv5akpry33l365dbz2r7kbuxxu": {
-    "value": {
-      "wnfs/pub/dir": {
-        "metadata": {
-          "created": 0,
-          "modified": 0
-        },
-        "previous": [],
-        "userland": {
-          "anime": {
-            "/": "bafyr4ie5jfvlj66jxhhvggxjltfj4ljfhjyirnngts23e33ugezjpc6xaq"
-          }
-        },
-        "version": "1.0.0"
-      }
-    },
-    "bytes": "oWx3bmZzL3B1Yi9kaXKkZ3ZlcnNpb25lMS4wLjBobWV0YWRhdGGiZ2NyZWF0ZWQAaG1vZGlmaWVkAGhwcmV2aW91c4BodXNlcmxhbmShZWFuaW1l2CpYJQABcR4gnUlqtPvJuc9TGulcyp4tJTpwiLWmnLWyb3QxMpeL1wQ="
-  },
-  "bafyr4ietl6u7ligzk3sxfwqvycd2vhd4ohw3rxn5qv7ajrlzommvzk5la4": {
-    "value": {
-      "wnfs/pub/dir": {
-        "metadata": {
-          "created": 0,
-          "modified": 0
-        },
-        "previous": [],
-        "userland": {
-          "jazz": {
-            "/": "bafyr4ie5jfvlj66jxhhvggxjltfj4ljfhjyirnngts23e33ugezjpc6xaq"
-          }
-        },
-        "version": "1.0.0"
-      }
-    },
-    "bytes": "oWx3bmZzL3B1Yi9kaXKkZ3ZlcnNpb25lMS4wLjBobWV0YWRhdGGiZ2NyZWF0ZWQAaG1vZGlmaWVkAGhwcmV2aW91c4BodXNlcmxhbmShZGphenrYKlglAAFxHiCdSWq0+8m5z1Ma6VzKni0lOnCItaactbJvdDEyl4vXBA=="
-  },
-  "bafyr4ifmlt3hmgb5kdaprkhqqg774bcgyra54sli273iceddse25d7xkbe": {
-    "value": {
-      "wnfs/pub/dir": {
-        "metadata": {
-          "created": 0,
-          "modified": 0
-        },
-        "previous": [],
-        "userland": {
-          "movies": {
-            "/": "bafyr4ielvme7szwdjuhhmiy2h27dqi7ayv5akpry33l365dbz2r7kbuxxu"
-          }
-        },
-        "version": "1.0.0"
-      }
-    },
-    "bytes": "oWx3bmZzL3B1Yi9kaXKkZ3ZlcnNpb25lMS4wLjBobWV0YWRhdGGiZ2NyZWF0ZWQAaG1vZGlmaWVkAGhwcmV2aW91c4BodXNlcmxhbmShZm1vdmllc9gqWCUAAXEeIIurCflmw00OdiMaPr44I+DFegU+ON7Xv3RhzqP1Bpe9"
+    "bytes": "oWx3bmZzL3B1Yi9kaXKkZ3ZlcnNpb25lMS4wLjBobWV0YWRhdGGiZ2NyZWF0ZWQAaG1vZGlmaWVkAGhwcmV2aW91c4HYKlglAAFxHiD7VpD7WhHEVsmy03LYDk//0ZTWX++8Kdc9NpRjpotfhGh1c2VybGFuZKNlbXVzaWPYKlglAAFxHiCU4kpY/kkQFGyryY8t0wQsTLzifhqcY0mmAqGjx0aspWZ2aWRlb3PYKlglAAFxHiCuCbNlo14qAlWAbJuofenKO1hxfS/HR1Y4WejMbdoRbGh0ZXh0LnR4dNgqWCUAAXEeIPI3l+N2dudBvJ9DQt54zAVofPwL43juGjRGIpOBQEdt"
   },
   "bafyr4ih3k2ipwwqryrlmtmwtolma4t772gknmx7pxqu5opjwsrr2nc27qq": {
     "value": {
@@ -114,5 +106,21 @@ expression: values
       }
     },
     "bytes": "oWx3bmZzL3B1Yi9kaXKkZ3ZlcnNpb25lMS4wLjBobWV0YWRhdGGiZ2NyZWF0ZWQAaG1vZGlmaWVkAGhwcmV2aW91c4BodXNlcmxhbmSg"
+  },
+  "bafyr4ihsg6l6g5tw45a3zh2dilphrtafnb6pyc7dpdxbuncgekjycqchnu": {
+    "value": {
+      "wnfs/pub/file": {
+        "metadata": {
+          "created": 0,
+          "modified": 0
+        },
+        "previous": [],
+        "userland": {
+          "/": "bafkr4ibirkdkphzauplnztoko4j35lwrpb4yffv57j4rh6rkmlmxe67y7a"
+        },
+        "version": "1.0.0"
+      }
+    },
+    "bytes": "oW13bmZzL3B1Yi9maWxlpGd2ZXJzaW9uZTEuMC4waG1ldGFkYXRhomdjcmVhdGVkAGhtb2RpZmllZABocHJldmlvdXOAaHVzZXJsYW5k2CpYJQABVR4gKIqGp58go9bczcp3E76u0Xh5gpa9+nkT+ipi2XJ7+Pg="
   }
 }

--- a/wnfs/src/public/snapshots/wnfs__public__directory__snapshot_tests__directory_with_children.snap
+++ b/wnfs/src/public/snapshots/wnfs__public__directory__snapshot_tests__directory_with_children.snap
@@ -12,17 +12,17 @@ expression: dir
       "previous": [],
       "userland": {
         "music": {
-          "/": "bafyr4ietl6u7ligzk3sxfwqvycd2vhd4ohw3rxn5qv7ajrlzommvzk5la4"
+          "/": "bafyr4iguzfbscuempj6k4ixjkjoezxl7w2bvpa3dussgtovh3uujrm2xam"
         },
         "text.txt": {
-          "/": "bafyr4ie5jfvlj66jxhhvggxjltfj4ljfhjyirnngts23e33ugezjpc6xaq"
+          "/": "bafyr4ibjz7atflofvn5i6f7li3djshlrgcu56cwgceetvzokvu26pekxoy"
         },
         "videos": {
-          "/": "bafyr4ifmlt3hmgb5kdaprkhqqg774bcgyra54sli273iceddse25d7xkbe"
+          "/": "bafyr4ihwxcdcoc36v7o6mkmpsmomiz5m3d3dbwvrixpirwr3vgdxrq2nue"
         }
       },
       "version": "1.0.0"
     }
   },
-  "bytes": "oWx3bmZzL3B1Yi9kaXKkZ3ZlcnNpb25lMS4wLjBobWV0YWRhdGGiZ2NyZWF0ZWQAaG1vZGlmaWVkAGhwcmV2aW91c4BodXNlcmxhbmSjZW11c2lj2CpYJQABcR4gk1+p9aDZVuVy2hXAh6qcfHHtuN29hX4ExXlzGVyrqwdmdmlkZW9z2CpYJQABcR4grFz2dhg9UMD4qPCBv/4ERsRB3klo1/aBEGORNdH+6glodGV4dC50eHTYKlglAAFxHiCdSWq0+8m5z1Ma6VzKni0lOnCItaactbJvdDEyl4vXBA=="
+  "bytes": "oWx3bmZzL3B1Yi9kaXKkZ3ZlcnNpb25lMS4wLjBobWV0YWRhdGGiZ2NyZWF0ZWQAaG1vZGlmaWVkAGhwcmV2aW91c4BodXNlcmxhbmSjZW11c2lj2CpYJQABcR4g1MlDIVCMenyuIulSXEzdf7aDV4NjpKRpuqfdKJizVwNmdmlkZW9z2CpYJQABcR4g9riGJwt+r93mKY+THMRnrNj2MNqxRd6I2juph3jDTaFodGV4dC50eHTYKlglAAFxHiApz8EyrcWreo8X60bGmR1xMKnfCsYRCTrlyq0155FXdg=="
 }

--- a/wnfs/src/public/snapshots/wnfs__public__directory__snapshot_tests__directory_with_previous_links.snap
+++ b/wnfs/src/public/snapshots/wnfs__public__directory__snapshot_tests__directory_with_previous_links.snap
@@ -16,17 +16,17 @@ expression: dir
       ],
       "userland": {
         "music": {
-          "/": "bafyr4ietl6u7ligzk3sxfwqvycd2vhd4ohw3rxn5qv7ajrlzommvzk5la4"
+          "/": "bafyr4iguzfbscuempj6k4ixjkjoezxl7w2bvpa3dussgtovh3uujrm2xam"
         },
         "text.txt": {
-          "/": "bafyr4ie5jfvlj66jxhhvggxjltfj4ljfhjyirnngts23e33ugezjpc6xaq"
+          "/": "bafyr4ibjz7atflofvn5i6f7li3djshlrgcu56cwgceetvzokvu26pekxoy"
         },
         "videos": {
-          "/": "bafyr4ifmlt3hmgb5kdaprkhqqg774bcgyra54sli273iceddse25d7xkbe"
+          "/": "bafyr4ihwxcdcoc36v7o6mkmpsmomiz5m3d3dbwvrixpirwr3vgdxrq2nue"
         }
       },
       "version": "1.0.0"
     }
   },
-  "bytes": "oWx3bmZzL3B1Yi9kaXKkZ3ZlcnNpb25lMS4wLjBobWV0YWRhdGGiZ2NyZWF0ZWQAaG1vZGlmaWVkAGhwcmV2aW91c4HYKlglAAFxHiD7VpD7WhHEVsmy03LYDk//0ZTWX++8Kdc9NpRjpotfhGh1c2VybGFuZKNlbXVzaWPYKlglAAFxHiCTX6n1oNlW5XLaFcCHqpx8ce243b2FfgTFeXMZXKurB2Z2aWRlb3PYKlglAAFxHiCsXPZ2GD1QwPio8IG//gRGxEHeSWjX9oEQY5E10f7qCWh0ZXh0LnR4dNgqWCUAAXEeIJ1JarT7ybnPUxrpXMqeLSU6cIi1ppy1sm90MTKXi9cE"
+  "bytes": "oWx3bmZzL3B1Yi9kaXKkZ3ZlcnNpb25lMS4wLjBobWV0YWRhdGGiZ2NyZWF0ZWQAaG1vZGlmaWVkAGhwcmV2aW91c4HYKlglAAFxHiD7VpD7WhHEVsmy03LYDk//0ZTWX++8Kdc9NpRjpotfhGh1c2VybGFuZKNlbXVzaWPYKlglAAFxHiDUyUMhUIx6fK4i6VJcTN1/toNXg2OkpGm6p90omLNXA2Z2aWRlb3PYKlglAAFxHiD2uIYnC36v3eYpj5McxGes2PYw2rFF3ojaO6mHeMNNoWh0ZXh0LnR4dNgqWCUAAXEeICnPwTKtxat6jxfrRsaZHXEwqd8KxhEJOuXKrTXnkVd2"
 }

--- a/wnfs/src/public/snapshots/wnfs__public__file__snapshot_tests__file_with_previous_links.snap
+++ b/wnfs/src/public/snapshots/wnfs__public__file__snapshot_tests__file_with_previous_links.snap
@@ -11,14 +11,14 @@ expression: file
       },
       "previous": [
         {
-          "/": "bafyr4ie5jfvlj66jxhhvggxjltfj4ljfhjyirnngts23e33ugezjpc6xaq"
+          "/": "bafyr4idombemml3z63t5smrs6ktag3dr2ckvvzbq2ngtjklwqkotxwzs3a"
         }
       ],
       "userland": {
-        "/": "baeaaaaa"
+        "/": "bafkr4ibirkdkphzauplnztoko4j35lwrpb4yffv57j4rh6rkmlmxe67y7a"
       },
       "version": "1.0.0"
     }
   },
-  "bytes": "oW13bmZzL3B1Yi9maWxlpGd2ZXJzaW9uZTEuMC4waG1ldGFkYXRhomdjcmVhdGVkAGhtb2RpZmllZABocHJldmlvdXOB2CpYJQABcR4gnUlqtPvJuc9TGulcyp4tJTpwiLWmnLWyb3QxMpeL1wRodXNlcmxhbmTYKkUAAQAAAA=="
+  "bytes": "oW13bmZzL3B1Yi9maWxlpGd2ZXJzaW9uZTEuMC4waG1ldGFkYXRhomdjcmVhdGVkAGhtb2RpZmllZABocHJldmlvdXOB2CpYJQABcR4gbmBIxi959ufZMjLypgNscdCVWuQw0000qXaCnTvbMthodXNlcmxhbmTYKlglAAFVHiAoioannyCj1tzNyncTvq7ReHmClr36eRP6KmLZcnv4+A=="
 }

--- a/wnfs/src/public/snapshots/wnfs__public__file__snapshot_tests__simple_file.snap
+++ b/wnfs/src/public/snapshots/wnfs__public__file__snapshot_tests__simple_file.snap
@@ -11,10 +11,10 @@ expression: file
       },
       "previous": [],
       "userland": {
-        "/": "baeaaaaa"
+        "/": "bafkr4ifpcne3t5pzugtkaqcn5i3nzskjtpfslsnnyejlpte2spfoihzsmi"
       },
       "version": "1.0.0"
     }
   },
-  "bytes": "oW13bmZzL3B1Yi9maWxlpGd2ZXJzaW9uZTEuMC4waG1ldGFkYXRhomdjcmVhdGVkAGhtb2RpZmllZABocHJldmlvdXOAaHVzZXJsYW5k2CpFAAEAAAA="
+  "bytes": "oW13bmZzL3B1Yi9maWxlpGd2ZXJzaW9uZTEuMC4waG1ldGFkYXRhomdjcmVhdGVkAGhtb2RpZmllZABocHJldmlvdXOAaHVzZXJsYW5k2CpYJQABVR4grxNJufX5oaagQE3qNtzJSZvLJcmtwRK3zJqTyuQfMmI="
 }

--- a/wnfs/src/root_tree.rs
+++ b/wnfs/src/root_tree.rs
@@ -26,7 +26,7 @@ use std::collections::HashMap;
 use wnfs_common::MemoryBlockStore;
 use wnfs_common::{
     utils::{Arc, CondSend},
-    BlockStore, Metadata, CODEC_RAW,
+    BlockStore, Metadata,
 };
 #[cfg(test)]
 use wnfs_nameaccumulator::AccumulatorSetup;
@@ -127,14 +127,8 @@ where
         };
 
         match first.as_str() {
-            "public" => {
-                let cid = self.public_root.read(path_segments, self.store).await?;
-                self.store.get_block(&cid).await.map(|b| b.to_vec())
-            }
-            "exchange" => {
-                let cid = self.exchange_root.read(path_segments, self.store).await?;
-                self.store.get_block(&cid).await.map(|b| b.to_vec())
-            }
+            "public" => self.public_root.read(path_segments, self.store).await,
+            "exchange" => self.exchange_root.read(path_segments, self.store).await,
             _ => {
                 let root = self
                     .private_map
@@ -160,15 +154,13 @@ where
 
         match first.as_str() {
             "public" => {
-                let cid = self.store.put_block(content, CODEC_RAW).await?;
                 self.public_root
-                    .write(path_segments, cid, time, self.store)
+                    .write(path_segments, content, time, self.store)
                     .await
             }
             "exchange" => {
-                let cid = self.store.put_block(content, CODEC_RAW).await?;
                 self.exchange_root
-                    .write(path_segments, cid, time, self.store)
+                    .write(path_segments, content, time, self.store)
                     .await
             }
             _ => {


### PR DESCRIPTION
Previously we only had a CID-based API that just "set" the file CID to some value.

This now requires public files to encode their content as byte arrays.

Now the public and private APIs are very similar, both operate on the byte-array level for files.

Made possible through #375 

TODO:
- [x] Update Wasm bindings