### PR TITLE
feat: add `get_raw_content_cid`

### DIFF
--- a/wnfs-wasm/src/fs/public/file.rs
+++ b/wnfs-wasm/src/fs/public/file.rs
@@ -94,6 +94,18 @@ impl PublicFile {
         JsMetadata(self.0.get_metadata()).try_into()
     }
 
+    /// Gets the content cid of the file.
+    #[wasm_bindgen(js_name = "getRawContentCid")]
+    pub fn get_raw_content_cid(&self, store: BlockStore) -> JsResult<Promise> {
+        let mut file = Rc::clone(&self.0);
+        let store = ForeignBlockStore(store);
+
+        Ok(future_to_promise(async move {
+            let content_cid: Cid = file.get_raw_content_cid(&store).await;
+            Ok(value!(Uint8Array::from(&content_cid.to_bytes()[..])))
+        }))
+    }
+
     /// Gets the content of the file at given offset & with an optional byte limit.
     #[wasm_bindgen(js_name = "readAt")]
     pub fn read_at(

--- a/wnfs-wasm/tests/public.spec.ts
+++ b/wnfs-wasm/tests/public.spec.ts
@@ -343,4 +343,26 @@ test.describe("PublicDirectory", () => {
 
     expect(result).toEqual(longString);
   });
+
+  test("A PublicFile has a content CID", async ({ page }) => {
+    const result = await page.evaluate(async () => {
+      const {
+        wnfs: { PublicFile },
+        mock: { CID, MemoryBlockStore },
+      } = await window.setup();
+
+      const store = new MemoryBlockStore();
+      const time = new Date();
+      const file = new PublicFile(time);
+
+      const content = new TextEncoder().encode("hello");
+      const file2 = await file.setContent(time, content, store);
+
+      const cid_bytes = await file2.getRawContentCid(store);
+      return cid_bytes ? CID.decode(cid_bytes).toV1().toString() : undefined;
+    });
+
+    expect(result).not.toBeUndefined();
+    expect(result).toEqual("bafkreibm6jg3ux5qumhcn2b3flc3tyu6dmlb4xa7u5bf44yegnrjhc4yeq");
+  });
 });

--- a/wnfs/src/public/file.rs
+++ b/wnfs/src/public/file.rs
@@ -347,6 +347,12 @@ impl PublicFile {
         Ok(())
     }
 
+    /// Gets the content cid of the file.
+    pub async fn get_raw_content_cid(&self, store: &impl BlockStore) -> Cid {
+        let content_cid: Result<Cid> = self.userland.resolve_cid(store).await;
+        content_cid.unwrap()
+    }
+
     /// Gets the previous value of the file.
     ///
     /// # Examples


### PR DESCRIPTION
## Summary

Adds back the public content CID functionality that was previously removed, under the new name `get_raw_content_cid`. This method is async as opposed to its predecessor.

## Test plan (required)

I've added a new test to [wnfs-wasm/tests/public.spec.ts](https://github.com/wnfs-wg/rs-wnfs/compare/get_raw_content_cid?expand=1#diff-636f0cb11fda133fb5499edf39f348da78cde25e0359199ac7df4600f94dced9)

## After Merge

- [ ] Does this change invalidate any docs or tutorials? _If so ensure the changes needed are either made or recorded_
- [ ] Does this change require a release to be made? Is so please create and deploy the release
