### PR TITLE
Match the public and private APIs for content reading

### DIFF
--- a/wnfs-wasm/src/fs/private/file.rs
+++ b/wnfs-wasm/src/fs/private/file.rs
@@ -107,7 +107,7 @@ impl PrivateFile {
         let store = ForeignBlockStore(store);
         let forest = Rc::clone(&forest.0);
 
-        let byte_offset = f64::from(byte_offset) as usize;
+        let byte_offset = f64::from(byte_offset) as u64;
         let limit = limit.map(|lim| f64::from(lim) as usize);
 
         Ok(future_to_promise(async move {

--- a/wnfs-wasm/src/fs/private/file.rs
+++ b/wnfs-wasm/src/fs/private/file.rs
@@ -9,7 +9,7 @@ use crate::{
     value,
 };
 use chrono::{DateTime, Utc};
-use js_sys::{Date, Promise, Uint8Array};
+use js_sys::{Date, Number, Promise, Uint8Array};
 use std::rc::Rc;
 use wasm_bindgen::{prelude::wasm_bindgen, JsValue};
 use wasm_bindgen_futures::future_to_promise;
@@ -86,23 +86,40 @@ impl PrivateFile {
     /// Gets the entire content of a file.
     #[wasm_bindgen(js_name = "getContent")]
     pub fn get_content(&self, forest: &PrivateForest, store: BlockStore) -> JsResult<Promise> {
-        let file = Rc::clone(&self.0);
-        let store = ForeignBlockStore(store);
-        let forest = Rc::clone(&forest.0);
-
-        Ok(future_to_promise(async move {
-            let content = file
-                .get_content(&forest, &store)
-                .await
-                .map_err(error("Cannot get content of file"))?;
-
-            Ok(value!(Uint8Array::from(content.as_slice())))
-        }))
+        self.read_at(value!(0).into(), None, forest, store)
     }
 
     /// Gets the metadata of this file.
     pub fn metadata(&self) -> JsResult<JsValue> {
         JsMetadata(self.0.get_metadata()).try_into()
+    }
+
+    /// Gets the content of the file at given offset & with an optional byte limit.
+    #[wasm_bindgen(js_name = "readAt")]
+    pub fn read_at(
+        &self,
+        byte_offset: Number,
+        limit: Option<Number>,
+        forest: &PrivateForest,
+        store: BlockStore,
+    ) -> JsResult<Promise> {
+        let file = Rc::clone(&self.0);
+        let store = ForeignBlockStore(store);
+        let forest = Rc::clone(&forest.0);
+
+        let byte_offset = f64::from(byte_offset) as usize;
+        let limit = limit.map(|lim| f64::from(lim) as usize);
+
+        Ok(future_to_promise(async move {
+            let result = file
+                .read_at(byte_offset, limit, &forest, &store)
+                .await
+                .map_err(error("Cannot read file"))?;
+
+            let uint8array = Uint8Array::from(result.as_ref());
+
+            Ok(value!(uint8array))
+        }))
     }
 
     /// Gets a unique id for node.

--- a/wnfs-wasm/src/fs/public/file.rs
+++ b/wnfs-wasm/src/fs/public/file.rs
@@ -89,6 +89,12 @@ impl PublicFile {
         arr
     }
 
+    /// Gets the entire content of a file.
+    #[wasm_bindgen(js_name = "getContent")]
+    pub fn get_content(&self, store: BlockStore) -> JsResult<Promise> {
+        self.read_at(value!(0).into(), None, store)
+    }
+
     /// Gets the metadata of this file.
     pub fn metadata(&self) -> JsResult<JsValue> {
         JsMetadata(self.0.get_metadata()).try_into()

--- a/wnfs-wasm/tests/private.spec.ts
+++ b/wnfs-wasm/tests/private.spec.ts
@@ -29,7 +29,7 @@ test.describe("PrivateDirectory", () => {
         new Date(),
         initialForest,
         store,
-        rng
+        rng,
       );
 
       return await rootDir.lookupNode("text.txt", true, forest, store);
@@ -56,7 +56,7 @@ test.describe("PrivateDirectory", () => {
         new Date(),
         initialForest,
         store,
-        rng
+        rng,
       );
 
       var { rootDir, forest } = await rootDir.write(
@@ -66,22 +66,12 @@ test.describe("PrivateDirectory", () => {
         new Date(),
         forest,
         store,
-        rng
+        rng,
       );
 
-      var result0 = await rootDir.getNode(
-        ["pictures", "cats", "tabby.png"],
-        true,
-        forest,
-        store
-      );
+      var result0 = await rootDir.getNode(["pictures", "cats", "tabby.png"], true, forest, store);
 
-      var result1 = await rootDir.getNode(
-        ["pictures", "dogs", "bingo.png"],
-        true,
-        forest,
-        store
-      );
+      var result1 = await rootDir.getNode(["pictures", "dogs", "bingo.png"], true, forest, store);
 
       console.log(result0);
       console.log(result1);
@@ -93,9 +83,7 @@ test.describe("PrivateDirectory", () => {
     expect(result1).toBeUndefined();
   });
 
-  test("lookupNode cannot fetch file not added to directory", async ({
-    page,
-  }) => {
+  test("lookupNode cannot fetch file not added to directory", async ({ page }) => {
     const result = await page.evaluate(async () => {
       const {
         wnfs: { PrivateDirectory, PrivateForest },
@@ -131,7 +119,7 @@ test.describe("PrivateDirectory", () => {
         new Date(),
         initialForest,
         store,
-        rng
+        rng,
       );
 
       var { rootDir, forest } = await rootDir.write(
@@ -141,15 +129,10 @@ test.describe("PrivateDirectory", () => {
         new Date(),
         forest,
         store,
-        rng
+        rng,
       );
 
-      var result = await rootDir.getNode(
-        ["pictures", "cats", "tabby.png"],
-        true,
-        forest,
-        store
-      );
+      var result = await rootDir.getNode(["pictures", "cats", "tabby.png"], true, forest, store);
 
       return result;
     });
@@ -175,7 +158,7 @@ test.describe("PrivateDirectory", () => {
         new Date(),
         initialForest,
         store,
-        rng
+        rng,
       );
 
       var { rootDir, forest } = await rootDir.write(
@@ -185,7 +168,7 @@ test.describe("PrivateDirectory", () => {
         new Date(),
         forest,
         store,
-        rng
+        rng,
       );
 
       var { result } = await rootDir.ls(["pictures"], true, forest, store);
@@ -217,7 +200,7 @@ test.describe("PrivateDirectory", () => {
         new Date(),
         initialForest,
         store,
-        rng
+        rng,
       );
 
       var { rootDir, forest } = await rootDir.write(
@@ -227,16 +210,10 @@ test.describe("PrivateDirectory", () => {
         new Date(),
         forest,
         store,
-        rng
+        rng,
       );
 
-      var { rootDir, forest } = await rootDir.rm(
-        ["pictures", "cats"],
-        true,
-        forest,
-        store,
-        rng
-      );
+      var { rootDir, forest } = await rootDir.rm(["pictures", "cats"], true, forest, store, rng);
 
       var { result } = await rootDir.ls(["pictures"], true, forest, store);
 
@@ -266,7 +243,7 @@ test.describe("PrivateDirectory", () => {
         new Date(),
         initialForest,
         store,
-        rng
+        rng,
       );
 
       var { rootDir, forest } = await rootDir.write(
@@ -276,7 +253,7 @@ test.describe("PrivateDirectory", () => {
         new Date(),
         forest,
         store,
-        rng
+        rng,
       );
 
       var { rootDir, forest } = await rootDir.mkdir(
@@ -285,7 +262,7 @@ test.describe("PrivateDirectory", () => {
         new Date(),
         forest,
         store,
-        rng
+        rng,
       );
 
       var { rootDir, forest } = await rootDir.basicMv(
@@ -295,22 +272,12 @@ test.describe("PrivateDirectory", () => {
         new Date(),
         forest,
         store,
-        rng
+        rng,
       );
 
-      var { result: imagesContent, forest } = await rootDir.ls(
-        ["images"],
-        true,
-        forest,
-        store
-      );
+      var { result: imagesContent, forest } = await rootDir.ls(["images"], true, forest, store);
 
-      var { result: picturesContent, forest } = await rootDir.ls(
-        ["pictures"],
-        true,
-        forest,
-        store
-      );
+      var { result: picturesContent, forest } = await rootDir.ls(["pictures"], true, forest, store);
 
       return [imagesContent, picturesContent];
     });
@@ -339,7 +306,7 @@ test.describe("PrivateDirectory", () => {
         new Date(),
         initialForest,
         store,
-        rng
+        rng,
       );
 
       var { rootDir, forest } = await rootDir.write(
@@ -349,7 +316,7 @@ test.describe("PrivateDirectory", () => {
         new Date(),
         forest,
         store,
-        rng
+        rng,
       );
 
       var { rootDir, forest } = await rootDir.mkdir(
@@ -358,7 +325,7 @@ test.describe("PrivateDirectory", () => {
         new Date(),
         forest,
         store,
-        rng
+        rng,
       );
 
       var { rootDir, forest } = await rootDir.cp(
@@ -368,22 +335,12 @@ test.describe("PrivateDirectory", () => {
         new Date(),
         forest,
         store,
-        rng
+        rng,
       );
 
-      var { result: imagesContent, forest } = await rootDir.ls(
-        ["images"],
-        true,
-        forest,
-        store
-      );
+      var { result: imagesContent, forest } = await rootDir.ls(["images"], true, forest, store);
 
-      var { result: picturesContent, forest } = await rootDir.ls(
-        ["pictures"],
-        true,
-        forest,
-        store
-      );
+      var { result: picturesContent, forest } = await rootDir.ls(["pictures"], true, forest, store);
 
       return [imagesContent, picturesContent];
     });
@@ -430,7 +387,7 @@ test.describe("PrivateFile", () => {
         new Uint8Array([1, 2, 3, 4, 5]),
         forest,
         store,
-        rng
+        rng,
       );
 
       return file.getId();
@@ -455,7 +412,7 @@ test.describe("PrivateFile", () => {
         new Uint8Array([1, 2, 3, 4, 5]),
         initialForest,
         store,
-        rng
+        rng,
       );
 
       let content = await file.getContent(forest, store);
@@ -465,6 +422,35 @@ test.describe("PrivateFile", () => {
 
     expect(length).toEqual(5);
     expect(type).toEqual("Uint8Array");
+  });
+
+  test("readAt can fetch file's partial content", async ({ page }) => {
+    const [length, type, content] = await page.evaluate(async () => {
+      const {
+        wnfs: { PrivateFile, PrivateForest },
+        mock: { MemoryBlockStore, Rng },
+      } = await window.setup();
+
+      const rng = new Rng();
+      const initialForest = new PrivateForest(rng);
+      const store = new MemoryBlockStore();
+      var [file, forest] = await PrivateFile.withContent(
+        initialForest.emptyName(),
+        new Date(),
+        new Uint8Array([1, 2, 3, 4, 5]),
+        initialForest,
+        store,
+        rng,
+      );
+
+      let content = await file.readAt(1, 3, forest, store);
+
+      return [content.length, content.constructor.name, content];
+    });
+
+    expect(length).toEqual(3);
+    expect(type).toEqual("Uint8Array");
+    expect(new Uint8Array(Object.values(content))).toEqual(new Uint8Array([2, 3, 4]));
   });
 
   test("A PrivateDirectory has the correct metadata", async ({ page }) => {
@@ -544,7 +530,15 @@ test.describe("PrivateNode", () => {
       const [accessKey, forest1] = await rootDir0.store(forest0, store, rng);
 
       // Write something to the directory and store it
-      const { rootDir: rootDir1, forest: forest2 } = await rootDir0.write(["some", "file.txt"], true, new Uint8Array([0]), time, forest1, store, rng);
+      const { rootDir: rootDir1, forest: forest2 } = await rootDir0.write(
+        ["some", "file.txt"],
+        true,
+        new Uint8Array([0]),
+        time,
+        forest1,
+        store,
+        rng,
+      );
       const [_, forest3] = await rootDir1.asNode().store(forest2, store, rng);
 
       // loading back the *old* directory using its access key should give an empty directory:
@@ -563,8 +557,8 @@ test.describe("PrivateNode", () => {
     expect(lsResultBefore).toEqual([]);
     expect(lsResultAfter.length).toEqual(1);
     expect(lsResultAfter[0].name).toEqual("some");
-  })
-})
+  });
+});
 
 test.describe("PrivateForest", () => {
   test("store returns a PrivateRef", async ({ page }) => {
@@ -627,12 +621,7 @@ test.describe("PrivateForest", () => {
   test("merge combines changes in forests", async ({ page }) => {
     const result = await page.evaluate(async () => {
       const {
-        wnfs: {
-          PrivateFile,
-          PrivateDirectory,
-          PrivateForest,
-          PrivateNode,
-        },
+        wnfs: { PrivateFile, PrivateDirectory, PrivateForest, PrivateNode },
         mock: { MemoryBlockStore, Rng },
       } = await window.setup();
 
@@ -665,7 +654,6 @@ test.describe("AccessKey", () => {
         wnfs: { AccessKey, PrivateFile, PrivateNode, PrivateForest },
         mock: { MemoryBlockStore, Rng },
       } = await window.setup();
-
 
       const rng = new Rng();
       const store = new MemoryBlockStore();

--- a/wnfs-wasm/tests/public.spec.ts
+++ b/wnfs-wasm/tests/public.spec.ts
@@ -311,12 +311,17 @@ test.describe("PublicDirectory", () => {
       const content = new TextEncoder().encode("Hello, World!");
       const file2 = await file.setContent(time, content, store);
 
-      const readBack = await file2.readAt(0, undefined, store);
+      const readBack = await file2.getContent(store);
+      const partialRead = await file2.readAt(7, 5, store);
 
-      return new TextDecoder().decode(readBack);
+      return [
+        new TextDecoder().decode(readBack),
+        new TextDecoder().decode(partialRead)
+      ];
     });
 
-    expect(result).toEqual("Hello, World!");
+    expect(result[0]).toEqual("Hello, World!");
+    expect(result[1]).toEqual("World");
   });
 
   test("A PublicFile supports chunking files", async ({ page }) => {

--- a/wnfs/src/private/file.rs
+++ b/wnfs/src/private/file.rs
@@ -979,8 +979,8 @@ impl PrivateForestContent {
         let block_content_size = MAX_BLOCK_CONTENT_SIZE as u64;
         let mut chunk_size_upper_bound = self.get_size_upper_bound() - byte_offset as usize;
 
-        if len_limit.is_some() {
-            chunk_size_upper_bound = chunk_size_upper_bound.min(len_limit.unwrap());
+        if let Some(len_limit) = len_limit {
+            chunk_size_upper_bound = chunk_size_upper_bound.min(len_limit);
         }
 
         if chunk_size_upper_bound == 0 {
@@ -1001,8 +1001,8 @@ impl PrivateForestContent {
             } else {
                 0
             };
-            let to = if Some(index) == last_block {
-                (byte_offset + len_limit.unwrap() as u64 - index * block_content_size)
+            let to = if let Some(len_limit) = len_limit && Some(index) == last_block {
+                (byte_offset + len_limit as u64 - index * block_content_size)
                     .min(chunk.len() as u64)
             } else {
                 chunk.len() as u64

--- a/wnfs/src/private/file.rs
+++ b/wnfs/src/private/file.rs
@@ -625,10 +625,7 @@ impl PrivateFile {
         forest: &impl PrivateForest,
         store: &impl BlockStore,
     ) -> Result<Vec<u8>> {
-        match &self.content.content {
-            FileContent::Inline { data } => Ok(data.clone()),
-            FileContent::External(external) => external.get_content(forest, store).await,
-        }
+        self.read_at(0, None, forest, store).await
     }
 
     /// Sets the content of a file.

--- a/wnfs/src/private/file.rs
+++ b/wnfs/src/private/file.rs
@@ -1334,11 +1334,11 @@ mod proptests {
     #[proptest(cases = 10)]
     fn can_read_section_of_file(
         #[strategy(0..FIXTURE_SCHERZO_SIZE)] size: usize,
-        #[strategy(0..FIXTURE_SCHERZO_SIZE)] offset: usize,
+        #[strategy(0..FIXTURE_SCHERZO_SIZE as u64)] offset: u64,
     ) {
         use async_std::{io::SeekFrom, prelude::*};
         async_std::task::block_on(async {
-            let size = size.min(FIXTURE_SCHERZO_SIZE - offset);
+            let size = size.min(FIXTURE_SCHERZO_SIZE - offset as usize);
             let mut disk_file = async_std::fs::File::open(
                 "./test/fixtures/Clara Schumann, Scherzo no. 2, Op. 14.mp3",
             )
@@ -1361,13 +1361,10 @@ mod proptests {
             .unwrap();
 
             let mut source_content = vec![0u8; size];
-            disk_file
-                .seek(SeekFrom::Start(offset as u64))
-                .await
-                .unwrap();
+            disk_file.seek(SeekFrom::Start(offset)).await.unwrap();
             disk_file.read_exact(&mut source_content).await.unwrap();
             let wnfs_content = file
-                .read_at(offset as u64, Some(size), forest, store)
+                .read_at(offset, Some(size), forest, store)
                 .await
                 .unwrap();
 

--- a/wnfs/src/private/file.rs
+++ b/wnfs/src/private/file.rs
@@ -1001,8 +1001,8 @@ impl PrivateForestContent {
             } else {
                 0
             };
-            let to = if let Some(len_limit) = len_limit && Some(index) == last_block {
-                (byte_offset + len_limit as u64 - index * block_content_size)
+            let to = if Some(index) == last_block {
+                (byte_offset + len_limit.unwrap_or_default() as u64 - index * block_content_size)
                     .min(chunk.len() as u64)
             } else {
                 chunk.len() as u64

--- a/wnfs/src/public/file.rs
+++ b/wnfs/src/public/file.rs
@@ -310,6 +310,43 @@ impl PublicFile {
         }
     }
 
+    /// Gets the entire content of a file.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use anyhow::Result;
+    /// use rand_chacha::ChaCha12Rng;
+    /// use rand_core::SeedableRng;
+    /// use chrono::Utc;
+    /// use wnfs::{
+    ///     public::PublicFile,
+    ///     common::{MemoryBlockStore, utils::get_random_bytes},
+    /// };
+    ///
+    /// #[async_std::main]
+    /// async fn main() -> Result<()> {
+    ///     let store = &MemoryBlockStore::new();
+    ///     let rng = &mut ChaCha12Rng::from_entropy();
+    ///     let content = get_random_bytes::<100>(rng).to_vec();
+    ///     let file = PublicFile::with_content(
+    ///         Utc::now(),
+    ///         content.clone(),
+    ///         store,
+    ///     )
+    ///     .await?;
+    ///
+    ///     let mut all_content = file.get_content(store).await?;
+    ///
+    ///     assert_eq!(content, all_content);
+    ///
+    ///     Ok(())
+    /// }
+    /// ```
+    pub async fn get_content(&self, store: &impl BlockStore) -> Result<Vec<u8>> {
+        self.read_at(0, None, store).await
+    }
+
     /// Takes care of creating previous links, in case the current
     /// directory was previously `.store()`ed.
     /// In any case it'll try to give you ownership of the directory if possible,


### PR DESCRIPTION
## Summary

I've made it so that the public and private APIs for reading content better match.

`wnfs` changes:
- Made the length param optional and renamed the offset param to match the public side.
- Copied the doc test from the public side to the private side.
- Made it so that `PrivateFile.get_content` uses its `read_at` method.
- Added `PublicFile.get_content` to reflect the private side.

`wnfs-wasm` changes:
- Added `PrivateFile.read_at`
- Made it so that `PrivateFile.get_content` uses its `read_at` method.
- Added `PublicFile.get_content`
- Adjusted tests to use new and changed methods.

## Test plan (required)

Added and adjusted some tests.

## After Merge

- [ ] Does this change invalidate any docs or tutorials? _If so ensure the changes needed are either made or recorded_
- [ ] Does this change require a release to be made? Is so please create and deploy the release
