### PR TITLE
chore: Remove leftover logging value

### DIFF
--- a/wnfs/src/public/directory.rs
+++ b/wnfs/src/public/directory.rs
@@ -851,10 +851,6 @@ impl Storable for PublicDirectory {
         cid: Option<&Cid>,
         serializable: Self::Serializable,
     ) -> Result<Self> {
-        println!(
-            "Public Directory from serializable cid: {}",
-            cid.map(Cid::to_string).unwrap_or("None".to_string())
-        );
         let PublicNodeSerializable::Dir(serializable) = serializable else {
             bail!(FsError::UnexpectedNodeType(NodeType::PublicFile));
         };


### PR DESCRIPTION
*Of course* I think of this *right after* publishing the next version.

Getting this in there quickly before I forget it for the next time.