### PR TITLE
feat: implement `PublicDirectory` conflict reconciliation

### DIFF
--- a/wnfs-hamt/src/merge.rs
+++ b/wnfs-hamt/src/merge.rs
@@ -69,6 +69,7 @@ where
 mod proptests {
     use crate::strategies::{self, generate_kvs};
     use async_std::task;
+    use proptest::prop_assert_eq;
     use std::cmp;
     use test_strategy::proptest;
     use wnfs_common::{utils::Arc, Link, MemoryBlockStore};
@@ -126,8 +127,9 @@ mod proptests {
                 .unwrap()
             };
 
-            assert_eq!(merge_node_left_assoc, merge_node_right_assoc);
-        });
+            prop_assert_eq!(merge_node_left_assoc, merge_node_right_assoc);
+            Ok(())
+        })?;
     }
 
     #[proptest(cases = 100)]
@@ -159,8 +161,9 @@ mod proptests {
             .await
             .unwrap();
 
-            assert_eq!(merge_node_1, merge_node_2);
-        })
+            prop_assert_eq!(merge_node_1, merge_node_2);
+            Ok(())
+        })?;
     }
 
     #[proptest(cases = 100)]
@@ -192,7 +195,8 @@ mod proptests {
             .await
             .unwrap();
 
-            assert_eq!(merge_node_1, merge_node_2);
-        })
+            prop_assert_eq!(merge_node_1, merge_node_2);
+            Ok(())
+        })?;
     }
 }

--- a/wnfs-hamt/src/node.rs
+++ b/wnfs-hamt/src/node.rs
@@ -1236,8 +1236,9 @@ mod proptests {
             node.set(key, value, store).await.unwrap();
             let cid2 = node.store(store).await.unwrap();
 
-            assert_eq!(cid1, cid2);
-        })
+            prop_assert_eq!(cid1, cid2);
+            Ok(())
+        })?;
     }
 
     #[proptest(cases = 50)]
@@ -1258,8 +1259,9 @@ mod proptests {
             node.remove(&key, store).await.unwrap();
             let cid2 = node.store(store).await.unwrap();
 
-            assert_eq!(cid1, cid2);
-        })
+            prop_assert_eq!(cid1, cid2);
+            Ok(())
+        })?;
     }
 
     #[proptest(cases = 100)]
@@ -1276,8 +1278,9 @@ mod proptests {
             let node_cid = node.store(store).await.unwrap();
             let decoded_node = Node::<String, u64>::load(&node_cid, store).await.unwrap();
 
-            assert_eq!(*node, decoded_node);
-        })
+            prop_assert_eq!(node.as_ref(), &decoded_node);
+            Ok(())
+        })?;
     }
 
     #[proptest(cases = 1000, max_shrink_iters = 10_000)]
@@ -1298,8 +1301,9 @@ mod proptests {
             let cid1 = node1.store(store).await.unwrap();
             let cid2 = node2.store(store).await.unwrap();
 
-            assert_eq!(cid1, cid2);
-        })
+            prop_assert_eq!(cid1, cid2);
+            Ok(())
+        })?;
     }
 
     // This is sort of a "control group" for making sure that operations_and_shuffled is correct.
@@ -1332,8 +1336,9 @@ mod proptests {
             let map = HashMap::from(&operations);
             let map_result = node.to_hashmap(store).await.unwrap();
 
-            assert_eq!(map, map_result);
-        })
+            prop_assert_eq!(map, map_result);
+            Ok(())
+        })?;
     }
 }
 

--- a/wnfs-hamt/src/pointer.rs
+++ b/wnfs-hamt/src/pointer.rs
@@ -227,7 +227,7 @@ where
 mod tests {
     use super::*;
     use testresult::TestResult;
-    use wnfs_common::{MemoryBlockStore, Storable};
+    use wnfs_common::MemoryBlockStore;
 
     #[async_std::test]
     async fn pointer_can_encode_decode_as_cbor() -> TestResult {

--- a/wnfs-nameaccumulator/src/name.rs
+++ b/wnfs-nameaccumulator/src/name.rs
@@ -818,7 +818,7 @@ mod tests {
 #[cfg(test)]
 mod snapshot_tests {
     use super::*;
-    use crate::{BigNumDig, NameSegment};
+    use crate::BigNumDig;
     use rand_chacha::ChaCha12Rng;
     use rand_core::SeedableRng;
     use wnfs_common::utils::SnapshotBlockStore;

--- a/wnfs-unixfs-file/src/balanced_tree.rs
+++ b/wnfs-unixfs-file/src/balanced_tree.rs
@@ -234,7 +234,6 @@ impl TreeNode {
 mod tests {
     use super::*;
     use bytes::BytesMut;
-    use futures::StreamExt;
     use wnfs_common::MemoryBlockStore;
 
     // chunks are just a single usize integer

--- a/wnfs-unixfs-file/src/builder.rs
+++ b/wnfs-unixfs-file/src/builder.rs
@@ -173,7 +173,6 @@ pub struct Config {
 mod tests {
     use super::*;
     use crate::chunker::DEFAULT_CHUNKS_SIZE;
-    use futures::TryStreamExt;
     use wnfs_common::MemoryBlockStore;
 
     #[tokio::test]

--- a/wnfs-unixfs-file/src/protobufs.rs
+++ b/wnfs-unixfs-file/src/protobufs.rs
@@ -91,7 +91,6 @@ pub struct Metadata {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use prost::Message;
     use testresult::TestResult;
 
     #[test]

--- a/wnfs/proptest-regressions/public/directory.txt
+++ b/wnfs/proptest-regressions/public/directory.txt
@@ -8,3 +8,4 @@ cc 4ca9259264a7fb240270a7f3a3c9f702cc5f3f7ec8f8add28e774546901bb064 # shrinks to
 cc 52d317f93f0d815bfd054e6147b32492abc79b100274458f3fc266d1d9f40083 # shrinks to input = _TestMergeCommutativityArgs { ops0: [Write(["a"], "a"), Mkdir(["a"])], ops1: [] }
 cc 5d512e34a6b76473ff418d6cc7730003875ae30727a3155b2abc13d5f8313b58 # shrinks to input = _TestMergeCommutativityArgs { fs0: FileSystem { files: {}, dirs: {} }, fs1: FileSystem { files: {["a"]: "a"}, dirs: {["a"]} } }
 cc d4c4529fd972a2a6af4dcecd28a289d11451203600ae18e001dbdd42fe19e245 # shrinks to input = _TestMergeCommutativityArgs { fs0: FileSystem { files: {["b"]: "a", ["b", "a"]: "a"}, dirs: {} }, fs1: FileSystem { files: {}, dirs: {} } }
+cc e5c61f6ac3dec61974eedf0a7042fd1f801efa9f020e4b37473d5a11a7a7a7a4 # shrinks to input = _TestMergeAssociativityArgs { fs0: FileSystem { files: {}, dirs: {["e", "b"]} }, fs1: FileSystem { files: {}, dirs: {["e", "b"]} }, fs2: FileSystem { files: {}, dirs: {["e", "b"]} } }

--- a/wnfs/proptest-regressions/public/directory.txt
+++ b/wnfs/proptest-regressions/public/directory.txt
@@ -1,0 +1,10 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc 4ca9259264a7fb240270a7f3a3c9f702cc5f3f7ec8f8add28e774546901bb064 # shrinks to input = _TestMergeDirectoryPreferredArgs { path: [] }
+cc 52d317f93f0d815bfd054e6147b32492abc79b100274458f3fc266d1d9f40083 # shrinks to input = _TestMergeCommutativityArgs { ops0: [Write(["a"], "a"), Mkdir(["a"])], ops1: [] }
+cc 5d512e34a6b76473ff418d6cc7730003875ae30727a3155b2abc13d5f8313b58 # shrinks to input = _TestMergeCommutativityArgs { fs0: FileSystem { files: {}, dirs: {} }, fs1: FileSystem { files: {["a"]: "a"}, dirs: {["a"]} } }
+cc d4c4529fd972a2a6af4dcecd28a289d11451203600ae18e001dbdd42fe19e245 # shrinks to input = _TestMergeCommutativityArgs { fs0: FileSystem { files: {["b"]: "a", ["b", "a"]: "a"}, dirs: {} }, fs1: FileSystem { files: {}, dirs: {} } }

--- a/wnfs/proptest-regressions/public/node/node.txt
+++ b/wnfs/proptest-regressions/public/node/node.txt
@@ -1,0 +1,8 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc 964d01e6f0fa5c2e45a8d245bb705007a50c24fb53348cb96a528ec52e27a49a # shrinks to input = _TestTransitivityArgs { operations0: [Write(0), Write(0), Write(0), Write(0), Write(0)], operations1: [Write(0), Write(0), Write(0), Write(0)], operations2: [Write(0), Write(0), Write(15671), Fork(2303347135), Write(593116438)] }
+cc 60cd267331f207e164af9c65aaf9c1232633c97d9e258dcd01d1630292820569 # shrinks to input = _TestTransitivityArgs { operations0: [], operations1: [Write(0)], operations2: [Write(0)] }

--- a/wnfs/src/private/file.rs
+++ b/wnfs/src/private/file.rs
@@ -1288,6 +1288,7 @@ mod proptests {
     use async_std::io::Cursor;
     use chrono::Utc;
     use futures::{future, StreamExt};
+    use proptest::{prop_assert, prop_assert_eq};
     use rand_chacha::ChaCha12Rng;
     use rand_core::SeedableRng;
     use test_strategy::proptest;
@@ -1319,8 +1320,9 @@ mod proptests {
 
             let collected_content = file.get_content(forest, store).await.unwrap();
 
-            assert_eq!(collected_content, content);
-        })
+            prop_assert_eq!(collected_content, content);
+            Ok(())
+        })?;
     }
 
     #[proptest(cases = 10)]
@@ -1352,8 +1354,9 @@ mod proptests {
                 })
                 .await;
 
-            assert_eq!(collected_content, content);
-        })
+            prop_assert_eq!(collected_content, content);
+            Ok(())
+        })?;
     }
 
     #[proptest(cases = 100)]
@@ -1384,8 +1387,9 @@ mod proptests {
 
             let error = error.downcast_ref::<BlockStoreError>().unwrap();
 
-            assert!(matches!(error, BlockStoreError::CIDNotFound(_)));
-        })
+            prop_assert!(matches!(error, BlockStoreError::CIDNotFound(_)));
+            Ok(())
+        })?;
     }
 
     #[proptest(cases = 10)]
@@ -1425,7 +1429,8 @@ mod proptests {
                 .await
                 .unwrap();
 
-            assert_eq!(source_content, wnfs_content);
-        })
+            prop_assert_eq!(source_content, wnfs_content);
+            Ok(())
+        })?;
     }
 }

--- a/wnfs/src/public/directory.rs
+++ b/wnfs/src/public/directory.rs
@@ -1534,7 +1534,7 @@ mod proptests {
 
             root1.mkdir(&path, time, store).await.unwrap();
 
-            root0.merge(root1, time, store).await.unwrap();
+            root0.merge(root1, store).await.unwrap();
 
             let node = root0
                 .get_node(&path, store)
@@ -1561,9 +1561,9 @@ mod proptests {
             let root1 = convert_fs(fs1, time, store).await.unwrap();
 
             let mut merge_one_way = Arc::clone(&root0);
-            merge_one_way.merge(&root1, time, store).await.unwrap();
+            merge_one_way.merge(&root1, store).await.unwrap();
             let mut merge_other_way = Arc::clone(&root1);
-            merge_other_way.merge(&root0, time, store).await.unwrap();
+            merge_other_way.merge(&root0, store).await.unwrap();
 
             let cid_one_way = merge_one_way.store(store).await.unwrap();
             let cid_other_way = merge_other_way.store(store).await.unwrap();
@@ -1588,16 +1588,13 @@ mod proptests {
             let root2 = convert_fs(fs2, time, store).await.unwrap();
 
             let mut merge_0_1_then_2 = Arc::clone(&root0);
-            merge_0_1_then_2.merge(&root1, time, store).await.unwrap();
-            merge_0_1_then_2.merge(&root2, time, store).await.unwrap();
+            merge_0_1_then_2.merge(&root1, store).await.unwrap();
+            merge_0_1_then_2.merge(&root2, store).await.unwrap();
 
             let mut merge_1_2 = Arc::clone(&root1);
-            merge_1_2.merge(&root2, time, store).await.unwrap();
+            merge_1_2.merge(&root2, store).await.unwrap();
             let mut merge_0_with_1_2 = Arc::clone(&root0);
-            merge_0_with_1_2
-                .merge(&merge_1_2, time, store)
-                .await
-                .unwrap();
+            merge_0_with_1_2.merge(&merge_1_2, store).await.unwrap();
 
             let cid_one_way = merge_0_1_then_2.store(store).await.unwrap();
             let cid_other_way = merge_0_with_1_2.store(store).await.unwrap();
@@ -1623,7 +1620,7 @@ mod proptests {
             let mut root = convert_fs(fs0, time, store).await.unwrap();
             let root1 = convert_fs(fs1, time, store).await.unwrap();
 
-            root.merge(&root1, time, store).await.unwrap();
+            root.merge(&root1, store).await.unwrap();
 
             for dir in all_dirs {
                 let exists = root.get_node(&dir, store).await.unwrap().is_some();

--- a/wnfs/src/public/directory.rs
+++ b/wnfs/src/public/directory.rs
@@ -166,13 +166,26 @@ impl PublicDirectory {
     /// Advances this node to the next revision, unless it's already a merge node.
     /// Merge nodes preferably just grow in size. This allows them to combine more nicely
     /// without causing further conflicts.
-    pub(crate) fn prepare_next_merge<'a>(self: &'a mut Arc<Self>) -> &'a mut Self {
+    pub(crate) async fn prepare_next_merge<'a>(
+        self: &'a mut Arc<Self>,
+        store: &impl BlockStore,
+    ) -> Result<&'a mut Self> {
         if self.previous.len() > 1 {
             // This is a merge node
-            return Arc::make_mut(self);
+            let cloned = Arc::make_mut(self);
+            cloned.persisted_as = OnceCell::new();
+            return Ok(cloned);
         }
 
-        self.prepare_next_revision()
+        // This is not a merge node. We need to force a new revision.
+        // Otherwise we would turn a node that is possibly storing uncommitted
+        // new changes into a merge node, but merge nodes should have no changes
+        // besides the merge itself.
+        let previous_cid = self.store(store).await?;
+        let cloned = Arc::make_mut(self);
+        cloned.persisted_as = OnceCell::new();
+        cloned.previous = BTreeSet::from([previous_cid]);
+        Ok(cloned)
     }
 
     async fn get_leaf_dir<'a>(
@@ -902,7 +915,14 @@ impl PublicDirectory {
         current_path: &[String],
         file_tie_breaks: &mut BTreeSet<Vec<String>>,
     ) -> Result<()> {
-        let dir = self.prepare_next_merge();
+        let our_cid = self.store(store).await?;
+        let other_cid = other.store(store).await?;
+        if our_cid == other_cid {
+            // We don't have to merge
+            return Ok(());
+        }
+
+        let dir = self.prepare_next_merge(store).await?;
         if other.previous.len() > 1 {
             // The other node is a merge node, we should merge the merge nodes directly:
             dir.previous.extend(other.previous.iter().cloned());
@@ -929,7 +949,7 @@ impl PublicDirectory {
                             let our_cid = our_file.userland.resolve_cid(store).await?;
                             let other_cid = other_file.userland.resolve_cid(store).await?;
 
-                            let file = our_file.perpare_next_merge();
+                            let file = our_file.prepare_next_merge(store).await?;
                             if other_file.previous.len() > 1 {
                                 // The other node is a merge node, we should merge the merge nodes directly:
                                 file.previous.extend(other_file.previous.iter().cloned());

--- a/wnfs/src/public/file.rs
+++ b/wnfs/src/public/file.rs
@@ -405,7 +405,10 @@ impl PublicFile {
         cloned
     }
 
-    /// TODO(matheus23) DOCS
+    /// Call this function to prepare this directory for conflict reconciliation merge changes.
+    /// Advances this node to the next revision, unless it's already a merge node.
+    /// Merge nodes preferably just grow in size. This allows them to combine more nicely
+    /// without causing further conflicts.
     pub(crate) fn perpare_next_merge<'a>(self: &'a mut Arc<Self>) -> &'a mut Self {
         if self.previous.len() > 1 {
             // This is a merge node. Keep using it

--- a/wnfs/src/public/file.rs
+++ b/wnfs/src/public/file.rs
@@ -405,6 +405,16 @@ impl PublicFile {
         cloned
     }
 
+    /// TODO(matheus23) DOCS
+    pub(crate) fn perpare_next_merge<'a>(self: &'a mut Arc<Self>) -> &'a mut Self {
+        if self.previous.len() > 1 {
+            // This is a merge node. Keep using it
+            return Arc::make_mut(self);
+        }
+
+        self.prepare_next_revision()
+    }
+
     /// Writes a new content cid to the file.
     /// This will create a new revision of the file.
     pub async fn set_content(

--- a/wnfs/src/public/node/node.rs
+++ b/wnfs/src/public/node/node.rs
@@ -230,7 +230,16 @@ impl PublicNode {
         matches!(self, Self::File(_))
     }
 
-    /// Comparing the merkle clocks of this node to the other node
+    /// Comparing the merkle clocks of this node to the other node.
+    ///
+    /// This gives you information about which node is "ahead" of which other node
+    /// (think similar to git).
+    /// This is what the return types indicate:
+    /// - `Ok(None)`: These two nodes don't share any history.
+    /// - `Ok(Some(Ordering::Equal))`: These nodes represent the same point in history/are the same exact node.
+    /// - `Ok(Some(Ordering::Less))`: The other node is "further ahead" in history than this node.
+    /// - `Ok(Some(Ordering::Greater))`: This node is "further ahead".
+    /// - `Err(_)`: Something went wrong during deserialization/in the blockstore.
     pub async fn causal_compare(
         &self,
         other: &Self,


### PR DESCRIPTION
This implements three functions:
- `PublicDirectory::reconcile` which takes two directories & reconciles all changes between them. Think of this as similar to `get pull`, but where conflicts in files are merged automatically via a simple tie-breaking mechanism on the file hash. The return value indicates whether and which files were affected by the automatic merge, if at all.
- `PublicDirectory::merge`, the underlying function for `reconcile`, but which doesn't take into account if one of the directories may have been "ahead" in history. Use only if you know what you're doing, otherwise opt for `reconcile`.
- `PublicNode::causal_compare`, the underlying function in `reconcile` that figures out whether one version of a node is "ahead" of another or behind, or if they're two conflicting versions and need to be merged.
