### PR TITLE
fix: Public reconciliation of a concurrent write and remove (of independent paths)

### DIFF
--- a/wnfs-common/src/link.rs
+++ b/wnfs-common/src/link.rs
@@ -199,8 +199,12 @@ where
 {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         match self {
-            Self::Encoded { cid, .. } => f.debug_tuple("Link::Encoded").field(cid).finish(),
-            Self::Decoded { value, .. } => f.debug_tuple("Link::Decoded").field(value).finish(),
+            Self::Encoded { cid, value_cache } => f
+                .debug_struct("Link::Encoded")
+                .field("cid", &format!("{cid}"))
+                .field("value_cache", &value_cache.get())
+                .finish(),
+            Self::Decoded { value } => f.debug_tuple("Link::Decoded").field(value).finish(),
         }
     }
 }

--- a/wnfs/src/private/directory.rs
+++ b/wnfs/src/private/directory.rs
@@ -1453,13 +1453,13 @@ impl PrivateDirectory {
                             }
                             (PrivateNode::File(_), PrivateNode::Dir(_)) => {
                                 // a directory wins over a file
-                                *our_link = other_link.clone();
+                                our_link.clone_from(other_link);
                             }
                             // file vs. file and dir vs. dir cases
                             _ => {
                                 // We tie-break as usual
                                 if ord == Ordering::Greater {
-                                    *our_link = other_link.clone();
+                                    our_link.clone_from(other_link);
                                 }
                             }
                         }

--- a/wnfs/src/public/file.rs
+++ b/wnfs/src/public/file.rs
@@ -1,7 +1,9 @@
 //! Public fs file node.
 
 use super::{PublicFileSerializable, PublicNodeSerializable};
-use crate::{error::FsError, is_readable_wnfs_version, traits::Id, WNFS_VERSION};
+use crate::{
+    error::FsError, is_readable_wnfs_version, traits::Id, utils::OnceCellDebug, WNFS_VERSION,
+};
 use anyhow::{anyhow, bail, Result};
 use async_once_cell::OnceCell;
 use chrono::{DateTime, Utc};
@@ -28,7 +30,6 @@ use wnfs_unixfs_file::{builder::FileBuilder, unixfs::UnixFsFile};
 ///
 /// println!("File: {:?}", file);
 /// ```
-#[derive(Debug)]
 pub struct PublicFile {
     persisted_as: OnceCell<Cid>,
     pub(crate) metadata: Metadata,
@@ -542,6 +543,27 @@ impl PublicFile {
 
         // Returning true to indicate that we needed to tie-break
         Ok(true)
+    }
+}
+
+impl std::fmt::Debug for PublicFile {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("PublicFile")
+            .field(
+                "persisted_as",
+                &OnceCellDebug(self.persisted_as.get().map(|cid| format!("{cid}"))),
+            )
+            .field("metadata", &self.metadata)
+            .field("userland", &self.userland)
+            .field(
+                "previous",
+                &self
+                    .previous
+                    .iter()
+                    .map(|cid| format!("{cid}"))
+                    .collect::<Vec<_>>(),
+            )
+            .finish()
     }
 }
 


### PR DESCRIPTION
This is an edge case I came across while implementing private conflict reconciliation.

Essentially we have this setup:
- Both replicas share the same state of a single file, e.g. at "public/a/b.txt".
- Then one replica deletes that file
- The other replica does an unrelated write, e.g. it adds "public/file.txt"
- Both replicas merge again

What happened previously was:
- We detected that two independent writes were done on the root directory
- We run a deep merge on both directories. The `b.txt` file gets re-introduced (the remove gets "overwritten"), because we don't re-check the causal relationship of the "a" directories.

We now check the causal relationship between directories on every level (recursively).

I also removed the `merge` function, as otherwise it'd be hard to disentangle the recursion, but that'd be needed to not duplicate the whole `reconcile_helper` and `merge_helper` functions.